### PR TITLE
fix: restore legacy DeepSeek MPS rows

### DIFF
--- a/models/deepseek/deepseek-v3.1.yaml
+++ b/models/deepseek/deepseek-v3.1.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+provider: deepseek
+authType: api_key
+model: deepseek-v3.1
+params:
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls whether DeepSeek thinking mode is enabled for this legacy model ID.
+    default: enabled
+    values:
+      - enabled
+      - disabled
+    group: reasoning

--- a/models/deepseek/deepseek-v3.2.yaml
+++ b/models/deepseek/deepseek-v3.2.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+provider: deepseek
+authType: api_key
+model: deepseek-v3.2
+params:
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls whether DeepSeek thinking mode is enabled for this legacy model ID.
+    default: enabled
+    values:
+      - enabled
+      - disabled
+    group: reasoning

--- a/models/deepseek/deepseek-v4.yaml
+++ b/models/deepseek/deepseek-v4.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+provider: deepseek
+authType: api_key
+model: deepseek-v4
+params:
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls whether DeepSeek thinking mode is enabled for this legacy model ID.
+    default: enabled
+    values:
+      - enabled
+      - disabled
+    group: reasoning


### PR DESCRIPTION
## Summary
- restore legacy DeepSeek MPS rows for `deepseek-v3.1`, `deepseek-v3.2`, and `deepseek-v4`
- keep the same Thinking mode control those rows had before, avoiding regressions for existing saved Manifest routes
- leave the current V4 Flash/Pro and reasoner rows from #2 intact

## Validation
- `npm run validate`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`