### PR TITLE
fix: correct provider MPS rows

### DIFF
--- a/models/anthropic/claude-haiku-4-5-20251001.yaml
+++ b/models/anthropic/claude-haiku-4-5-20251001.yaml
@@ -25,9 +25,10 @@ params:
     group: sampling
     applicability:
       except:
-        thinking.type:
-          - adaptive
-          - enabled
+        - thinking.type:
+            - enabled
+        - top_p:
+            not: null
   - path: top_p
     type: number
     label: Top P
@@ -43,10 +44,9 @@ params:
     applicability:
       except:
         - thinking.type:
-            - adaptive
             - enabled
         - temperature:
-            not: 1
+            not: null
   - path: top_k
     type: integer
     label: Top K
@@ -58,7 +58,6 @@ params:
     applicability:
       except:
         thinking.type:
-          - adaptive
           - enabled
   - path: thinking.type
     type: enum

--- a/models/anthropic/claude-opus-4-6.yaml
+++ b/models/anthropic/claude-opus-4-6.yaml
@@ -25,9 +25,10 @@ params:
     group: sampling
     applicability:
       except:
-        thinking.type:
-          - adaptive
-          - enabled
+        - thinking.type:
+            - enabled
+        - top_p:
+            not: null
   - path: top_p
     type: number
     label: Top P
@@ -43,10 +44,9 @@ params:
     applicability:
       except:
         - thinking.type:
-            - adaptive
             - enabled
         - temperature:
-            not: 1
+            not: null
   - path: top_k
     type: integer
     label: Top K
@@ -58,7 +58,6 @@ params:
     applicability:
       except:
         thinking.type:
-          - adaptive
           - enabled
   - path: thinking.type
     type: enum
@@ -67,7 +66,6 @@ params:
     default: disabled
     values:
       - disabled
-      - adaptive
       - enabled
     group: reasoning
   - path: thinking.budget_tokens

--- a/models/anthropic/claude-opus-4-7.yaml
+++ b/models/anthropic/claude-opus-4-7.yaml
@@ -11,55 +11,6 @@ params:
     range:
       min: 1
     group: generation_length
-  - path: temperature
-    type: number
-    label: Temperature
-    description: >-
-      Controls randomness. Lower values make outputs more focused; higher values make them more
-      varied.
-    default: 1
-    range:
-      min: 0
-      max: 1
-      step: 0.1
-    group: sampling
-    applicability:
-      except:
-        thinking.type:
-          - adaptive
-          - enabled
-  - path: top_p
-    type: number
-    label: Top P
-    description: >-
-      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
-      reaches this value.
-    default: 1
-    range:
-      min: 0
-      max: 1
-      step: 0.01
-    group: sampling
-    applicability:
-      except:
-        - thinking.type:
-            - adaptive
-            - enabled
-        - temperature:
-            not: 1
-  - path: top_k
-    type: integer
-    label: Top K
-    description: Limits token sampling to the top K most likely next tokens.
-    default: 0
-    range:
-      min: 0
-    group: sampling
-    applicability:
-      except:
-        thinking.type:
-          - adaptive
-          - enabled
   - path: thinking.type
     type: enum
     label: Thinking mode
@@ -67,5 +18,4 @@ params:
     default: disabled
     values:
       - disabled
-      - adaptive
     group: reasoning

--- a/models/anthropic/claude-sonnet-4-5-20250929.yaml
+++ b/models/anthropic/claude-sonnet-4-5-20250929.yaml
@@ -25,9 +25,10 @@ params:
     group: sampling
     applicability:
       except:
-        thinking.type:
-          - adaptive
-          - enabled
+        - thinking.type:
+            - enabled
+        - top_p:
+            not: null
   - path: top_p
     type: number
     label: Top P
@@ -43,10 +44,9 @@ params:
     applicability:
       except:
         - thinking.type:
-            - adaptive
             - enabled
         - temperature:
-            not: 1
+            not: null
   - path: top_k
     type: integer
     label: Top K
@@ -58,7 +58,6 @@ params:
     applicability:
       except:
         thinking.type:
-          - adaptive
           - enabled
   - path: thinking.type
     type: enum
@@ -67,7 +66,6 @@ params:
     default: disabled
     values:
       - disabled
-      - adaptive
       - enabled
     group: reasoning
   - path: thinking.budget_tokens

--- a/models/anthropic/claude-sonnet-4-6.yaml
+++ b/models/anthropic/claude-sonnet-4-6.yaml
@@ -25,9 +25,10 @@ params:
     group: sampling
     applicability:
       except:
-        thinking.type:
-          - adaptive
-          - enabled
+        - thinking.type:
+            - enabled
+        - top_p:
+            not: null
   - path: top_p
     type: number
     label: Top P
@@ -43,10 +44,9 @@ params:
     applicability:
       except:
         - thinking.type:
-            - adaptive
             - enabled
         - temperature:
-            not: 1
+            not: null
   - path: top_k
     type: integer
     label: Top K
@@ -58,7 +58,6 @@ params:
     applicability:
       except:
         thinking.type:
-          - adaptive
           - enabled
   - path: thinking.type
     type: enum
@@ -67,7 +66,6 @@ params:
     default: disabled
     values:
       - disabled
-      - adaptive
       - enabled
     group: reasoning
   - path: thinking.budget_tokens

--- a/models/openai/gpt-5-chat-latest.yaml
+++ b/models/openai/gpt-5-chat-latest.yaml
@@ -3,46 +3,11 @@ provider: openai
 authType: api_key
 model: gpt-5-chat-latest
 params:
-  - path: max_tokens
+  - path: max_completion_tokens
     type: integer
     label: Max tokens
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 1
+      min: 16
     group: generation_length
-  - path: temperature
-    type: number
-    label: Temperature
-    description: >-
-      Controls randomness. Lower values make outputs more focused; higher values make them more
-      varied.
-    default: 1
-    range:
-      min: 0
-      max: 2
-      step: 0.1
-    group: sampling
-  - path: top_p
-    type: number
-    label: Top P
-    description: >-
-      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
-      reaches this value.
-    default: 1
-    range:
-      min: 0
-      max: 1
-      step: 0.01
-    group: sampling
-  - path: reasoning_effort
-    type: enum
-    label: Reasoning effort
-    description: Controls how much reasoning the model should perform before producing an answer.
-    default: medium
-    values:
-      - minimal
-      - low
-      - medium
-      - high
-    group: reasoning

--- a/models/openai/gpt-5-mini.yaml
+++ b/models/openai/gpt-5-mini.yaml
@@ -3,38 +3,14 @@ provider: openai
 authType: api_key
 model: gpt-5-mini
 params:
-  - path: max_tokens
+  - path: max_completion_tokens
     type: integer
     label: Max tokens
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 1
+      min: 16
     group: generation_length
-  - path: temperature
-    type: number
-    label: Temperature
-    description: >-
-      Controls randomness. Lower values make outputs more focused; higher values make them more
-      varied.
-    default: 1
-    range:
-      min: 0
-      max: 2
-      step: 0.1
-    group: sampling
-  - path: top_p
-    type: number
-    label: Top P
-    description: >-
-      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
-      reaches this value.
-    default: 1
-    range:
-      min: 0
-      max: 1
-      step: 0.01
-    group: sampling
   - path: reasoning_effort
     type: enum
     label: Reasoning effort

--- a/models/openai/gpt-5-nano.yaml
+++ b/models/openai/gpt-5-nano.yaml
@@ -3,38 +3,14 @@ provider: openai
 authType: api_key
 model: gpt-5-nano
 params:
-  - path: max_tokens
+  - path: max_completion_tokens
     type: integer
     label: Max tokens
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 1
+      min: 16
     group: generation_length
-  - path: temperature
-    type: number
-    label: Temperature
-    description: >-
-      Controls randomness. Lower values make outputs more focused; higher values make them more
-      varied.
-    default: 1
-    range:
-      min: 0
-      max: 2
-      step: 0.1
-    group: sampling
-  - path: top_p
-    type: number
-    label: Top P
-    description: >-
-      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
-      reaches this value.
-    default: 1
-    range:
-      min: 0
-      max: 1
-      step: 0.01
-    group: sampling
   - path: reasoning_effort
     type: enum
     label: Reasoning effort

--- a/models/openai/gpt-5.1.yaml
+++ b/models/openai/gpt-5.1.yaml
@@ -3,38 +3,14 @@ provider: openai
 authType: api_key
 model: gpt-5.1
 params:
-  - path: max_tokens
+  - path: max_completion_tokens
     type: integer
     label: Max tokens
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 1
+      min: 16
     group: generation_length
-  - path: temperature
-    type: number
-    label: Temperature
-    description: >-
-      Controls randomness. Lower values make outputs more focused; higher values make them more
-      varied.
-    default: 1
-    range:
-      min: 0
-      max: 2
-      step: 0.1
-    group: sampling
-  - path: top_p
-    type: number
-    label: Top P
-    description: >-
-      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
-      reaches this value.
-    default: 1
-    range:
-      min: 0
-      max: 1
-      step: 0.01
-    group: sampling
   - path: reasoning_effort
     type: enum
     label: Reasoning effort

--- a/models/openai/gpt-5.2.yaml
+++ b/models/openai/gpt-5.2.yaml
@@ -3,45 +3,21 @@ provider: openai
 authType: api_key
 model: gpt-5.2
 params:
-  - path: max_tokens
+  - path: max_completion_tokens
     type: integer
     label: Max tokens
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 1
+      min: 16
     group: generation_length
-  - path: temperature
-    type: number
-    label: Temperature
-    description: >-
-      Controls randomness. Lower values make outputs more focused; higher values make them more
-      varied.
-    default: 1
-    range:
-      min: 0
-      max: 2
-      step: 0.1
-    group: sampling
-  - path: top_p
-    type: number
-    label: Top P
-    description: >-
-      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
-      reaches this value.
-    default: 1
-    range:
-      min: 0
-      max: 1
-      step: 0.01
-    group: sampling
   - path: reasoning_effort
     type: enum
     label: Reasoning effort
     description: Controls how much reasoning the model should perform before producing an answer.
     default: medium
     values:
-      - minimal
+      - none
       - low
       - medium
       - high

--- a/models/openai/gpt-5.4-mini.yaml
+++ b/models/openai/gpt-5.4-mini.yaml
@@ -3,45 +3,21 @@ provider: openai
 authType: api_key
 model: gpt-5.4-mini
 params:
-  - path: max_tokens
+  - path: max_completion_tokens
     type: integer
     label: Max tokens
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 1
+      min: 16
     group: generation_length
-  - path: temperature
-    type: number
-    label: Temperature
-    description: >-
-      Controls randomness. Lower values make outputs more focused; higher values make them more
-      varied.
-    default: 1
-    range:
-      min: 0
-      max: 2
-      step: 0.1
-    group: sampling
-  - path: top_p
-    type: number
-    label: Top P
-    description: >-
-      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
-      reaches this value.
-    default: 1
-    range:
-      min: 0
-      max: 1
-      step: 0.01
-    group: sampling
   - path: reasoning_effort
     type: enum
     label: Reasoning effort
     description: Controls how much reasoning the model should perform before producing an answer.
     default: medium
     values:
-      - minimal
+      - none
       - low
       - medium
       - high

--- a/models/openai/gpt-5.4.yaml
+++ b/models/openai/gpt-5.4.yaml
@@ -3,45 +3,21 @@ provider: openai
 authType: api_key
 model: gpt-5.4
 params:
-  - path: max_tokens
+  - path: max_completion_tokens
     type: integer
     label: Max tokens
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 1
+      min: 16
     group: generation_length
-  - path: temperature
-    type: number
-    label: Temperature
-    description: >-
-      Controls randomness. Lower values make outputs more focused; higher values make them more
-      varied.
-    default: 1
-    range:
-      min: 0
-      max: 2
-      step: 0.1
-    group: sampling
-  - path: top_p
-    type: number
-    label: Top P
-    description: >-
-      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
-      reaches this value.
-    default: 1
-    range:
-      min: 0
-      max: 1
-      step: 0.01
-    group: sampling
   - path: reasoning_effort
     type: enum
     label: Reasoning effort
     description: Controls how much reasoning the model should perform before producing an answer.
     default: medium
     values:
-      - minimal
+      - none
       - low
       - medium
       - high

--- a/models/openai/gpt-5.5.yaml
+++ b/models/openai/gpt-5.5.yaml
@@ -3,45 +3,21 @@ provider: openai
 authType: api_key
 model: gpt-5.5
 params:
-  - path: max_tokens
+  - path: max_completion_tokens
     type: integer
     label: Max tokens
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 1
+      min: 16
     group: generation_length
-  - path: temperature
-    type: number
-    label: Temperature
-    description: >-
-      Controls randomness. Lower values make outputs more focused; higher values make them more
-      varied.
-    default: 1
-    range:
-      min: 0
-      max: 2
-      step: 0.1
-    group: sampling
-  - path: top_p
-    type: number
-    label: Top P
-    description: >-
-      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
-      reaches this value.
-    default: 1
-    range:
-      min: 0
-      max: 1
-      step: 0.01
-    group: sampling
   - path: reasoning_effort
     type: enum
     label: Reasoning effort
     description: Controls how much reasoning the model should perform before producing an answer.
     default: medium
     values:
-      - minimal
+      - none
       - low
       - medium
       - high

--- a/models/openai/gpt-5.yaml
+++ b/models/openai/gpt-5.yaml
@@ -3,38 +3,14 @@ provider: openai
 authType: api_key
 model: gpt-5
 params:
-  - path: max_tokens
+  - path: max_completion_tokens
     type: integer
     label: Max tokens
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 1
+      min: 16
     group: generation_length
-  - path: temperature
-    type: number
-    label: Temperature
-    description: >-
-      Controls randomness. Lower values make outputs more focused; higher values make them more
-      varied.
-    default: 1
-    range:
-      min: 0
-      max: 2
-      step: 0.1
-    group: sampling
-  - path: top_p
-    type: number
-    label: Top P
-    description: >-
-      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
-      reaches this value.
-    default: 1
-    range:
-      min: 0
-      max: 1
-      step: 0.01
-    group: sampling
   - path: reasoning_effort
     type: enum
     label: Reasoning effort

--- a/models/openai/o1.yaml
+++ b/models/openai/o1.yaml
@@ -3,13 +3,13 @@ provider: openai
 authType: api_key
 model: o1
 params:
-  - path: max_tokens
+  - path: max_completion_tokens
     type: integer
     label: Max tokens
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 1
+      min: 16
     group: generation_length
   - path: reasoning_effort
     type: enum
@@ -17,8 +17,8 @@ params:
     description: Controls how much reasoning the model should perform before producing an answer.
     default: medium
     values:
-      - minimal
       - low
       - medium
       - high
+      - xhigh
     group: reasoning

--- a/models/openai/o3-mini.yaml
+++ b/models/openai/o3-mini.yaml
@@ -3,13 +3,13 @@ provider: openai
 authType: api_key
 model: o3-mini
 params:
-  - path: max_tokens
+  - path: max_completion_tokens
     type: integer
     label: Max tokens
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 1
+      min: 16
     group: generation_length
   - path: reasoning_effort
     type: enum
@@ -17,8 +17,8 @@ params:
     description: Controls how much reasoning the model should perform before producing an answer.
     default: medium
     values:
-      - minimal
       - low
       - medium
       - high
+      - xhigh
     group: reasoning

--- a/models/openai/o3.yaml
+++ b/models/openai/o3.yaml
@@ -3,13 +3,13 @@ provider: openai
 authType: api_key
 model: o3
 params:
-  - path: max_tokens
+  - path: max_completion_tokens
     type: integer
     label: Max tokens
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 1
+      min: 16
     group: generation_length
   - path: reasoning_effort
     type: enum
@@ -17,8 +17,8 @@ params:
     description: Controls how much reasoning the model should perform before producing an answer.
     default: medium
     values:
-      - minimal
       - low
       - medium
       - high
+      - xhigh
     group: reasoning

--- a/models/openai/o4-mini.yaml
+++ b/models/openai/o4-mini.yaml
@@ -3,13 +3,13 @@ provider: openai
 authType: api_key
 model: o4-mini
 params:
-  - path: max_tokens
+  - path: max_completion_tokens
     type: integer
     label: Max tokens
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 1
+      min: 16
     group: generation_length
   - path: reasoning_effort
     type: enum
@@ -17,8 +17,8 @@ params:
     description: Controls how much reasoning the model should perform before producing an answer.
     default: medium
     values:
-      - minimal
       - low
       - medium
       - high
+      - xhigh
     group: reasoning


### PR DESCRIPTION
## Summary
- correct OpenAI API-key MPS rows against the official Chat Completions schema and live behavior
- correct Anthropic API-key MPS rows, including current dated Claude 4.x IDs and Opus 4.7 adaptive-thinking rules
- correct DeepSeek API-key MPS rows so current DeepSeek models and legacy aliases expose the thinking toggle/effort without invalid sampling combinations

## Official docs checked
- OpenAI Chat Completions API: `max_completion_tokens`, `temperature`, `top_p`, and `reasoning_effort` model constraints
- Anthropic Claude Opus 4.7 docs: adaptive thinking only, no fixed thinking budgets, no non-default sampling params
- Anthropic effort docs/model overview: current Claude 4.x model IDs and effort behavior
- DeepSeek Chat Completion + Thinking Mode docs: `thinking.type`, `reasoning_effort`, sampling behavior while thinking is enabled

## Live smoke coverage
- OpenAI API-key catalog re-smoked: accessible rows had no parameter-shape failures; `chatgpt-4o-latest`, `o1-mini`, and `o1-preview` returned 404 for this test key, so they are left as a separate coverage/pruning policy question
- Anthropic targeted current rows: Opus 4.7 adaptive/effort rules pass; deprecated sampling and fixed-budget thinking fail as expected and are no longer exposed
- DeepSeek targeted rows: `deepseek-chat`, `deepseek-reasoner`, `deepseek-v4-flash`, and `deepseek-v4-pro` pass for supported parameter combinations; sampling params are hidden while thinking is enabled
- Post-patch dependency-aware smoke on changed Anthropic/DeepSeek rows: 118 live calls, 0 failures

## Notes
- This intentionally does not include the reusable live smoke harness from closed PR #4. That should remain a separate PR.
- This PR removes DeepSeek rows rejected by the live API (`deepseek-v3.1`, `deepseek-v3.2`, `deepseek-v4`) and keeps the accepted aliases (`deepseek-chat`, `deepseek-reasoner`).

## Local validation
- `npm run validate`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npx prettier --check .`
- `git diff --check`
