### PR TITLE
chore: switch domain to modelparams.dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ The formal catalog convention is the [Model Parameters convention](docs/model-pa
 2. **Start the file with the schema header** so your editor gives you autocomplete:
 
    ```yaml
-   # yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+   # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
    ```
 
 3. **Required top-level fields:** `provider`, `authType` (`api_key` or `subscription`), `model`, `params`.
@@ -54,7 +54,7 @@ The formal catalog convention is the [Model Parameters convention](docs/model-pa
 ## Example
 
 ```yaml
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-sonnet-4-6

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 modelparameters.dev contributors
+Copyright (c) 2026 modelparams.dev contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# modelparameters.dev
+# modelparams.dev
 
 > An open, community-maintained catalog of LLM model parameters.
 
 [![CI](https://github.com/mnfst/modelparameters.dev/actions/workflows/ci.yml/badge.svg)](https://github.com/mnfst/modelparameters.dev/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-[modelproviders.dev](https://modelproviders.dev) is an open-source database that lists the parameters available for popular AI models. It is heavily inspired on [models.dev](https://github.com/anomalyco/models.dev) and we use it at [Manifest](https://manifest.build/).
+[modelparams.dev](https://modelparams.dev) is an open-source database that lists the parameters available for popular AI models. It is heavily inspired on [models.dev](https://github.com/anomalyco/models.dev) and we use it at [Manifest](https://manifest.build/).
 
 ## API
 
 You can access this data through an API.
 
 ```
-curl https://modelparameters.dev/api/v1/models.json
+curl https://modelparams.dev/api/v1/models.json
 ```
 
 The catalog follows the [Model Parameters convention](docs/model-parameters-schema.md).
 The generated JSON Schema is available at
-`https://modelparameters.dev/api/v1/schema.json`.
+`https://modelparams.dev/api/v1/schema.json`.
 
 ## Adding a model or a parameter
 

--- a/docs/model-parameters-schema.md
+++ b/docs/model-parameters-schema.md
@@ -1,7 +1,7 @@
 # Model Parameters Convention
 
 The Model Parameters Schema (MPS) convention is the JSON/YAML shape used by
-modelparameters.dev to describe the request parameters available for a specific
+modelparams.dev to describe the request parameters available for a specific
 provider, auth type, and model.
 
 This catalog is metadata. It describes knobs a consumer can put into an outbound
@@ -11,8 +11,8 @@ authentication flows, endpoint compatibility, pricing, or UI control types.
 
 The public runtime sources are:
 
-- `https://modelparameters.dev/api/v1/models.json`
-- `https://modelparameters.dev/api/v1/schema.json`
+- `https://modelparams.dev/api/v1/models.json`
+- `https://modelparams.dev/api/v1/schema.json`
 
 ## Catalog Entry
 

--- a/models/anthropic/claude-3-5-haiku-20241022.yaml
+++ b/models/anthropic/claude-3-5-haiku-20241022.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-3-5-haiku-20241022

--- a/models/anthropic/claude-3-5-haiku-latest.yaml
+++ b/models/anthropic/claude-3-5-haiku-latest.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-3-5-haiku-latest

--- a/models/anthropic/claude-3-5-sonnet-20241022.yaml
+++ b/models/anthropic/claude-3-5-sonnet-20241022.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-3-5-sonnet-20241022

--- a/models/anthropic/claude-3-5-sonnet-latest.yaml
+++ b/models/anthropic/claude-3-5-sonnet-latest.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-3-5-sonnet-latest

--- a/models/anthropic/claude-3-7-sonnet-20250219.yaml
+++ b/models/anthropic/claude-3-7-sonnet-20250219.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-3-7-sonnet-20250219

--- a/models/anthropic/claude-3-7-sonnet-latest.yaml
+++ b/models/anthropic/claude-3-7-sonnet-latest.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-3-7-sonnet-latest

--- a/models/anthropic/claude-3-opus-20240229.yaml
+++ b/models/anthropic/claude-3-opus-20240229.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-3-opus-20240229

--- a/models/anthropic/claude-3-opus-latest.yaml
+++ b/models/anthropic/claude-3-opus-latest.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-3-opus-latest

--- a/models/anthropic/claude-haiku-4-5-20251001.yaml
+++ b/models/anthropic/claude-haiku-4-5-20251001.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-haiku-4-5-20251001

--- a/models/anthropic/claude-haiku-4-5.yaml
+++ b/models/anthropic/claude-haiku-4-5.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-haiku-4-5

--- a/models/anthropic/claude-haiku-4-subscription.yaml
+++ b/models/anthropic/claude-haiku-4-subscription.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
 model: claude-haiku-4

--- a/models/anthropic/claude-haiku-4.yaml
+++ b/models/anthropic/claude-haiku-4.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-haiku-4

--- a/models/anthropic/claude-opus-4-1-20250805.yaml
+++ b/models/anthropic/claude-opus-4-1-20250805.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-opus-4-1-20250805

--- a/models/anthropic/claude-opus-4-20250514.yaml
+++ b/models/anthropic/claude-opus-4-20250514.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-opus-4-20250514

--- a/models/anthropic/claude-opus-4-5-20251101.yaml
+++ b/models/anthropic/claude-opus-4-5-20251101.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-opus-4-5-20251101

--- a/models/anthropic/claude-opus-4-6.yaml
+++ b/models/anthropic/claude-opus-4-6.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-opus-4-6

--- a/models/anthropic/claude-opus-4-7.yaml
+++ b/models/anthropic/claude-opus-4-7.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-opus-4-7

--- a/models/anthropic/claude-opus-4-subscription.yaml
+++ b/models/anthropic/claude-opus-4-subscription.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
 model: claude-opus-4

--- a/models/anthropic/claude-sonnet-4-20250514.yaml
+++ b/models/anthropic/claude-sonnet-4-20250514.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-sonnet-4-20250514

--- a/models/anthropic/claude-sonnet-4-5-20250929.yaml
+++ b/models/anthropic/claude-sonnet-4-5-20250929.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-sonnet-4-5-20250929

--- a/models/anthropic/claude-sonnet-4-5.yaml
+++ b/models/anthropic/claude-sonnet-4-5.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-sonnet-4-5

--- a/models/anthropic/claude-sonnet-4-6.yaml
+++ b/models/anthropic/claude-sonnet-4-6.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
 model: claude-sonnet-4-6

--- a/models/anthropic/claude-sonnet-4-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-subscription.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
 model: claude-sonnet-4

--- a/models/deepseek/deepseek-chat.yaml
+++ b/models/deepseek/deepseek-chat.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: deepseek
 authType: api_key
 model: deepseek-chat

--- a/models/deepseek/deepseek-reasoner.yaml
+++ b/models/deepseek/deepseek-reasoner.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: deepseek
 authType: api_key
 model: deepseek-reasoner

--- a/models/deepseek/deepseek-v4-flash.yaml
+++ b/models/deepseek/deepseek-v4-flash.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: deepseek
 authType: api_key
 model: deepseek-v4-flash

--- a/models/deepseek/deepseek-v4-pro.yaml
+++ b/models/deepseek/deepseek-v4-pro.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: deepseek
 authType: api_key
 model: deepseek-v4-pro

--- a/models/openai/chatgpt-4o-latest.yaml
+++ b/models/openai/chatgpt-4o-latest.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: chatgpt-4o-latest

--- a/models/openai/gpt-3.5-turbo.yaml
+++ b/models/openai/gpt-3.5-turbo.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-3.5-turbo

--- a/models/openai/gpt-4-turbo-2024-04-09.yaml
+++ b/models/openai/gpt-4-turbo-2024-04-09.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-4-turbo-2024-04-09

--- a/models/openai/gpt-4-turbo.yaml
+++ b/models/openai/gpt-4-turbo.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-4-turbo

--- a/models/openai/gpt-4.1-mini.yaml
+++ b/models/openai/gpt-4.1-mini.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-4.1-mini

--- a/models/openai/gpt-4.1-nano.yaml
+++ b/models/openai/gpt-4.1-nano.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-4.1-nano

--- a/models/openai/gpt-4.1.yaml
+++ b/models/openai/gpt-4.1.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-4.1

--- a/models/openai/gpt-4o-2024-11-20.yaml
+++ b/models/openai/gpt-4o-2024-11-20.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-4o-2024-11-20

--- a/models/openai/gpt-4o-mini.yaml
+++ b/models/openai/gpt-4o-mini.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-4o-mini

--- a/models/openai/gpt-4o.yaml
+++ b/models/openai/gpt-4o.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-4o

--- a/models/openai/gpt-5-chat-latest.yaml
+++ b/models/openai/gpt-5-chat-latest.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-5-chat-latest

--- a/models/openai/gpt-5-mini.yaml
+++ b/models/openai/gpt-5-mini.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-5-mini

--- a/models/openai/gpt-5-nano.yaml
+++ b/models/openai/gpt-5-nano.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-5-nano

--- a/models/openai/gpt-5.1-codex-max-subscription.yaml
+++ b/models/openai/gpt-5.1-codex-max-subscription.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
 model: gpt-5.1-codex-max

--- a/models/openai/gpt-5.1-codex-subscription.yaml
+++ b/models/openai/gpt-5.1-codex-subscription.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
 model: gpt-5.1-codex

--- a/models/openai/gpt-5.1.yaml
+++ b/models/openai/gpt-5.1.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-5.1

--- a/models/openai/gpt-5.2-codex-subscription.yaml
+++ b/models/openai/gpt-5.2-codex-subscription.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
 model: gpt-5.2-codex

--- a/models/openai/gpt-5.2-subscription.yaml
+++ b/models/openai/gpt-5.2-subscription.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
 model: gpt-5.2

--- a/models/openai/gpt-5.2.yaml
+++ b/models/openai/gpt-5.2.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-5.2

--- a/models/openai/gpt-5.3-codex-spark-subscription.yaml
+++ b/models/openai/gpt-5.3-codex-spark-subscription.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
 model: gpt-5.3-codex-spark

--- a/models/openai/gpt-5.3-codex-subscription.yaml
+++ b/models/openai/gpt-5.3-codex-subscription.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
 model: gpt-5.3-codex

--- a/models/openai/gpt-5.4-mini-subscription.yaml
+++ b/models/openai/gpt-5.4-mini-subscription.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
 model: gpt-5.4-mini

--- a/models/openai/gpt-5.4-mini.yaml
+++ b/models/openai/gpt-5.4-mini.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-5.4-mini

--- a/models/openai/gpt-5.4-subscription.yaml
+++ b/models/openai/gpt-5.4-subscription.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
 model: gpt-5.4

--- a/models/openai/gpt-5.4.yaml
+++ b/models/openai/gpt-5.4.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-5.4

--- a/models/openai/gpt-5.5-subscription.yaml
+++ b/models/openai/gpt-5.5-subscription.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
 model: gpt-5.5

--- a/models/openai/gpt-5.5.yaml
+++ b/models/openai/gpt-5.5.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-5.5

--- a/models/openai/gpt-5.yaml
+++ b/models/openai/gpt-5.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: gpt-5

--- a/models/openai/o1-mini.yaml
+++ b/models/openai/o1-mini.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: o1-mini

--- a/models/openai/o1-preview.yaml
+++ b/models/openai/o1-preview.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: o1-preview

--- a/models/openai/o1.yaml
+++ b/models/openai/o1.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: o1

--- a/models/openai/o3-mini.yaml
+++ b/models/openai/o3-mini.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: o3-mini

--- a/models/openai/o3.yaml
+++ b/models/openai/o3.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: o3

--- a/models/openai/o4-mini.yaml
+++ b/models/openai/o4-mini.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
 model: o4-mini

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "modelparameters.dev",
+  "name": "modelparams.dev",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "modelparameters.dev",
+      "name": "modelparams.dev",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "modelparameters.dev",
+  "name": "modelparams.dev",
   "version": "0.1.0",
   "description": "An open catalog of LLM model parameters. The community-maintained source of truth for every knob you can turn.",
   "type": "module",
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "git+https://github.com/mnfst/modelparameters.dev.git"
   },
-  "homepage": "https://modelparameters.dev",
+  "homepage": "https://modelparams.dev",
   "bugs": {
     "url": "https://github.com/mnfst/modelparameters.dev/issues"
   },

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -17,7 +17,7 @@ import { buildModelJsonSchema } from "../schema/generate.js";
 import { bundleClientScript, compileStyles, copyStaticAssets } from "./assets.js";
 import { renderIndex } from "./render.js";
 
-const SITE_URL = process.env.SITE_URL ?? "https://modelparameters.dev";
+const SITE_URL = process.env.SITE_URL ?? "https://modelparams.dev";
 
 async function cleanDist(): Promise<void> {
   await fs.rm(DIST_DIR, { recursive: true, force: true });
@@ -46,7 +46,7 @@ async function writeRobotsAndSitemap(): Promise<void> {
 
 async function writeApiIndex(modelCount: number): Promise<void> {
   const body = {
-    name: "modelparameters.dev API",
+    name: "modelparams.dev API",
     version: "v1",
     endpoints: {
       catalog: "/api/v1/models.json",
@@ -91,7 +91,7 @@ export async function build(): Promise<{ models: number }> {
     const [provider, slug] = modelId(model).split("/");
     if (!provider || !slug) continue;
     await writeJson(path.join(DIST_API_DIR, "models", provider, `${slug}.json`), {
-      $schema: "https://modelparameters.dev/api/v1/schema.json",
+      $schema: "https://modelparams.dev/api/v1/schema.json",
       ...model,
     });
   }

--- a/src/build/render.ts
+++ b/src/build/render.ts
@@ -18,7 +18,7 @@ import { logoFor } from "../data/logos.js";
 import { VIEWS_DIR } from "../data/paths.js";
 import { modelId, type Catalog, type Model } from "../schema/model.js";
 
-const SITE_URL = process.env.SITE_URL ?? "https://modelparameters.dev";
+const SITE_URL = process.env.SITE_URL ?? "https://modelparams.dev";
 const SITE_DESCRIPTION =
   "An open, community-maintained catalog of LLM model parameters. Search and filter every knob you can turn — API-key and subscription variants tracked separately.";
 
@@ -33,7 +33,7 @@ function buildStructuredData(models: Model[]): string {
   const data = {
     "@context": "https://schema.org",
     "@type": "ItemList",
-    name: "modelparameters.dev catalog",
+    name: "modelparams.dev catalog",
     description: SITE_DESCRIPTION,
     numberOfItems: models.length,
     itemListElement: models.slice(0, 50).map((m, i) => ({
@@ -75,7 +75,7 @@ export async function renderIndex(opts: RenderOptions): Promise<string> {
   });
 
   const html = await ejs.renderFile(layoutPath, {
-    title: "modelparameters.dev — Open catalog of LLM model parameters",
+    title: "modelparams.dev — Open catalog of LLM model parameters",
     description: SITE_DESCRIPTION,
     canonicalUrl: SITE_URL,
     initialThemeClass: opts.initialThemeClass ?? "",

--- a/src/data/catalog.ts
+++ b/src/data/catalog.ts
@@ -1,6 +1,6 @@
 import type { Catalog, Model } from "../schema/model.js";
 
-const SCHEMA_URL = "https://modelparameters.dev/api/v1/schema.json";
+const SCHEMA_URL = "https://modelparams.dev/api/v1/schema.json";
 
 export function buildCatalog(models: Model[]): Catalog {
   return {

--- a/src/schema/generate.ts
+++ b/src/schema/generate.ts
@@ -1,7 +1,7 @@
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Model } from "./model.js";
 
-const SCHEMA_ID = "https://modelparameters.dev/api/v1/schema.json";
+const SCHEMA_ID = "https://modelparams.dev/api/v1/schema.json";
 
 export function buildModelJsonSchema(): Record<string, unknown> {
   const generated = zodToJsonSchema(Model, {
@@ -12,8 +12,8 @@ export function buildModelJsonSchema(): Record<string, unknown> {
   return {
     $schema: "http://json-schema.org/draft-07/schema#",
     $id: SCHEMA_ID,
-    title: "modelparameters.dev Model",
-    description: "Schema for a single AI model variant entry in the modelparameters.dev catalog.",
+    title: "modelparams.dev Model",
+    description: "Schema for a single AI model variant entry in the modelparams.dev catalog.",
     ...generated,
   };
 }

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -97,7 +97,7 @@ function makeApp(): express.Express {
         res.status(404).json({ error: "not_found", id: wanted });
         return;
       }
-      res.json({ $schema: "https://modelparameters.dev/api/v1/schema.json", ...model });
+      res.json({ $schema: "https://modelparams.dev/api/v1/schema.json", ...model });
     } catch (err) {
       next(err);
     }
@@ -117,7 +117,7 @@ async function main(): Promise<void> {
   watch();
   const app = makeApp();
   app.listen(PORT, () => {
-    console.log(`[dev] modelparameters.dev → http://localhost:${PORT}`);
+    console.log(`[dev] modelparams.dev → http://localhost:${PORT}`);
   });
 }
 

--- a/src/views/layout.ejs
+++ b/src/views/layout.ejs
@@ -11,7 +11,7 @@
     <meta property="og:title" content="<%= title %>" />
     <meta property="og:description" content="<%= description %>" />
     <meta property="og:url" content="<%= canonicalUrl %>" />
-    <meta property="og:site_name" content="modelparameters.dev" />
+    <meta property="og:site_name" content="modelparams.dev" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="<%= title %>" />
     <meta name="twitter:description" content="<%= description %>" />

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -11,7 +11,7 @@
           <path d="M4 6h6M4 12h10M4 18h6" stroke-linecap="round" />
         </svg>
       </span>
-      <span class="text-base sm:text-lg">modelparameters.dev</span>
+      <span class="text-base sm:text-lg">modelparams.dev</span>
     </a>
     <nav class="flex items-center gap-1 text-sm">
       <button

--- a/src/views/partials/how_to_use.ejs
+++ b/src/views/partials/how_to_use.ejs
@@ -20,7 +20,7 @@
   <div class="space-y-6 px-6 py-6 text-sm leading-relaxed text-slate-700 dark:text-slate-300">
     <section class="space-y-3">
       <p>
-        <a href="/" class="font-medium text-accent hover:text-accent-hover">modelparameters.dev</a>
+        <a href="/" class="font-medium text-accent hover:text-accent-hover">modelparams.dev</a>
         is an open, community-maintained catalog of LLM model parameters. Each entry shows the
         knobs you can turn — type, default, range, and the conditions that gate it.
       </p>
@@ -34,7 +34,7 @@
     <section class="space-y-3">
       <h3 class="text-sm font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Catalog API</h3>
       <p>The full catalog is static JSON, CORS-enabled, served from the edge.</p>
-      <pre class="overflow-x-auto rounded-lg bg-slate-100 px-3 py-2 font-mono text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200"><code>curl <a class="underline decoration-dotted underline-offset-2 hover:text-accent" href="/api/v1/models.json">https://modelparameters.dev/api/v1/models.json</a></code></pre>
+      <pre class="overflow-x-auto rounded-lg bg-slate-100 px-3 py-2 font-mono text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200"><code>curl <a class="underline decoration-dotted underline-offset-2 hover:text-accent" href="/api/v1/models.json">https://modelparams.dev/api/v1/models.json</a></code></pre>
       <p>
         Each entry is keyed by <code class="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-xs dark:bg-slate-800">provider/model</code> for API-key variants; subscription variants append <code class="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-xs dark:bg-slate-800">-subscription</code>.
       </p>
@@ -42,8 +42,8 @@
 
     <section class="space-y-3">
       <h3 class="text-sm font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Single model</h3>
-      <pre class="overflow-x-auto rounded-lg bg-slate-100 px-3 py-2 font-mono text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200"><code>curl <a class="underline decoration-dotted underline-offset-2 hover:text-accent" href="/api/v1/models/anthropic/claude-opus-4-7.json">https://modelparameters.dev/api/v1/models/anthropic/claude-opus-4-7.json</a>
-curl <a class="underline decoration-dotted underline-offset-2 hover:text-accent" href="/api/v1/models/anthropic/claude-opus-4-7-subscription.json">https://modelparameters.dev/api/v1/models/anthropic/claude-opus-4-7-subscription.json</a></code></pre>
+      <pre class="overflow-x-auto rounded-lg bg-slate-100 px-3 py-2 font-mono text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200"><code>curl <a class="underline decoration-dotted underline-offset-2 hover:text-accent" href="/api/v1/models/anthropic/claude-opus-4-7.json">https://modelparams.dev/api/v1/models/anthropic/claude-opus-4-7.json</a>
+curl <a class="underline decoration-dotted underline-offset-2 hover:text-accent" href="/api/v1/models/anthropic/claude-opus-4-7-subscription.json">https://modelparams.dev/api/v1/models/anthropic/claude-opus-4-7-subscription.json</a></code></pre>
     </section>
 
     <section class="space-y-3">
@@ -51,11 +51,11 @@ curl <a class="underline decoration-dotted underline-offset-2 hover:text-accent"
       <p>
         Every entry validates against a JSON Schema you can use in your editor or pipeline.
       </p>
-      <pre class="overflow-x-auto rounded-lg bg-slate-100 px-3 py-2 font-mono text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200"><code>curl <a class="underline decoration-dotted underline-offset-2 hover:text-accent" href="/api/v1/schema.json">https://modelparameters.dev/api/v1/schema.json</a></code></pre>
+      <pre class="overflow-x-auto rounded-lg bg-slate-100 px-3 py-2 font-mono text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200"><code>curl <a class="underline decoration-dotted underline-offset-2 hover:text-accent" href="/api/v1/schema.json">https://modelparams.dev/api/v1/schema.json</a></code></pre>
       <p>
         Add this header to any YAML you author for autocomplete in VS Code:
       </p>
-      <pre class="overflow-x-auto rounded-lg bg-slate-100 px-3 py-2 font-mono text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200"><code># yaml-language-server: $schema=https://modelparameters.dev/api/v1/schema.json</code></pre>
+      <pre class="overflow-x-auto rounded-lg bg-slate-100 px-3 py-2 font-mono text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200"><code># yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json</code></pre>
     </section>
 
     <section class="space-y-3">
@@ -64,7 +64,7 @@ curl <a class="underline decoration-dotted underline-offset-2 hover:text-accent"
         Provider logos are available at <code class="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-xs dark:bg-slate-800">/assets/logos/{provider}.svg</code>
         where <code class="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-xs dark:bg-slate-800">{provider}</code> is the provider slug. They use <code class="font-mono">currentColor</code> so they inherit your text color.
       </p>
-      <pre class="overflow-x-auto rounded-lg bg-slate-100 px-3 py-2 font-mono text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200"><code>curl <a class="underline decoration-dotted underline-offset-2 hover:text-accent" href="/assets/logos/anthropic.svg">https://modelparameters.dev/assets/logos/anthropic.svg</a></code></pre>
+      <pre class="overflow-x-auto rounded-lg bg-slate-100 px-3 py-2 font-mono text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200"><code>curl <a class="underline decoration-dotted underline-offset-2 hover:text-accent" href="/assets/logos/anthropic.svg">https://modelparams.dev/assets/logos/anthropic.svg</a></code></pre>
       <p class="text-xs text-slate-500 dark:text-slate-400">
         Logos are sourced from the <a class="underline" href="https://github.com/anomalyco/models.dev" target="_blank" rel="noopener">models.dev</a> repo (MIT) and used under nominative fair use.
       </p>

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -36,7 +36,7 @@ describe("buildCatalog", () => {
     const catalog = buildCatalog([makeModel()]);
     expect(catalog.count).toBe(1);
     expect(catalog.models).toHaveLength(1);
-    expect(catalog.$schema).toBe("https://modelparameters.dev/api/v1/schema.json");
+    expect(catalog.$schema).toBe("https://modelparams.dev/api/v1/schema.json");
     expect(typeof catalog.generatedAt).toBe("string");
   });
 });

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -286,7 +286,7 @@ describe("JSON Schema generator", () => {
   it("produces a draft-07 schema with $id", () => {
     const schema = buildModelJsonSchema();
     expect(schema.$schema).toBe("http://json-schema.org/draft-07/schema#");
-    expect(schema.$id).toBe("https://modelparameters.dev/api/v1/schema.json");
+    expect(schema.$id).toBe("https://modelparams.dev/api/v1/schema.json");
     expect(typeof schema.title).toBe("string");
   });
 });


### PR DESCRIPTION
### 💭 Why
The catalog moved to a new home at modelparams.dev. Everything still pointed at the old modelparameters.dev domain.

### ✨ What changed
- Site URL, canonical/OG tags, sitemap, robots, and API base now use modelparams.dev.
- JSON Schema `$id` and all 61 model `$schema` headers updated.
- package name, README, LICENSE, and docs updated to match.

### 🔧 For operators
Point the modelparams.dev domain at this deployment. Anything pinning the old schema id (`https://modelparameters.dev/api/v1/schema.json`) should switch to the new host.

### 📝 Notes
GitHub repo links (CI badge, "Edit on GitHub") still use mnfst/modelparameters.dev because the repo itself was not renamed.
