### PR TITLE
feat: make the catalog easy for AI agents to use

### DIFF
--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -6,13 +6,14 @@ import {
   buildProviderFacets,
 } from "../data/catalog.js";
 import { loadAllModels } from "../data/load.js";
+import { buildLlmsFullTxt, buildLlmsTxt } from "../data/llms.js";
 import {
   DIST_API_DIR,
   DIST_ASSETS_DIR,
   DIST_DIR,
   MODELS_DIR,
 } from "../data/paths.js";
-import { modelId } from "../schema/model.js";
+import { modelId, type Model } from "../schema/model.js";
 import { buildModelJsonSchema } from "../schema/generate.js";
 import { bundleClientScript, compileStyles, copyStaticAssets } from "./assets.js";
 import { renderIndex } from "./render.js";
@@ -30,15 +31,36 @@ async function writeJson(file: string, payload: unknown): Promise<void> {
   await fs.writeFile(file, JSON.stringify(payload, null, 2) + "\n", "utf8");
 }
 
+async function writeLlmsFiles(models: Model[]): Promise<void> {
+  await fs.writeFile(path.join(DIST_DIR, "llms.txt"), buildLlmsTxt(SITE_URL, models), "utf8");
+  await fs.writeFile(
+    path.join(DIST_DIR, "llms-full.txt"),
+    buildLlmsFullTxt(SITE_URL, models),
+    "utf8",
+  );
+}
+
 async function writeRobotsAndSitemap(): Promise<void> {
-  const robots = `User-agent: *\nAllow: /\nSitemap: ${SITE_URL}/sitemap.xml\n`;
+  const robots = `# AI agents welcome. Machine-readable overview: ${SITE_URL}/llms.txt\nUser-agent: *\nAllow: /\nSitemap: ${SITE_URL}/sitemap.xml\n`;
   await fs.writeFile(path.join(DIST_DIR, "robots.txt"), robots, "utf8");
 
   const today = new Date().toISOString().slice(0, 10);
+  const urls = [
+    { loc: `${SITE_URL}/`, priority: "1.0" },
+    { loc: `${SITE_URL}/llms.txt`, priority: "0.8" },
+    { loc: `${SITE_URL}/llms-full.txt`, priority: "0.7" },
+    { loc: `${SITE_URL}/api/v1/models.json`, priority: "0.5" },
+    { loc: `${SITE_URL}/api/v1/schema.json`, priority: "0.5" },
+  ];
+  const body = urls
+    .map(
+      ({ loc, priority }) =>
+        `  <url><loc>${loc}</loc><lastmod>${today}</lastmod><priority>${priority}</priority></url>`,
+    )
+    .join("\n");
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>${SITE_URL}/</loc><lastmod>${today}</lastmod><priority>1.0</priority></url>
-  <url><loc>${SITE_URL}/api/v1/models.json</loc><lastmod>${today}</lastmod><priority>0.5</priority></url>
+${body}
 </urlset>
 `;
   await fs.writeFile(path.join(DIST_DIR, "sitemap.xml"), sitemap, "utf8");
@@ -99,6 +121,7 @@ export async function build(): Promise<{ models: number }> {
   console.log("Bundling client + styles...");
   await Promise.all([bundleClientScript(), compileStyles(), copyStaticAssets()]);
 
+  await writeLlmsFiles(models);
   await writeRobotsAndSitemap();
 
   const elapsed = ((Date.now() - startedAt) / 1000).toFixed(2);

--- a/src/build/render.ts
+++ b/src/build/render.ts
@@ -14,6 +14,7 @@ import {
   providerLabel,
 } from "../data/display.js";
 import { groupParams } from "../data/group.js";
+import { usageGuideMarkdown } from "../data/llms.js";
 import { logoFor } from "../data/logos.js";
 import { VIEWS_DIR } from "../data/paths.js";
 import { modelId, type Catalog, type Model } from "../schema/model.js";
@@ -30,8 +31,37 @@ export interface RenderOptions {
 }
 
 function buildStructuredData(models: Model[]): string {
-  const data = {
-    "@context": "https://schema.org",
+  const website = {
+    "@type": "WebSite",
+    "@id": `${SITE_URL}/#website`,
+    url: `${SITE_URL}/`,
+    name: "modelparameters.dev",
+    description: SITE_DESCRIPTION,
+    potentialAction: {
+      "@type": "SearchAction",
+      target: {
+        "@type": "EntryPoint",
+        urlTemplate: `${SITE_URL}/?q={search_term_string}`,
+      },
+      "query-input": "required name=search_term_string",
+    },
+  };
+  const dataset = {
+    "@type": "Dataset",
+    "@id": `${SITE_URL}/#dataset`,
+    name: "modelparameters.dev catalog",
+    description: SITE_DESCRIPTION,
+    url: `${SITE_URL}/`,
+    license: "https://opensource.org/licenses/MIT",
+    isAccessibleForFree: true,
+    creator: { "@type": "Organization", name: "modelparameters.dev", url: `${SITE_URL}/` },
+    distribution: {
+      "@type": "DataDownload",
+      encodingFormat: "application/json",
+      contentUrl: `${SITE_URL}/api/v1/models.json`,
+    },
+  };
+  const itemList = {
     "@type": "ItemList",
     name: "modelparameters.dev catalog",
     description: SITE_DESCRIPTION,
@@ -48,7 +78,7 @@ function buildStructuredData(models: Model[]): string {
       },
     })),
   };
-  return JSON.stringify(data);
+  return JSON.stringify({ "@context": "https://schema.org", "@graph": [website, dataset, itemList] });
 }
 
 export async function renderIndex(opts: RenderOptions): Promise<string> {
@@ -80,6 +110,7 @@ export async function renderIndex(opts: RenderOptions): Promise<string> {
     canonicalUrl: SITE_URL,
     initialThemeClass: opts.initialThemeClass ?? "",
     structuredData: buildStructuredData(opts.catalog.models),
+    usageGuide: usageGuideMarkdown(SITE_URL),
     body,
   });
 

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -1,3 +1,5 @@
+import { setupWebMCP } from "./webmcp.js";
+
 type AuthFilter = "all" | "api_key" | "subscription";
 
 interface FilterState {
@@ -40,6 +42,57 @@ function setupHowToUseModal(): void {
   });
   dialog.addEventListener("click", (event) => {
     if (event.target === dialog) close();
+  });
+}
+
+async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    /* fall through to the execCommand path below */
+  }
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  let copied = false;
+  try {
+    copied = document.execCommand("copy");
+  } catch {
+    copied = false;
+  }
+  document.body.removeChild(textarea);
+  return copied;
+}
+
+function setupCopyHowToUse(): void {
+  const button = document.querySelector<HTMLButtonElement>("[data-copy-how-to-use]");
+  const source = document.getElementById("how-to-use-md");
+  if (!button || !source) return;
+
+  const label = button.querySelector<HTMLElement>("[data-copy-label]");
+  const idleIcon = button.querySelector<HTMLElement>("[data-copy-idle]");
+  const doneIcon = button.querySelector<HTMLElement>("[data-copy-done]");
+  const idleText = label?.textContent ?? "Copy";
+  let resetTimer = 0;
+
+  button.addEventListener("click", async () => {
+    const copied = await copyText((source.textContent ?? "").trim());
+    if (label) label.textContent = copied ? "Copied" : "Press ⌘C";
+    idleIcon?.classList.toggle("hidden", copied);
+    doneIcon?.classList.toggle("hidden", !copied);
+    window.clearTimeout(resetTimer);
+    resetTimer = window.setTimeout(() => {
+      if (label) label.textContent = idleText;
+      idleIcon?.classList.remove("hidden");
+      doneIcon?.classList.add("hidden");
+    }, 2000);
   });
 }
 
@@ -100,6 +153,14 @@ function setupSearch(): void {
     state.query = input.value.trim().toLowerCase();
     applyFilters();
   });
+
+  // Deep link: /?q=opus pre-fills the search (backs the schema.org SearchAction).
+  const initial = new URLSearchParams(window.location.search).get("q");
+  if (initial) {
+    input.value = initial;
+    state.query = initial.trim().toLowerCase();
+    applyFilters();
+  }
 }
 
 function setupAuthFilters(): void {
@@ -136,8 +197,10 @@ function setupToggleChips(selector: string, datasetKey: string, bucket: Set<stri
 document.addEventListener("DOMContentLoaded", () => {
   setupThemeToggle();
   setupHowToUseModal();
+  setupCopyHowToUse();
   setupSearch();
   setupAuthFilters();
   setupToggleChips("[data-provider]", "provider", state.providers);
   setupToggleChips("[data-capability]", "capability", state.capabilities);
+  setupWebMCP();
 });

--- a/src/client/webmcp.ts
+++ b/src/client/webmcp.ts
@@ -1,0 +1,267 @@
+// Exposes the catalog to in-browser agents via the WebMCP API
+// (window.navigator.modelContext). See https://github.com/webmachinelearning/webmcp.
+// Standalone by design: it talks to the JSON API and the DOM, so it pulls no
+// server-side modules (and no zod) into the client bundle.
+
+type AuthType = "api_key" | "subscription";
+
+interface CatalogParam {
+  path: string;
+  type: string;
+  group: string;
+  description: string;
+  default?: unknown;
+  values?: unknown[];
+}
+
+interface CatalogModel {
+  provider: string;
+  authType: AuthType;
+  model: string;
+  params: CatalogParam[];
+}
+
+interface Catalog {
+  count: number;
+  generatedAt?: string;
+  models: CatalogModel[];
+}
+
+interface ToolResponse {
+  content: Array<{ type: "text"; text: string }>;
+}
+
+interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+  execute: (params: Record<string, unknown>) => Promise<ToolResponse> | ToolResponse;
+}
+
+interface ModelContext {
+  provideContext?: (context: { tools: ToolDefinition[] }) => void;
+}
+
+function modelId(model: CatalogModel): string {
+  const suffix = model.authType === "subscription" ? "-subscription" : "";
+  return `${model.provider}/${model.model}${suffix}`;
+}
+
+let catalogPromise: Promise<Catalog> | null = null;
+
+function getCatalog(): Promise<Catalog> {
+  if (!catalogPromise) {
+    catalogPromise = fetch("/api/v1/models.json")
+      .then((res) => {
+        if (!res.ok) throw new Error(`catalog fetch failed (${res.status})`);
+        return res.json() as Promise<Catalog>;
+      })
+      .catch((err) => {
+        catalogPromise = null;
+        throw err;
+      });
+  }
+  return catalogPromise;
+}
+
+function ok(payload: unknown): ToolResponse {
+  return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asStringList(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === "string");
+  const single = asString(value);
+  return single ? [single] : [];
+}
+
+// Mirror the agent's query onto the visible filter controls so a human watching
+// the page sees what the agent searched for. Best-effort: it drives the same
+// buttons/inputs a person would, and silently skips controls that aren't present.
+function reflectInUi(filters: {
+  query?: string;
+  auth?: string;
+  providers: string[];
+  capabilities: string[];
+}): void {
+  const search = document.querySelector<HTMLInputElement>("[data-search]");
+  if (search && filters.query !== undefined) {
+    search.value = filters.query;
+    search.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+  if (filters.auth) {
+    document.querySelector<HTMLButtonElement>(`[data-auth-filter="${filters.auth}"]`)?.click();
+  }
+  setToggleGroup("[data-provider]", "provider", filters.providers);
+  setToggleGroup("[data-capability]", "capability", filters.capabilities);
+}
+
+function setToggleGroup(selector: string, key: string, wanted: string[]): void {
+  if (wanted.length === 0) return;
+  const want = new Set(wanted);
+  document.querySelectorAll<HTMLButtonElement>(selector).forEach((btn) => {
+    const value = btn.dataset[key] ?? "";
+    const active = btn.dataset.active === "true";
+    if (want.has(value) !== active) btn.click();
+  });
+}
+
+function searchModels(catalog: Catalog, params: Record<string, unknown>) {
+  const query = asString(params.query)?.toLowerCase();
+  const auth = asString(params.auth);
+  const providers = asStringList(params.provider);
+  const capabilities = asStringList(params.capability);
+  const limit = typeof params.limit === "number" ? Math.max(1, Math.floor(params.limit)) : 25;
+
+  const matches = catalog.models.filter((model) => {
+    if (auth && auth !== "all" && model.authType !== auth) return false;
+    if (providers.length > 0 && !providers.includes(model.provider)) return false;
+    const paths = new Set(model.params.map((p) => p.path));
+    if (!capabilities.every((cap) => paths.has(cap))) return false;
+    if (query) {
+      const haystack = `${model.model} ${model.provider} ${modelId(model)}`.toLowerCase();
+      if (!haystack.includes(query)) return false;
+    }
+    return true;
+  });
+
+  reflectInUi({ query: asString(params.query) ?? "", auth, providers, capabilities });
+
+  return {
+    total: matches.length,
+    returned: Math.min(matches.length, limit),
+    truncated: matches.length > limit,
+    models: matches.slice(0, limit).map((model) => ({
+      id: modelId(model),
+      provider: model.provider,
+      model: model.model,
+      authType: model.authType,
+      parameterCount: model.params.length,
+      parameters: model.params.map((p) => p.path),
+    })),
+  };
+}
+
+async function getModelParameters(params: Record<string, unknown>): Promise<ToolResponse> {
+  const id = asString(params.id);
+  if (!id) return ok({ error: "Provide an `id` such as anthropic/claude-opus-4-7." });
+  const res = await fetch(`/api/v1/models/${id}.json`);
+  if (!res.ok) return ok({ error: `No model with id "${id}" (HTTP ${res.status}).` });
+  return ok(await res.json());
+}
+
+function usageGuideText(): string {
+  const embedded = document.getElementById("how-to-use-md")?.textContent?.trim();
+  return embedded && embedded.length > 0
+    ? embedded
+    : "Usage guide unavailable on this page; fetch /llms-full.txt instead.";
+}
+
+function buildTools(): ToolDefinition[] {
+  return [
+    {
+      name: "search_models",
+      description:
+        "Search the LLM parameter catalog. Filter by free-text query, provider slug, " +
+        "required parameter path(s), and auth type (api_key | subscription | all). Also " +
+        "mirrors the query onto the page's visible filters. Returns matching model ids.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Free-text match on model name, provider, or id." },
+          provider: {
+            type: "string",
+            description: "Provider slug, e.g. anthropic, openai, deepseek.",
+          },
+          capability: {
+            type: "array",
+            items: { type: "string" },
+            description: "Parameter path(s) the model must support, e.g. thinking.type.",
+          },
+          auth: {
+            type: "string",
+            enum: ["all", "api_key", "subscription"],
+            description: "Auth variant to include. Defaults to all.",
+          },
+          limit: { type: "number", description: "Max models to return (default 25)." },
+        },
+      },
+      execute: async (params) => ok(searchModels(await getCatalog(), params)),
+    },
+    {
+      name: "get_model_parameters",
+      description:
+        "Fetch the full parameter set for one model by id (e.g. anthropic/claude-opus-4-7, " +
+        "or append -subscription for the subscription variant). Returns every parameter with " +
+        "type, default, range, allowed values, and applicability conditions.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          id: { type: "string", description: "Model id: provider/model[-subscription]." },
+        },
+        required: ["id"],
+      },
+      execute: getModelParameters,
+    },
+    {
+      name: "list_providers",
+      description: "List every provider in the catalog with its model count.",
+      inputSchema: { type: "object", properties: {} },
+      execute: async () => {
+        const catalog = await getCatalog();
+        const counts = new Map<string, number>();
+        for (const model of catalog.models) {
+          counts.set(model.provider, (counts.get(model.provider) ?? 0) + 1);
+        }
+        const providers = [...counts.entries()]
+          .map(([provider, count]) => ({ provider, count }))
+          .sort((a, b) => b.count - a.count || a.provider.localeCompare(b.provider));
+        return ok({ total: providers.length, providers });
+      },
+    },
+    {
+      name: "list_parameters",
+      description:
+        "List every parameter path documented across the catalog with how many models expose it.",
+      inputSchema: { type: "object", properties: {} },
+      execute: async () => {
+        const catalog = await getCatalog();
+        const counts = new Map<string, number>();
+        for (const model of catalog.models) {
+          for (const path of new Set(model.params.map((p) => p.path))) {
+            counts.set(path, (counts.get(path) ?? 0) + 1);
+          }
+        }
+        const parameters = [...counts.entries()]
+          .map(([path, count]) => ({ path, count }))
+          .sort((a, b) => b.count - a.count || a.path.localeCompare(b.path));
+        return ok({ total: parameters.length, parameters });
+      },
+    },
+    {
+      name: "get_usage_guide",
+      description:
+        "Return the modelparameters.dev usage guide as Markdown: how to call the API, the " +
+        "JSON Schema, logos, and how to contribute. Hand this to a coding agent verbatim.",
+      inputSchema: { type: "object", properties: {} },
+      execute: () => ({ content: [{ type: "text", text: usageGuideText() }] }),
+    },
+  ];
+}
+
+export function setupWebMCP(): void {
+  const context = (window.navigator as Navigator & { modelContext?: ModelContext }).modelContext;
+  if (!context || typeof context.provideContext !== "function") return;
+  try {
+    context.provideContext({ tools: buildTools() });
+  } catch {
+    /* a stricter host may reject the registration; degrade to plain HTML/JSON */
+  }
+}

--- a/src/data/llms.ts
+++ b/src/data/llms.ts
@@ -1,0 +1,219 @@
+import { describeApplicability } from "./applicability.js";
+import { buildProviderFacets } from "./catalog.js";
+import { authLabel, modelLabel, paramGroupLabel, providerLabel } from "./display.js";
+import { groupParams } from "./group.js";
+import { modelId, type Model, type Parameter } from "../schema/model.js";
+
+const REPO_URL = "https://github.com/mnfst/modelparameters.dev";
+
+function modelJsonUrl(siteUrl: string, model: Model): string {
+  return `${siteUrl}/api/v1/models/${modelId(model)}.json`;
+}
+
+function modelTitle(model: Model): string {
+  return `${providerLabel(model.provider)} ${modelLabel(model)} (${authLabel(model.authType)})`;
+}
+
+function plural(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+function guideIntro(siteUrl: string): string[] {
+  return [
+    "# How to use modelparameters.dev",
+    "",
+    `[modelparameters.dev](${siteUrl}) is an open, community-maintained catalog of LLM model`,
+    "parameters. Each entry shows the knobs you can turn — type, default, range, and the",
+    "conditions that gate it.",
+    "",
+    "The same model accessed via an **API key** and via a **subscription** usually exposes a",
+    "different set of parameters. We list both as separate entries so the data stays honest.",
+    "",
+  ];
+}
+
+function guideApi(siteUrl: string): string[] {
+  return [
+    "## Catalog API",
+    "",
+    "The full catalog is static JSON, CORS-enabled, served from the edge:",
+    "",
+    "```bash",
+    `curl ${siteUrl}/api/v1/models.json`,
+    "```",
+    "",
+    "Each entry is keyed by `provider/model` for API-key variants; subscription variants",
+    "append `-subscription`.",
+    "",
+    "## Single model",
+    "",
+    "```bash",
+    `curl ${siteUrl}/api/v1/models/anthropic/claude-opus-4-7.json`,
+    `curl ${siteUrl}/api/v1/models/anthropic/claude-opus-4-7-subscription.json`,
+    "```",
+    "",
+    "## JSON Schema",
+    "",
+    "Every entry validates against a JSON Schema you can use in your editor or pipeline:",
+    "",
+    "```bash",
+    `curl ${siteUrl}/api/v1/schema.json`,
+    "```",
+    "",
+    "Add this header to any YAML you author for autocomplete in VS Code:",
+    "",
+    "```yaml",
+    `# yaml-language-server: $schema=${siteUrl}/api/v1/schema.json`,
+    "```",
+    "",
+    "## Logos",
+    "",
+    "Provider logos are at `/assets/logos/{provider}.svg`. They use `currentColor`, so they",
+    "inherit your text color:",
+    "",
+    "```bash",
+    `curl ${siteUrl}/assets/logos/anthropic.svg`,
+    "```",
+    "",
+  ];
+}
+
+function guideAgents(siteUrl: string): string[] {
+  return [
+    "## Contribute",
+    "",
+    "The data lives in YAML under `models/{provider}/{model}-{auth}.yaml` in the",
+    `[GitHub repo](${REPO_URL}). Open a PR; CI validates against the schema and rebuilds.`,
+    "",
+    "## For agents",
+    "",
+    `- Machine-readable site overview: ${siteUrl}/llms.txt`,
+    `- Full usage guide plus every parameter inline: ${siteUrl}/llms-full.txt`,
+    "- When your browser supports it, this page registers in-browser **WebMCP** tools on",
+    "  `navigator.modelContext`: `search_models`, `get_model_parameters`, `list_providers`,",
+    "  `list_parameters`, and `get_usage_guide`.",
+    "",
+  ];
+}
+
+/**
+ * The "How to use" guide as Markdown. This is the canonical agent-facing doc:
+ * it backs the modal's Copy button and the body of /llms-full.txt.
+ */
+export function usageGuideMarkdown(siteUrl: string): string {
+  return [...guideIntro(siteUrl), ...guideApi(siteUrl), ...guideAgents(siteUrl)].join("\n");
+}
+
+function fmtValue(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return `"${value}"`;
+  return String(value);
+}
+
+function paramConstraints(param: Parameter): string {
+  const bits: string[] = [];
+  if (param.default !== undefined) bits.push(`default: ${fmtValue(param.default)}`);
+  if (param.type === "enum") bits.push(`values: ${param.values.map(fmtValue).join(", ")}`);
+  if ((param.type === "integer" || param.type === "number") && param.range) {
+    const range: string[] = [];
+    if (param.range.min !== undefined) range.push(`min ${param.range.min}`);
+    if (param.range.max !== undefined) range.push(`max ${param.range.max}`);
+    if (param.range.step !== undefined) range.push(`step ${param.range.step}`);
+    if (range.length > 0) bits.push(`range: ${range.join(", ")}`);
+  }
+  const applicability = describeApplicability(param.applicability);
+  if (applicability.only.length > 0) bits.push(`only when ${applicability.only.join("; ")}`);
+  if (applicability.except.length > 0) bits.push(`except when ${applicability.except.join("; ")}`);
+  return bits.length > 0 ? ` [${bits.join("] [")}]` : "";
+}
+
+function paramLine(param: Parameter): string {
+  return `- \`${param.path}\` (${param.type}, ${paramGroupLabel(param.group)}) — ${param.description}${paramConstraints(param)}`;
+}
+
+function sortById(models: Model[]): Model[] {
+  return [...models].sort((a, b) => modelId(a).localeCompare(modelId(b)));
+}
+
+/**
+ * Concise, link-first overview following the llms.txt convention (llmstxt.org):
+ * H1, blockquote summary, then sectioned lists of links agents can fetch.
+ */
+export function buildLlmsTxt(siteUrl: string, models: Model[]): string {
+  const lines: string[] = [
+    "# modelparameters.dev",
+    "",
+    "> An open, community-maintained catalog of LLM model parameters — every knob you can",
+    "> turn, for every model, with API-key and subscription variants tracked separately.",
+    "",
+    "All data is machine-readable: CORS-enabled static JSON validated against a published JSON",
+    "Schema, served from the edge under `/api/v1/`. IDs are `provider/model` for API-key",
+    "variants and `provider/model-subscription` for subscription variants.",
+    "",
+    "## API",
+    `- [Full catalog](${siteUrl}/api/v1/models.json): Every model and its parameters in one JSON file (${plural(models.length, "model")}).`,
+    `- [JSON Schema](${siteUrl}/api/v1/schema.json): Validates every entry; use it for editor autocomplete or CI checks.`,
+    `- [API index](${siteUrl}/api/v1/index.json): Endpoint map and live model count.`,
+    "",
+    "## Guides",
+    `- [Usage guide + full parameter dump](${siteUrl}/llms-full.txt): How to call the API plus every model's parameters inline.`,
+    "",
+    "## Models",
+  ];
+  for (const model of sortById(models)) {
+    lines.push(
+      `- [${modelId(model)}](${modelJsonUrl(siteUrl, model)}): ${modelTitle(model)} — ${plural(model.params.length, "parameter")}.`,
+    );
+  }
+  lines.push(
+    "",
+    "## Optional",
+    `- [GitHub repository](${REPO_URL}): Source data, JSON Schema, and contribution guide.`,
+    `- [Web catalog](${siteUrl}/): Searchable HTML view that also exposes WebMCP tools to in-browser agents.`,
+    "",
+  );
+  return lines.join("\n");
+}
+
+function modelSection(siteUrl: string, model: Model): string[] {
+  const lines = [
+    `### ${modelId(model)}`,
+    "",
+    `${modelTitle(model)} · JSON: ${modelJsonUrl(siteUrl, model)}`,
+    "",
+  ];
+  if (model.params.length === 0) {
+    lines.push("_No parameters documented yet._", "");
+    return lines;
+  }
+  for (const { params } of groupParams(model.params)) {
+    for (const param of params) lines.push(paramLine(param));
+  }
+  lines.push("");
+  return lines;
+}
+
+/**
+ * The complete agent payload: the usage guide followed by every model's parameters
+ * inline, grouped by provider. Served at /llms-full.txt.
+ */
+export function buildLlmsFullTxt(siteUrl: string, models: Model[]): string {
+  const lines: string[] = [
+    usageGuideMarkdown(siteUrl).trimEnd(),
+    "",
+    "---",
+    "",
+    "# Full catalog",
+    "",
+    `${plural(models.length, "model")}, grouped by provider. Each line reads: \`path\` (type,`,
+    "group) — description, then defaults, ranges, allowed values, and applicability conditions",
+    "in brackets.",
+    "",
+  ];
+  for (const facet of buildProviderFacets(models)) {
+    lines.push(`## ${providerLabel(facet.provider)}`, "");
+    const group = sortById(models.filter((model) => model.provider === facet.provider));
+    for (const model of group) lines.push(...modelSection(siteUrl, model));
+  }
+  return lines.join("\n");
+}

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import chokidar from "chokidar";
 import express from "express";
 import { buildCapabilityFacets, buildCatalog, buildProviderFacets } from "../data/catalog.js";
+import { buildLlmsFullTxt, buildLlmsTxt } from "../data/llms.js";
 import { loadAllModels } from "../data/load.js";
 import { CLIENT_DIR, DIST_ASSETS_DIR, MODELS_DIR, VIEWS_DIR } from "../data/paths.js";
 import { buildModelJsonSchema } from "../schema/generate.js";
@@ -10,6 +11,7 @@ import { renderIndex } from "../build/render.js";
 import { modelId, type Model } from "../schema/model.js";
 
 const PORT = Number(process.env.PORT ?? 3000);
+const SITE_URL = process.env.SITE_URL ?? "https://modelparameters.dev";
 
 interface CacheEntry {
   models: Model[];
@@ -33,18 +35,32 @@ async function getCache(): Promise<CacheEntry> {
   return cache ?? (await refresh());
 }
 
+// Ignore dotfiles by basename only. The previous regex (/(^|[\\/])\../) tested the
+// full absolute path, so a dot-segment in an ancestor dir — e.g. a checkout under
+// ~/.paseo/... — matched and silently disabled the entire watch.
+const ignoreDotfiles = (target: string): boolean => path.basename(target).startsWith(".");
+
+// Poll by default so the watch is reliable on container, overlay, and network
+// mounts where native FS events don't propagate; set CHOKIDAR_USEPOLLING=false to
+// use native events on a normal local disk. awaitWriteFinish avoids half-written reads.
+const WATCH_OPTIONS = {
+  ignoreInitial: true,
+  ignored: ignoreDotfiles,
+  usePolling: process.env.CHOKIDAR_USEPOLLING !== "false",
+  interval: 300,
+  binaryInterval: 600,
+  awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
+};
+
 function watch(): void {
-  const watcher = chokidar.watch([MODELS_DIR, VIEWS_DIR], {
-    ignoreInitial: true,
-    ignored: /(^|[\\/])\../,
-  });
+  const watcher = chokidar.watch([MODELS_DIR, VIEWS_DIR], WATCH_OPTIONS);
   watcher.on("all", async (event, file) => {
     console.log(`[dev] ${event} ${path.relative(process.cwd(), file)} — refreshing`);
     cache = null;
     await refresh();
   });
 
-  const clientWatcher = chokidar.watch(CLIENT_DIR, { ignoreInitial: true });
+  const clientWatcher = chokidar.watch(CLIENT_DIR, WATCH_OPTIONS);
   clientWatcher.on("all", async () => {
     console.log("[dev] client changed — rebundling");
     await rebuildClientAssets();
@@ -86,6 +102,24 @@ function makeApp(): express.Express {
 
   app.get("/api/v1/schema.json", (_req, res) => {
     res.json(buildModelJsonSchema());
+  });
+
+  app.get("/llms.txt", async (_req, res, next) => {
+    try {
+      const { models } = await getCache();
+      res.type("text/plain; charset=utf-8").send(buildLlmsTxt(SITE_URL, models));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get("/llms-full.txt", async (_req, res, next) => {
+    try {
+      const { models } = await getCache();
+      res.type("text/plain; charset=utf-8").send(buildLlmsFullTxt(SITE_URL, models));
+    } catch (err) {
+      next(err);
+    }
   });
 
   app.get("/api/v1/models/:provider/:slug.json", async (req, res, next) => {

--- a/src/views/layout.ejs
+++ b/src/views/layout.ejs
@@ -6,6 +6,7 @@
     <title><%= title %></title>
     <meta name="description" content="<%= description %>" />
     <link rel="canonical" href="<%= canonicalUrl %>" />
+    <link rel="alternate" type="text/markdown" href="/llms.txt" title="LLM-friendly site overview" />
 
     <meta property="og:type" content="website" />
     <meta property="og:title" content="<%= title %>" />
@@ -39,7 +40,7 @@
 
     <%- include("partials/footer") %>
 
-    <%- include("partials/how_to_use") %>
+    <%- include("partials/how_to_use", { usageGuide: usageGuide }) %>
 
     <script type="application/ld+json">
       <%- structuredData %>

--- a/src/views/partials/how_to_use.ejs
+++ b/src/views/partials/how_to_use.ejs
@@ -5,19 +5,48 @@
 >
   <div class="sticky top-0 flex items-center justify-between border-b border-slate-200 bg-white/95 px-6 py-4 backdrop-blur dark:border-slate-800 dark:bg-slate-900/95">
     <h2 id="how-to-use-title" class="text-lg font-semibold tracking-tight">How to use</h2>
-    <button
-      type="button"
-      data-close-how-to-use
-      aria-label="Close"
-      class="-mr-2 inline-flex h-9 w-9 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-white"
-    >
-      <svg viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-        <path stroke-linecap="round" d="M18 6 6 18M6 6l12 12" />
-      </svg>
-    </button>
+    <div class="-mr-2 flex items-center gap-1">
+      <button
+        type="button"
+        data-copy-how-to-use
+        aria-label="Copy this guide as Markdown"
+        class="inline-flex items-center gap-1.5 rounded-md border border-slate-200 px-2.5 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white"
+      >
+        <svg data-copy-idle viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <rect x="9" y="9" width="11" height="11" rx="2" />
+          <path d="M5 15V5a2 2 0 0 1 2-2h10" />
+        </svg>
+        <svg data-copy-done viewBox="0 0 24 24" class="hidden h-4 w-4 text-emerald-600 dark:text-emerald-400" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="m20 6-11 11-5-5" />
+        </svg>
+        <span data-copy-label aria-live="polite">Copy</span>
+      </button>
+      <button
+        type="button"
+        data-close-how-to-use
+        aria-label="Close"
+        class="inline-flex h-9 w-9 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-white"
+      >
+        <svg viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" d="M18 6 6 18M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
   </div>
 
   <div class="space-y-6 px-6 py-6 text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+    <div class="flex items-start gap-3 rounded-xl border border-accent/20 bg-accent/5 px-4 py-3 dark:border-accent/30 dark:bg-accent/10">
+      <svg class="mt-0.5 h-5 w-5 shrink-0 text-accent" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2m0 14v2m9-9h-2M5 12H3m13.95-6.95-1.41 1.41M8.46 15.54l-1.41 1.41m11.31 0-1.41-1.41M8.46 8.46 7.05 7.05" />
+        <circle cx="12" cy="12" r="3.5" />
+      </svg>
+      <p class="text-xs text-slate-600 dark:text-slate-300">
+        Building with an AI agent? Hit <span class="font-semibold text-slate-900 dark:text-white">Copy</span>
+        to grab this whole guide as Markdown and paste it in — or point your agent straight at
+        <a href="/llms.txt" class="font-medium text-accent underline decoration-dotted underline-offset-2 hover:text-accent-hover">/llms.txt</a>.
+      </p>
+    </div>
+
     <section class="space-y-3">
       <p>
         <a href="/" class="font-medium text-accent hover:text-accent-hover">modelparameters.dev</a>
@@ -84,4 +113,6 @@ curl <a class="underline decoration-dotted underline-offset-2 hover:text-accent"
     <a class="hover:text-slate-900 dark:hover:text-white" href="https://github.com/mnfst/modelparameters.dev" target="_blank" rel="noopener">Edit on GitHub</a>
     <span>MIT licensed</span>
   </div>
+
+  <script type="text/markdown" id="how-to-use-md"><%- usageGuide %></script>
 </dialog>

--- a/tests/llms.test.ts
+++ b/tests/llms.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { buildLlmsFullTxt, buildLlmsTxt, usageGuideMarkdown } from "../src/data/llms.js";
+import type { Model } from "../src/schema/model.js";
+
+const SITE = "https://modelparameters.dev";
+
+function makeModel(overrides: Partial<Model> = {}): Model {
+  return {
+    provider: "anthropic",
+    authType: "api_key",
+    model: "claude-opus-4-7",
+    params: [
+      {
+        path: "max_tokens",
+        type: "integer",
+        label: "Max tokens",
+        description: "Maximum output tokens.",
+        default: 4096,
+        range: { min: 1 },
+        group: "generation_length",
+      },
+      {
+        path: "thinking.display",
+        type: "enum",
+        label: "Thinking display",
+        description: "Whether thinking is summarized.",
+        default: "omitted",
+        values: ["summarized", "omitted"],
+        group: "reasoning",
+        applicability: { only: { "thinking.type": ["adaptive"] } },
+      },
+    ],
+    ...overrides,
+  } as Model;
+}
+
+describe("usageGuideMarkdown", () => {
+  it("renders the guide as Markdown with the catalog endpoints", () => {
+    const md = usageGuideMarkdown(SITE);
+    expect(md.startsWith("# How to use modelparameters.dev")).toBe(true);
+    expect(md).toContain(`curl ${SITE}/api/v1/models.json`);
+    expect(md).toContain(`curl ${SITE}/api/v1/schema.json`);
+    expect(md).toContain(`${SITE}/llms-full.txt`);
+    expect(md).toContain("WebMCP");
+  });
+
+  it("threads the provided site url through every reference", () => {
+    const md = usageGuideMarkdown("http://localhost:3000");
+    expect(md).toContain("curl http://localhost:3000/api/v1/models.json");
+    expect(md).not.toContain("https://modelparameters.dev");
+  });
+});
+
+describe("buildLlmsTxt", () => {
+  it("follows the llms.txt shape: H1, summary, sections, model links", () => {
+    const txt = buildLlmsTxt(SITE, [makeModel(), makeModel({ authType: "subscription" })]);
+    expect(txt.startsWith("# modelparameters.dev")).toBe(true);
+    expect(txt).toContain("\n> An open, community-maintained catalog");
+    expect(txt).toContain("## API");
+    expect(txt).toContain("## Models");
+    expect(txt).toContain("## Optional");
+    expect(txt).toContain(
+      `- [anthropic/claude-opus-4-7](${SITE}/api/v1/models/anthropic/claude-opus-4-7.json):`,
+    );
+    expect(txt).toContain(
+      `- [anthropic/claude-opus-4-7-subscription](${SITE}/api/v1/models/anthropic/claude-opus-4-7-subscription.json):`,
+    );
+    expect(txt).toContain("2 parameters.");
+  });
+
+  it("singularizes a one-parameter model", () => {
+    const txt = buildLlmsTxt(SITE, [makeModel({ params: [makeModel().params[0]!] })]);
+    expect(txt).toContain("1 parameter.");
+  });
+});
+
+describe("buildLlmsFullTxt", () => {
+  it("embeds the usage guide and dumps each parameter with constraints", () => {
+    const full = buildLlmsFullTxt(SITE, [makeModel()]);
+    expect(full).toContain("# How to use modelparameters.dev");
+    expect(full).toContain("# Full catalog");
+    expect(full).toContain("## Anthropic");
+    expect(full).toContain("### anthropic/claude-opus-4-7");
+    expect(full).toContain(
+      "- `max_tokens` (integer, Length) — Maximum output tokens. [default: 4096] [range: min 1]",
+    );
+    expect(full).toContain(
+      '- `thinking.display` (enum, Reasoning) — Whether thinking is summarized. [default: "omitted"] [values: "summarized", "omitted"] [only when thinking.type = "adaptive"]',
+    );
+  });
+
+  it("notes models that have no parameters yet", () => {
+    const full = buildLlmsFullTxt(SITE, [makeModel({ params: [] })]);
+    expect(full).toContain("_No parameters documented yet._");
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,14 @@
         { "key": "Access-Control-Allow-Origin", "value": "*" },
         { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=3600" }
       ]
+    },
+    {
+      "source": "/(llms.txt|llms-full.txt)",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Content-Type", "value": "text/plain; charset=utf-8" },
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=3600" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### 💭 Why
People are pasting the "How to use" guide into coding agents, and agents that hit the site had to scrape HTML. This gives them first-class ways to read the catalog.

### ✨ What changed
- Copy button on the "How to use" modal copies the guide as Markdown (clipboard API, with an execCommand fallback).
- `/llms.txt` and `/llms-full.txt` generated from the YAML catalog at build time, served in dev too.
- WebMCP tools on `navigator.modelContext`: search_models, get_model_parameters, list_providers, list_parameters, get_usage_guide.
- Structured data adds WebSite + SearchAction + Dataset next to the existing ItemList.
- `/?q=` deep-links the search (backs the SearchAction); robots.txt and sitemap point at the new files; CORS on the `.txt` files.
- Dev watcher fix: the dotfile-ignore regex matched the `.paseo` ancestor dir and silently disabled the whole watch. Scoped it to the basename and poll by default.

### 👤 For users
The "How to use" modal has a Copy button that yields paste-ready Markdown. Agents can read `/llms.txt`, `/llms-full.txt`, or call the in-page WebMCP tools instead of scraping.

### 📝 Notes
Adds tests/llms.test.ts. Build writes both `.txt` files into dist/. Set CHOKIDAR_USEPOLLING=false for native FS events on a normal local disk.