### PR TITLE
chore: add parameter request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/parameter-request.yml
+++ b/.github/ISSUE_TEMPLATE/parameter-request.yml
@@ -1,11 +1,11 @@
 name: Request model parameters
 description: Request a new or updated provider/model parameter entry.
-title: "[Catalog]: "
 body:
   - type: markdown
     attributes:
       value: |
         Use this form to request parameter coverage for a model in modelparameters.dev.
+        Suggested issue title: `<provider>/<model>: parameter coverage`.
 
         This catalog covers configurable request parameters such as `temperature`, `top_p`, `max_tokens`, `reasoning_effort`, and `thinking.type`. It does not track pricing, streaming support, auth setup, endpoints, fallback behavior, or proxy behavior.
 


### PR DESCRIPTION
## Summary
- add a GitHub issue form for model parameter coverage requests
- collect provider, model, auth type, official docs, requested parameter details, and MPS scope confirmation
- leave the GitHub issue title empty so users must enter a concrete title, with a suggested `<provider>/<model>: parameter coverage` format

## Validation
- Ruby YAML parse for `.github/ISSUE_TEMPLATE/parameter-request.yml`
- `git diff --check`