### PR TITLE
test: verify parameter-removal guard (do not merge)

### DIFF
--- a/models/anthropic/claude-opus-4-7.yaml
+++ b/models/anthropic/claude-opus-4-7.yaml
@@ -33,15 +33,3 @@ params:
       only:
         thinking.type:
           - adaptive
-  - path: output_config.effort
-    type: enum
-    label: Effort
-    description: Controls Anthropic response thoroughness and token spend.
-    default: high
-    values:
-      - low
-      - medium
-      - high
-      - xhigh
-      - max
-    group: reasoning


### PR DESCRIPTION
Temporary PR to verify the Param guard blocks parameter removals. Removes `output_config.effort` from claude-opus-4-7. Expected: the `No parameter removals` check fails and merge is blocked. Will be closed.