### PR TITLE
fix: refine Google Gemini parameter applicability

### DIFF
--- a/models/google/gemini-2.5-flash-lite.yaml
+++ b/models/google/gemini-2.5-flash-lite.yaml
@@ -37,22 +37,12 @@ params:
     description: Limits token sampling to the top K most likely next tokens.
     default: 64
     range:
-      min: 1
+      min: 0
     group: sampling
   - path: generationConfig.seed
     type: integer
     label: Seed
     description: Optional seed used for decoding when reproducible sampling is desired.
-    group: sampling
-  - path: generationConfig.presencePenalty
-    type: number
-    label: Presence penalty
-    description: Penalizes tokens that have already appeared in the response to encourage new vocabulary.
-    group: sampling
-  - path: generationConfig.frequencyPenalty
-    type: number
-    label: Frequency penalty
-    description: Penalizes tokens proportionally to how often they have already appeared in the response.
     group: sampling
   - path: generationConfig.thinkingConfig.thinkingBudget
     type: integer

--- a/models/google/gemini-2.5-flash.yaml
+++ b/models/google/gemini-2.5-flash.yaml
@@ -37,22 +37,12 @@ params:
     description: Limits token sampling to the top K most likely next tokens.
     default: 64
     range:
-      min: 1
+      min: 0
     group: sampling
   - path: generationConfig.seed
     type: integer
     label: Seed
     description: Optional seed used for decoding when reproducible sampling is desired.
-    group: sampling
-  - path: generationConfig.presencePenalty
-    type: number
-    label: Presence penalty
-    description: Penalizes tokens that have already appeared in the response to encourage new vocabulary.
-    group: sampling
-  - path: generationConfig.frequencyPenalty
-    type: number
-    label: Frequency penalty
-    description: Penalizes tokens proportionally to how often they have already appeared in the response.
     group: sampling
   - path: generationConfig.thinkingConfig.thinkingBudget
     type: integer

--- a/models/google/gemini-2.5-pro.yaml
+++ b/models/google/gemini-2.5-pro.yaml
@@ -37,22 +37,12 @@ params:
     description: Limits token sampling to the top K most likely next tokens.
     default: 64
     range:
-      min: 1
+      min: 0
     group: sampling
   - path: generationConfig.seed
     type: integer
     label: Seed
     description: Optional seed used for decoding when reproducible sampling is desired.
-    group: sampling
-  - path: generationConfig.presencePenalty
-    type: number
-    label: Presence penalty
-    description: Penalizes tokens that have already appeared in the response to encourage new vocabulary.
-    group: sampling
-  - path: generationConfig.frequencyPenalty
-    type: number
-    label: Frequency penalty
-    description: Penalizes tokens proportionally to how often they have already appeared in the response.
     group: sampling
   - path: generationConfig.thinkingConfig.thinkingBudget
     type: integer

--- a/models/google/gemini-3.5-flash.yaml
+++ b/models/google/gemini-3.5-flash.yaml
@@ -37,22 +37,12 @@ params:
     description: Limits token sampling to the top K most likely next tokens.
     default: 64
     range:
-      min: 1
+      min: 0
     group: sampling
   - path: generationConfig.seed
     type: integer
     label: Seed
     description: Optional seed used for decoding when reproducible sampling is desired.
-    group: sampling
-  - path: generationConfig.presencePenalty
-    type: number
-    label: Presence penalty
-    description: Penalizes tokens that have already appeared in the response to encourage new vocabulary.
-    group: sampling
-  - path: generationConfig.frequencyPenalty
-    type: number
-    label: Frequency penalty
-    description: Penalizes tokens proportionally to how often they have already appeared in the response.
     group: sampling
   - path: generationConfig.thinkingConfig.thinkingLevel
     type: enum


### PR DESCRIPTION
## Summary
- remove Google Gemini presence/frequency penalty params because live `generateContent` rejects them for all four cataloged Gemini models
- relax `generationConfig.topK` lower bound from `1` to `0`, matching live validation (`topK: 0` accepted, `topK: -1` rejected as nonnegative)

## Verification
- Official docs checked today:
  - https://ai.google.dev/api/generate-content
  - https://ai.google.dev/gemini-api/docs/thinking
- Live Google API matrix with key from `.env.keys`:
  - `getModel` confirmed `gemini-3.5-flash` exists today as `3.5-flash-05-2026`
  - sampling params without penalties are accepted with thinking enabled on `gemini-3.5-flash`, `gemini-2.5-pro`, `gemini-2.5-flash`, and `gemini-2.5-flash-lite`
  - `presencePenalty: 0.1` and `frequencyPenalty: 0.1` are rejected on all four with `Penalty is not enabled`
  - all listed post-patch params were sent together per YAML row and returned HTTP 200 for all four models
- `npm run validate`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run guard:params`
- `npx prettier --check .`
- `git diff --check`