### PR TITLE
chore: point package.json at renamed repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mnfst/modelparameters.dev.git"
+    "url": "git+https://github.com/mnfst/modelparams.dev.git"
   },
   "homepage": "https://modelparams.dev",
   "bugs": {
-    "url": "https://github.com/mnfst/modelparameters.dev/issues"
+    "url": "https://github.com/mnfst/modelparams.dev/issues"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
### 💭 Why
The repo was renamed to `mnfst/modelparams.dev`, but `package.json` still pointed `repository.url` and `bugs.url` at the old `modelparameters.dev` path.

### ✨ What changed
- `repository.url` → `git+https://github.com/mnfst/modelparams.dev.git`
- `bugs.url` → `https://github.com/mnfst/modelparams.dev/issues`