### PR TITLE
feat: add Vercel Web Analytics

### DIFF
--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -102,7 +102,7 @@ export async function build(): Promise<{ models: number }> {
   const providers = buildProviderFacets(models);
 
   console.log(`Rendering HTML for ${models.length} model(s)...`);
-  const html = await renderIndex({ catalog, capabilities, providers });
+  const html = await renderIndex({ catalog, capabilities, providers, analytics: true });
   await fs.writeFile(path.join(DIST_DIR, "index.html"), html, "utf8");
 
   console.log("Writing JSON API...");

--- a/src/build/render.ts
+++ b/src/build/render.ts
@@ -28,6 +28,8 @@ export interface RenderOptions {
   capabilities: CapabilityFacet[];
   providers: ProviderFacet[];
   initialThemeClass?: string;
+  /** Inject the Vercel Web Analytics snippet. Enabled for production builds; off in dev. */
+  analytics?: boolean;
 }
 
 function buildStructuredData(models: Model[]): string {
@@ -111,6 +113,7 @@ export async function renderIndex(opts: RenderOptions): Promise<string> {
     initialThemeClass: opts.initialThemeClass ?? "",
     structuredData: buildStructuredData(opts.catalog.models),
     usageGuide: usageGuideMarkdown(SITE_URL),
+    analytics: opts.analytics ?? false,
     body,
   });
 

--- a/src/views/layout.ejs
+++ b/src/views/layout.ejs
@@ -46,5 +46,16 @@
       <%- structuredData %>
     </script>
     <script type="module" src="/assets/main.js"></script>
+    <% if (analytics) { %>
+    <!-- Vercel Web Analytics -->
+    <script>
+      window.va =
+        window.va ||
+        function () {
+          (window.vaq = window.vaq || []).push(arguments);
+        };
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+    <% } %>
   </body>
 </html>


### PR DESCRIPTION
### 💭 Why
We have no traffic data for the site. This wires up Vercel Web Analytics so we can see page views and visitors.

### ✨ What changed
- Inject the Vercel analytics snippet into the page layout.
- Gated to the production build; the dev server skips it.

### 🔧 For operators
Enable Web Analytics in the Vercel project (Analytics tab) for data to start flowing. The snippet loads `/_vercel/insights/script.js`, which Vercel only serves once that toggle is on.

### 📝 Notes
No new dependency. The static-site script tag matches what `@vercel/analytics` emits, and sidesteps an optional Svelte peer-dep that breaks `npm ci`.