### PR TITLE
feat: add MiniMax models to the catalog

### DIFF
--- a/models/minimax/minimax-m2.1-highspeed.yaml
+++ b/models/minimax/minimax-m2.1-highspeed.yaml
@@ -18,9 +18,9 @@ params:
       varied. Values must be greater than 0 and at most 1.
     default: 1
     range:
-      min: 0
+      min: 0.01
       max: 1
-      step: 0.1
+      step: 0.01
     group: sampling
   - path: top_p
     type: number
@@ -28,7 +28,7 @@ params:
     description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
     default: 0.95
     range:
-      min: 0
+      min: 0.01
       max: 1
       step: 0.01
     group: sampling

--- a/models/minimax/minimax-m2.1-highspeed.yaml
+++ b/models/minimax/minimax-m2.1-highspeed.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: api_key
+model: minimax-m2.1-highspeed
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max completion tokens
+    description: Maximum number of tokens to generate in the completion.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: reasoning_split
+    type: boolean
+    label: Split reasoning
+    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    default: false
+    group: reasoning

--- a/models/minimax/minimax-m2.1.yaml
+++ b/models/minimax/minimax-m2.1.yaml
@@ -18,9 +18,9 @@ params:
       varied. Values must be greater than 0 and at most 1.
     default: 1
     range:
-      min: 0
+      min: 0.01
       max: 1
-      step: 0.1
+      step: 0.01
     group: sampling
   - path: top_p
     type: number
@@ -28,7 +28,7 @@ params:
     description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
     default: 0.95
     range:
-      min: 0
+      min: 0.01
       max: 1
       step: 0.01
     group: sampling

--- a/models/minimax/minimax-m2.1.yaml
+++ b/models/minimax/minimax-m2.1.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: api_key
+model: minimax-m2.1
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max completion tokens
+    description: Maximum number of tokens to generate in the completion.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: reasoning_split
+    type: boolean
+    label: Split reasoning
+    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    default: false
+    group: reasoning

--- a/models/minimax/minimax-m2.5-highspeed.yaml
+++ b/models/minimax/minimax-m2.5-highspeed.yaml
@@ -18,9 +18,9 @@ params:
       varied. Values must be greater than 0 and at most 1.
     default: 1
     range:
-      min: 0
+      min: 0.01
       max: 1
-      step: 0.1
+      step: 0.01
     group: sampling
   - path: top_p
     type: number
@@ -28,7 +28,7 @@ params:
     description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
     default: 0.95
     range:
-      min: 0
+      min: 0.01
       max: 1
       step: 0.01
     group: sampling

--- a/models/minimax/minimax-m2.5-highspeed.yaml
+++ b/models/minimax/minimax-m2.5-highspeed.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: api_key
+model: minimax-m2.5-highspeed
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max completion tokens
+    description: Maximum number of tokens to generate in the completion.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: reasoning_split
+    type: boolean
+    label: Split reasoning
+    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    default: false
+    group: reasoning

--- a/models/minimax/minimax-m2.5.yaml
+++ b/models/minimax/minimax-m2.5.yaml
@@ -18,9 +18,9 @@ params:
       varied. Values must be greater than 0 and at most 1.
     default: 1
     range:
-      min: 0
+      min: 0.01
       max: 1
-      step: 0.1
+      step: 0.01
     group: sampling
   - path: top_p
     type: number
@@ -28,7 +28,7 @@ params:
     description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
     default: 0.95
     range:
-      min: 0
+      min: 0.01
       max: 1
       step: 0.01
     group: sampling

--- a/models/minimax/minimax-m2.5.yaml
+++ b/models/minimax/minimax-m2.5.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: api_key
+model: minimax-m2.5
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max completion tokens
+    description: Maximum number of tokens to generate in the completion.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: reasoning_split
+    type: boolean
+    label: Split reasoning
+    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    default: false
+    group: reasoning

--- a/models/minimax/minimax-m2.7-highspeed-subscription.yaml
+++ b/models/minimax/minimax-m2.7-highspeed-subscription.yaml
@@ -18,9 +18,9 @@ params:
       varied. Values must be greater than 0 and at most 1.
     default: 1
     range:
-      min: 0
+      min: 0.01
       max: 1
-      step: 0.1
+      step: 0.01
     group: sampling
   - path: top_p
     type: number
@@ -28,7 +28,7 @@ params:
     description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
     default: 0.95
     range:
-      min: 0
+      min: 0.01
       max: 1
       step: 0.01
     group: sampling

--- a/models/minimax/minimax-m2.7-highspeed-subscription.yaml
+++ b/models/minimax/minimax-m2.7-highspeed-subscription.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: subscription
+model: minimax-m2.7-highspeed
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling

--- a/models/minimax/minimax-m2.7-highspeed.yaml
+++ b/models/minimax/minimax-m2.7-highspeed.yaml
@@ -18,9 +18,9 @@ params:
       varied. Values must be greater than 0 and at most 1.
     default: 1
     range:
-      min: 0
+      min: 0.01
       max: 1
-      step: 0.1
+      step: 0.01
     group: sampling
   - path: top_p
     type: number
@@ -28,7 +28,7 @@ params:
     description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
     default: 0.95
     range:
-      min: 0
+      min: 0.01
       max: 1
       step: 0.01
     group: sampling

--- a/models/minimax/minimax-m2.7-highspeed.yaml
+++ b/models/minimax/minimax-m2.7-highspeed.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: api_key
+model: minimax-m2.7-highspeed
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max completion tokens
+    description: Maximum number of tokens to generate in the completion.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: reasoning_split
+    type: boolean
+    label: Split reasoning
+    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    default: false
+    group: reasoning

--- a/models/minimax/minimax-m2.7-subscription.yaml
+++ b/models/minimax/minimax-m2.7-subscription.yaml
@@ -18,9 +18,9 @@ params:
       varied. Values must be greater than 0 and at most 1.
     default: 1
     range:
-      min: 0
+      min: 0.01
       max: 1
-      step: 0.1
+      step: 0.01
     group: sampling
   - path: top_p
     type: number
@@ -28,7 +28,7 @@ params:
     description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
     default: 0.95
     range:
-      min: 0
+      min: 0.01
       max: 1
       step: 0.01
     group: sampling

--- a/models/minimax/minimax-m2.7-subscription.yaml
+++ b/models/minimax/minimax-m2.7-subscription.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: subscription
+model: minimax-m2.7
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling

--- a/models/minimax/minimax-m2.7.yaml
+++ b/models/minimax/minimax-m2.7.yaml
@@ -18,9 +18,9 @@ params:
       varied. Values must be greater than 0 and at most 1.
     default: 1
     range:
-      min: 0
+      min: 0.01
       max: 1
-      step: 0.1
+      step: 0.01
     group: sampling
   - path: top_p
     type: number
@@ -28,7 +28,7 @@ params:
     description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
     default: 0.95
     range:
-      min: 0
+      min: 0.01
       max: 1
       step: 0.01
     group: sampling

--- a/models/minimax/minimax-m2.7.yaml
+++ b/models/minimax/minimax-m2.7.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: api_key
+model: minimax-m2.7
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max completion tokens
+    description: Maximum number of tokens to generate in the completion.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: reasoning_split
+    type: boolean
+    label: Split reasoning
+    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    default: false
+    group: reasoning

--- a/models/minimax/minimax-m2.yaml
+++ b/models/minimax/minimax-m2.yaml
@@ -18,9 +18,9 @@ params:
       varied. Values must be greater than 0 and at most 1.
     default: 1
     range:
-      min: 0
+      min: 0.01
       max: 1
-      step: 0.1
+      step: 0.01
     group: sampling
   - path: top_p
     type: number
@@ -28,7 +28,7 @@ params:
     description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
     default: 0.95
     range:
-      min: 0
+      min: 0.01
       max: 1
       step: 0.01
     group: sampling

--- a/models/minimax/minimax-m2.yaml
+++ b/models/minimax/minimax-m2.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: api_key
+model: minimax-m2
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max completion tokens
+    description: Maximum number of tokens to generate in the completion.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: reasoning_split
+    type: boolean
+    label: Split reasoning
+    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    default: false
+    group: reasoning

--- a/src/client/logos/minimax.svg
+++ b/src/client/logos/minimax.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 9.75V14.25M7.5 4.5V19.5M12 7.75V16.25M16.5 2.75V21.25M21 10.25V13.75" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/data/display.ts
+++ b/src/data/display.ts
@@ -8,6 +8,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   meta: "Meta",
   mistral: "Mistral",
   deepseek: "DeepSeek",
+  minimax: "MiniMax",
   cohere: "Cohere",
   perplexity: "Perplexity",
 };
@@ -20,6 +21,13 @@ const MODEL_LABEL_OVERRIDES: Record<string, string> = {
   "openai/o3": "o3",
   "openai/o3-mini": "o3-mini",
   "openai/o4-mini": "o4-mini",
+  "minimax/minimax-m2": "MiniMax M2",
+  "minimax/minimax-m2.1": "MiniMax M2.1",
+  "minimax/minimax-m2.1-highspeed": "MiniMax M2.1 Highspeed",
+  "minimax/minimax-m2.5": "MiniMax M2.5",
+  "minimax/minimax-m2.5-highspeed": "MiniMax M2.5 Highspeed",
+  "minimax/minimax-m2.7": "MiniMax M2.7",
+  "minimax/minimax-m2.7-highspeed": "MiniMax M2.7 Highspeed",
 };
 
 const AUTH_LABELS: Record<AuthType, string> = {


### PR DESCRIPTION
### 💭 Why
The MiniMax M2 line wasn't in the catalog, so anyone configuring those models had no reference for their parameters.

### ✨ What changed
- Add 9 MiniMax models: M2, M2.1, M2.5, M2.7, plus highspeed and subscription variants.
- Add the MiniMax provider label and model display-name overrides.
- Add the MiniMax logo.

### 👤 For users
MiniMax now shows up as a provider with 9 browsable, filterable models.