### PR TITLE
fix(minimax): align params with official API docs

### DIFF
--- a/models/minimax/minimax-m2.1-highspeed.yaml
+++ b/models/minimax/minimax-m2.1-highspeed.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2.1-highspeed
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,9 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
+  - path: thinking
     type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    label: Thinking
+    description: Enables the model's reasoning process to be returned in the response.
     default: false
     group: reasoning

--- a/models/minimax/minimax-m2.1.yaml
+++ b/models/minimax/minimax-m2.1.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2.1
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,9 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
+  - path: thinking
     type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    label: Thinking
+    description: Enables the model's reasoning process to be returned in the response.
     default: false
     group: reasoning

--- a/models/minimax/minimax-m2.5-highspeed.yaml
+++ b/models/minimax/minimax-m2.5-highspeed.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2.5-highspeed
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,9 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
+  - path: thinking
     type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    label: Thinking
+    description: Enables the model's reasoning process to be returned in the response.
     default: false
     group: reasoning

--- a/models/minimax/minimax-m2.5.yaml
+++ b/models/minimax/minimax-m2.5.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2.5
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,9 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
+  - path: thinking
     type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    label: Thinking
+    description: Enables the model's reasoning process to be returned in the response.
     default: false
     group: reasoning

--- a/models/minimax/minimax-m2.7-highspeed-subscription.yaml
+++ b/models/minimax/minimax-m2.7-highspeed-subscription.yaml
@@ -32,3 +32,9 @@ params:
       max: 1
       step: 0.01
     group: sampling
+  - path: thinking
+    type: boolean
+    label: Thinking
+    description: Enables the model's reasoning process to be returned in the response.
+    default: false
+    group: reasoning

--- a/models/minimax/minimax-m2.7-highspeed.yaml
+++ b/models/minimax/minimax-m2.7-highspeed.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2.7-highspeed
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,9 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
+  - path: thinking
     type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    label: Thinking
+    description: Enables the model's reasoning process to be returned in the response.
     default: false
     group: reasoning

--- a/models/minimax/minimax-m2.7-subscription.yaml
+++ b/models/minimax/minimax-m2.7-subscription.yaml
@@ -32,3 +32,9 @@ params:
       max: 1
       step: 0.01
     group: sampling
+  - path: thinking
+    type: boolean
+    label: Thinking
+    description: Enables the model's reasoning process to be returned in the response.
+    default: false
+    group: reasoning

--- a/models/minimax/minimax-m2.7.yaml
+++ b/models/minimax/minimax-m2.7.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2.7
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,9 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
+  - path: thinking
     type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    label: Thinking
+    description: Enables the model's reasoning process to be returned in the response.
     default: false
     group: reasoning

--- a/models/minimax/minimax-m2.yaml
+++ b/models/minimax/minimax-m2.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,9 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
+  - path: thinking
     type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
+    label: Thinking
+    description: Enables the model's reasoning process to be returned in the response.
     default: false
     group: reasoning


### PR DESCRIPTION
## Summary
- Change `max_completion_tokens` to `max_tokens` (official API uses `max_tokens`)
- Replace `reasoning_split` with `thinking` parameter (API supports `thinking` for reasoning content)
- Update all MiniMax models (m2, m2.1, m2.5, m2.7) with both `api_key` and `subscription` auth types

## Changes
- 9 YAML files modified across all MiniMax model variants
- Parameters now match the official MiniMax Anthropic-compatible API docs

## Testing
- `npm run validate` passes ✓