### PR TITLE
fix(minimax): align api_key params with official API

### DIFF
--- a/models/minimax/minimax-m2.1-highspeed.yaml
+++ b/models/minimax/minimax-m2.1-highspeed.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2.1-highspeed
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,12 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
-    type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
-    default: false
+  - path: thinking
+    type: enum
+    label: Thinking mode
+    description: Controls the thinking/reasoning mode. When enabled, the model shows its reasoning before the final answer.
+    default: disabled
+    values:
+      - disabled
+      - enabled
     group: reasoning

--- a/models/minimax/minimax-m2.1.yaml
+++ b/models/minimax/minimax-m2.1.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2.1
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,12 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
-    type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
-    default: false
+  - path: thinking
+    type: enum
+    label: Thinking mode
+    description: Controls the thinking/reasoning mode. When enabled, the model shows its reasoning before the final answer.
+    default: disabled
+    values:
+      - disabled
+      - enabled
     group: reasoning

--- a/models/minimax/minimax-m2.5-highspeed.yaml
+++ b/models/minimax/minimax-m2.5-highspeed.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2.5-highspeed
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,12 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
-    type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
-    default: false
+  - path: thinking
+    type: enum
+    label: Thinking mode
+    description: Controls the thinking/reasoning mode. When enabled, the model shows its reasoning before the final answer.
+    default: disabled
+    values:
+      - disabled
+      - enabled
     group: reasoning

--- a/models/minimax/minimax-m2.5.yaml
+++ b/models/minimax/minimax-m2.5.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2.5
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,12 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
-    type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
-    default: false
+  - path: thinking
+    type: enum
+    label: Thinking mode
+    description: Controls the thinking/reasoning mode. When enabled, the model shows its reasoning before the final answer.
+    default: disabled
+    values:
+      - disabled
+      - enabled
     group: reasoning

--- a/models/minimax/minimax-m2.7-highspeed.yaml
+++ b/models/minimax/minimax-m2.7-highspeed.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2.7-highspeed
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,12 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
-    type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
-    default: false
+  - path: thinking
+    type: enum
+    label: Thinking mode
+    description: Controls the thinking/reasoning mode. When enabled, the model shows its reasoning before the final answer.
+    default: disabled
+    values:
+      - disabled
+      - enabled
     group: reasoning

--- a/models/minimax/minimax-m2.7.yaml
+++ b/models/minimax/minimax-m2.7.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2.7
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,12 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
-    type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
-    default: false
+  - path: thinking
+    type: enum
+    label: Thinking mode
+    description: Controls the thinking/reasoning mode. When enabled, the model shows its reasoning before the final answer.
+    default: disabled
+    values:
+      - disabled
+      - enabled
     group: reasoning

--- a/models/minimax/minimax-m2.yaml
+++ b/models/minimax/minimax-m2.yaml
@@ -3,10 +3,10 @@ provider: minimax
 authType: api_key
 model: minimax-m2
 params:
-  - path: max_completion_tokens
+  - path: max_tokens
     type: integer
-    label: Max completion tokens
-    description: Maximum number of tokens to generate in the completion.
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
     range:
       min: 1
     group: generation_length
@@ -32,9 +32,12 @@ params:
       max: 1
       step: 0.01
     group: sampling
-  - path: reasoning_split
-    type: boolean
-    label: Split reasoning
-    description: Returns the model's reasoning in a separate reasoning_details field instead of inline with the response.
-    default: false
+  - path: thinking
+    type: enum
+    label: Thinking mode
+    description: Controls the thinking/reasoning mode. When enabled, the model shows its reasoning before the final answer.
+    default: disabled
+    values:
+      - disabled
+      - enabled
     group: reasoning


### PR DESCRIPTION
## Summary
- Replace `max_completion_tokens` with `max_tokens` (official MiniMax API uses `max_tokens`)
- Replace `reasoning_split` (boolean) with `thinking` enum (`disabled`/`enabled`) to match API behavior
- Applies to all MiniMax `api_key` models: m2, m2.1, m2.5, m2.7 (+ highspeed variants)
- `subscription` models already correct (max_tokens, temperature, top_p)

## Changes
- 7 YAML files modified across all MiniMax api_key variants
- Parameters now match the official MiniMax Anthropic-compatible API docs

## Testing
- `npm run validate` passes ✓ (113 models validated)