### PR TITLE
fix: add MiniMax and Z.ai subscription params

### DIFF
--- a/docs/model-parameters-schema.md
+++ b/docs/model-parameters-schema.md
@@ -46,8 +46,8 @@ Conventions:
 
 - `provider`, `authType`, and `model` identify exactly one model route.
 - `provider` is a kebab-case slug.
-- `model` is the provider-native model id without path separators. It may
-  contain dots or colons when the upstream model id does.
+- `model` is the provider-native model id without path separators. Preserve
+  upstream casing; it may contain dots or colons when the upstream model id does.
 - `authType` is `api_key` or `subscription`.
 - `params` is the non-empty list of parameters for that exact route.
 - `path` is the exact provider API request parameter path in dot notation. Use

--- a/models/minimax/MiniMax-M2-subscription.yaml
+++ b/models/minimax/MiniMax-M2-subscription.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: subscription
-model: minimax-m2.7
+model: MiniMax-M2
 params:
   - path: max_tokens
     type: integer

--- a/models/minimax/MiniMax-M2.1-highspeed-subscription.yaml
+++ b/models/minimax/MiniMax-M2.1-highspeed-subscription.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: subscription
+model: MiniMax-M2.1-highspeed
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling

--- a/models/minimax/MiniMax-M2.1-subscription.yaml
+++ b/models/minimax/MiniMax-M2.1-subscription.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: subscription
+model: MiniMax-M2.1
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling

--- a/models/minimax/MiniMax-M2.5-highspeed-subscription.yaml
+++ b/models/minimax/MiniMax-M2.5-highspeed-subscription.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: subscription
+model: MiniMax-M2.5-highspeed
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling

--- a/models/minimax/MiniMax-M2.5-subscription.yaml
+++ b/models/minimax/MiniMax-M2.5-subscription.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: subscription
+model: MiniMax-M2.5
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling

--- a/models/minimax/MiniMax-M2.7-highspeed-subscription.yaml
+++ b/models/minimax/MiniMax-M2.7-highspeed-subscription.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: subscription
+model: MiniMax-M2.7-highspeed
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling

--- a/models/minimax/MiniMax-M2.7-subscription.yaml
+++ b/models/minimax/MiniMax-M2.7-subscription.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: subscription
+model: MiniMax-M2.7
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling

--- a/models/z-ai/glm-4.5-subscription.yaml
+++ b/models/z-ai/glm-4.5-subscription.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: z-ai
+authType: subscription
+model: glm-4.5
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Toggles the model's extended reasoning before it produces the final answer.
+    default: enabled
+    values:
+      - enabled
+      - disabled
+    group: reasoning

--- a/models/z-ai/glm-4.6-subscription.yaml
+++ b/models/z-ai/glm-4.6-subscription.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: z-ai
+authType: subscription
+model: glm-4.6
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Toggles the model's extended reasoning before it produces the final answer.
+    default: enabled
+    values:
+      - enabled
+      - disabled
+    group: reasoning

--- a/models/z-ai/glm-5-subscription.yaml
+++ b/models/z-ai/glm-5-subscription.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
-provider: minimax
+provider: z-ai
 authType: subscription
-model: minimax-m2.7-highspeed
+model: glm-5
 params:
   - path: max_tokens
     type: integer
@@ -13,14 +13,12 @@ params:
   - path: temperature
     type: number
     label: Temperature
-    description: >-
-      Controls randomness. Lower values make outputs more focused; higher values make them more
-      varied. Values must be greater than 0 and at most 1.
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
     default: 1
     range:
-      min: 0.01
+      min: 0
       max: 1
-      step: 0.01
+      step: 0.1
     group: sampling
   - path: top_p
     type: number
@@ -32,3 +30,12 @@ params:
       max: 1
       step: 0.01
     group: sampling
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Toggles the model's extended reasoning before it produces the final answer.
+    default: enabled
+    values:
+      - enabled
+      - disabled
+    group: reasoning

--- a/src/schema/model.ts
+++ b/src/schema/model.ts
@@ -18,7 +18,7 @@ export const ParameterGroup = z.enum([
 export type ParameterGroup = z.infer<typeof ParameterGroup>;
 
 const PROVIDER_SLUG = /^[a-z0-9][a-z0-9-]*$/;
-const MODEL_ID = /^[a-z0-9][a-z0-9._:-]*$/;
+const MODEL_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 const PARAM_PATH = /^[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)*$/;
 const BLOCKED_PARAM_PATHS = new Set(["stream"]);
 

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -43,6 +43,11 @@ describe("Model schema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts provider-native model ids with uppercase characters", () => {
+    const result = Model.safeParse({ ...VALID_MODEL, provider: "minimax", model: "MiniMax-M2.7" });
+    expect(result.success).toBe(true);
+  });
+
   it("rejects path separators in model ids", () => {
     const result = Model.safeParse({
       ...VALID_MODEL,


### PR DESCRIPTION
Summary
- Preserve provider-native uppercase MiniMax model IDs and allow uppercase characters in model IDs.
- Correct existing MiniMax M2.7 subscription row casing and add missing MiniMax subscription rows for M2, M2.1, M2.1-highspeed, M2.5, and M2.5-highspeed.
- Add missing Z.ai subscription rows for glm-4.5, glm-4.6, and glm-5.
- Update schema docs and tests for provider-native casing.

Notes
- MiniMax official docs publish these language model IDs with `MiniMax-*` casing.
- Git may display two MiniMax YAML changes as high-similarity renames because the parameter rows are intentionally near-identical except for model IDs; the final tree contains the intended uppercase MiniMax files and no lowercase duplicates.

Validation
- `npm run validate`
- `npm test`
- `npm run build`
- `npm run guard:params`
- `npm run typecheck`
- `npm run lint`
- `npx prettier --check` on touched files
- `git diff --check`