### PR TITLE
fix: add MiniMax and Z.ai subscription params

### DIFF
--- a/docs/model-parameters-schema.md
+++ b/docs/model-parameters-schema.md
@@ -46,8 +46,8 @@ Conventions:
 
 - `provider`, `authType`, and `model` identify exactly one model route.
 - `provider` is a kebab-case slug.
-- `model` is the provider-native model id without path separators. It may
-  contain dots or colons when the upstream model id does.
+- `model` is the provider-native model id without path separators. Preserve
+  upstream casing; it may contain dots or colons when the upstream model id does.
 - `authType` is `api_key` or `subscription`.
 - `params` is the non-empty list of parameters for that exact route.
 - `path` is the exact provider API request parameter path in dot notation. Use

--- a/models/minimax/MiniMax-M2-subscription.yaml
+++ b/models/minimax/MiniMax-M2-subscription.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: subscription
-model: minimax-m2.7-highspeed
+model: MiniMax-M2
 params:
   - path: max_tokens
     type: integer

--- a/models/minimax/MiniMax-M2.1-highspeed-subscription.yaml
+++ b/models/minimax/MiniMax-M2.1-highspeed-subscription.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: subscription
+model: MiniMax-M2.1-highspeed
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling

--- a/models/minimax/MiniMax-M2.1-subscription.yaml
+++ b/models/minimax/MiniMax-M2.1-subscription.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: subscription
+model: MiniMax-M2.1
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling

--- a/models/minimax/MiniMax-M2.5-highspeed-subscription.yaml
+++ b/models/minimax/MiniMax-M2.5-highspeed-subscription.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: subscription
+model: MiniMax-M2.5-highspeed
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling

--- a/models/minimax/MiniMax-M2.5-subscription.yaml
+++ b/models/minimax/MiniMax-M2.5-subscription.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: subscription
+model: MiniMax-M2.5
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling

--- a/models/minimax/MiniMax-M2.7-highspeed-subscription.yaml
+++ b/models/minimax/MiniMax-M2.7-highspeed-subscription.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: minimax
+authType: subscription
+model: MiniMax-M2.7-highspeed
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied. Values must be greater than 0 and at most 1.
+    default: 1
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling

--- a/models/minimax/MiniMax-M2.7-subscription.yaml
+++ b/models/minimax/MiniMax-M2.7-subscription.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: subscription
-model: minimax-m2.7
+model: MiniMax-M2.7
 params:
   - path: max_tokens
     type: integer

--- a/models/z-ai/glm-4.5-subscription.yaml
+++ b/models/z-ai/glm-4.5-subscription.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: subscription
-model: glm-4.5-air
+model: glm-4.5
 params:
   - path: max_tokens
     type: integer

--- a/models/z-ai/glm-4.6-subscription.yaml
+++ b/models/z-ai/glm-4.6-subscription.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: subscription
-model: glm-4.5-air
+model: glm-4.6
 params:
   - path: max_tokens
     type: integer
@@ -14,7 +14,7 @@ params:
     type: number
     label: Temperature
     description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
-    default: 0.6
+    default: 1
     range:
       min: 0
       max: 1

--- a/models/z-ai/glm-4.7-subscription.yaml
+++ b/models/z-ai/glm-4.7-subscription.yaml
@@ -20,6 +20,9 @@ params:
       max: 1
       step: 0.1
     group: sampling
+    applicability:
+      except:
+        do_sample: false
   - path: top_p
     type: number
     label: Top P
@@ -30,6 +33,15 @@ params:
       max: 1
       step: 0.01
     group: sampling
+    applicability:
+      except:
+        do_sample: false
+  - path: do_sample
+    type: boolean
+    label: Do sample
+    description: When false, the model uses greedy decoding and ignores temperature and top_p.
+    default: true
+    group: sampling
   - path: thinking.type
     type: enum
     label: Thinking mode
@@ -39,3 +51,12 @@ params:
       - enabled
       - disabled
     group: reasoning
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/models/z-ai/glm-5-subscription.yaml
+++ b/models/z-ai/glm-5-subscription.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: subscription
-model: glm-4.5-air
+model: glm-5
 params:
   - path: max_tokens
     type: integer
@@ -14,7 +14,7 @@ params:
     type: number
     label: Temperature
     description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
-    default: 0.6
+    default: 1
     range:
       min: 0
       max: 1

--- a/models/z-ai/glm-5-turbo-subscription.yaml
+++ b/models/z-ai/glm-5-turbo-subscription.yaml
@@ -20,6 +20,9 @@ params:
       max: 1
       step: 0.1
     group: sampling
+    applicability:
+      except:
+        do_sample: false
   - path: top_p
     type: number
     label: Top P
@@ -30,6 +33,15 @@ params:
       max: 1
       step: 0.01
     group: sampling
+    applicability:
+      except:
+        do_sample: false
+  - path: do_sample
+    type: boolean
+    label: Do sample
+    description: When false, the model uses greedy decoding and ignores temperature and top_p.
+    default: true
+    group: sampling
   - path: thinking.type
     type: enum
     label: Thinking mode
@@ -39,3 +51,12 @@ params:
       - enabled
       - disabled
     group: reasoning
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/models/z-ai/glm-5.1-subscription.yaml
+++ b/models/z-ai/glm-5.1-subscription.yaml
@@ -20,6 +20,9 @@ params:
       max: 1
       step: 0.1
     group: sampling
+    applicability:
+      except:
+        do_sample: false
   - path: top_p
     type: number
     label: Top P
@@ -30,6 +33,15 @@ params:
       max: 1
       step: 0.01
     group: sampling
+    applicability:
+      except:
+        do_sample: false
+  - path: do_sample
+    type: boolean
+    label: Do sample
+    description: When false, the model uses greedy decoding and ignores temperature and top_p.
+    default: true
+    group: sampling
   - path: thinking.type
     type: enum
     label: Thinking mode
@@ -39,3 +51,12 @@ params:
       - enabled
       - disabled
     group: reasoning
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/src/schema/model.ts
+++ b/src/schema/model.ts
@@ -18,7 +18,7 @@ export const ParameterGroup = z.enum([
 export type ParameterGroup = z.infer<typeof ParameterGroup>;
 
 const PROVIDER_SLUG = /^[a-z0-9][a-z0-9-]*$/;
-const MODEL_ID = /^[a-z0-9][a-z0-9._:-]*$/;
+const MODEL_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 const PARAM_PATH = /^[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)*$/;
 const BLOCKED_PARAM_PATHS = new Set(["stream"]);
 

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import { buildCapabilityFacets, buildCatalog, uniqueProviders } from "../src/data/catalog.js";
 import { describeApplicability } from "../src/data/applicability.js";
 import { modelLabel, providerLabel } from "../src/data/display.js";
+import { loadAllModels } from "../src/data/load.js";
+import { modelId } from "../src/schema/model.js";
 import type { Model } from "../src/schema/model.js";
 
 function makeModel(overrides: Partial<Model> = {}): Model {
@@ -111,5 +113,32 @@ describe("describeApplicability", () => {
   it("formats `not` expressions with ≠", () => {
     const out = describeApplicability({ except: [{ temperature: { not: 1 } }] });
     expect(out.except[0]).toBe("temperature ≠ 1");
+  });
+});
+
+describe("provider catalog rows", () => {
+  it("keeps Z.ai Coding Plan params aligned with the API-key rows", async () => {
+    const { models, issues } = await loadAllModels();
+    expect(issues).toEqual([]);
+
+    const byId = new Map(models.map((model) => [modelId(model), model]));
+    const sharedModels = [
+      "glm-5.1",
+      "glm-5-turbo",
+      "glm-5",
+      "glm-4.7",
+      "glm-4.6",
+      "glm-4.5",
+      "glm-4.5-air",
+    ];
+
+    for (const model of sharedModels) {
+      const apiKey = byId.get(`z-ai/${model}`);
+      const subscription = byId.get(`z-ai/${model}-subscription`);
+
+      expect(subscription?.params.map((param) => param.path)).toEqual(
+        apiKey?.params.map((param) => param.path),
+      );
+    }
   });
 });

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -43,6 +43,11 @@ describe("Model schema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts provider-native model ids with uppercase characters", () => {
+    const result = Model.safeParse({ ...VALID_MODEL, provider: "minimax", model: "MiniMax-M2.7" });
+    expect(result.success).toBe(true);
+  });
+
   it("rejects path separators in model ids", () => {
     const result = Model.safeParse({
       ...VALID_MODEL,


### PR DESCRIPTION
Summary
- Preserve provider-native uppercase MiniMax model IDs and allow uppercase characters in model IDs.
- Correct existing MiniMax M2.7 subscription row casing and add missing MiniMax subscription rows for M2, M2.1, M2.1-highspeed, M2.5, and M2.5-highspeed.
- Add missing Z.ai subscription rows for glm-4.5, glm-4.6, and glm-5, and align all Z.ai Coding Plan rows with the matching API-key parameter set (`do_sample`, `response_format.type`, sampling applicability).
- Update schema docs and tests for provider-native casing, plus a catalog regression that keeps Z.ai subscription/API-key param paths aligned for shared models.

Docs checked
- MiniMax Anthropic-compatible API: https://platform.minimax.io/docs/api-reference/text-anthropic-api
- MiniMax text API model/parameter reference: https://platform.minimax.io/docs/api-reference/text-post
- Z.ai Chat Completion API reference: https://docs.z.ai/api-reference/llm/chat-completion
- Z.ai GLM Coding Plan overview: https://docs.z.ai/devpack/overview
- Z.ai GLM Coding Plan quick start / Coding API endpoint: https://docs.z.ai/devpack/quick-start

Live smoke
- Used local provider keys from `.env.keys`; no secrets printed or committed.
- MiniMax model-list smoke passed: `GET https://api.minimax.io/anthropic/v1/models?limit=100` returned all 7 Manifest-known subscription IDs.
- MiniMax completion smoke was attempted for all 7 rows with `max_tokens`, `temperature`, and `top_p`, but every call failed before model execution with upstream `insufficient balance (1008)`.
- Z.ai Coding Plan model-list smoke passed: `GET https://open.bigmodel.cn/api/coding/paas/v4/models` returned all 7 Manifest-known subscription IDs.
- Z.ai completion smoke was attempted for all 7 rows with `max_tokens`, `temperature`, `top_p`, and `thinking.type`; extra probes for `do_sample` + `response_format.type` and `thinking.clear_thinking` were also attempted. All completion probes failed before model execution with upstream `429` / code `1309` because the Coding Plan package is expired.

Notes
- MiniMax official docs publish these language model IDs with `MiniMax-*` casing.
- MiniMax docs currently conflict on `thinking`: the support table says `thinking` is supported, but the later important note says `thinking` is ignored. Because live completion is blocked by account balance, this PR keeps MiniMax to the unambiguous scalar params already supported by the row shape.
- This same-repo branch supersedes fork PR #30 so Vercel can run without fork authorization failure.
- Git may display two MiniMax YAML changes as high-similarity renames because the parameter rows are intentionally near-identical except for model IDs; the final tree contains the intended uppercase MiniMax files and no lowercase duplicates.

Validation
- `npm run validate`
- `npm test`
- `npm run build`
- `npm run guard:params`
- `npm run typecheck`
- `npm run lint`
- `npx prettier --check` on touched files
- `git diff --check`
- Direct Manifest MPS lookup smoke against the rebuilt local catalog: zero missing MiniMax/Z.ai subscription specs; MiniMax rows expose `max_tokens`, `temperature`, `top_p`; Z.ai rows expose `max_tokens`, `do_sample`, `temperature`, `top_p`, `thinking.type`, `response_format.type`.
