### PR TITLE
Add OpenCode Go MiMo-V2.5 subscription params

### DIFF
--- a/models/opencode-go/mimo-v2.5-subscription.yaml
+++ b/models/opencode-go/mimo-v2.5-subscription.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: opencode-go
+authType: subscription
+model: mimo-v2.5
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max completion tokens
+    description: Upper bound for visible output tokens generated in the chat completion.
+    range:
+      min: 1
+    group: generation_length
+  - path: stop
+    type: string
+    label: Stop sequence
+    description: Stops generation when this string is produced. MiMo also accepts multiple stop sequences.
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    default: 1
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: frequency_penalty
+    type: number
+    label: Frequency penalty
+    description: Penalizes tokens that have already appeared, reducing repeated text.
+    default: 0
+    range:
+      min: -2
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: presence_penalty
+    type: number
+    label: Presence penalty
+    description: Penalizes tokens that have appeared at least once, encouraging new topics.
+    default: 0
+    range:
+      min: -2
+      max: 2
+      step: 0.1
+    group: sampling


### PR DESCRIPTION
## Summary
- Add an `opencode-go` subscription catalog row for `mimo-v2.5`.
- Include the scalar OpenAI-compatible request knobs documented for MiMo: `max_completion_tokens`, `stop`, `temperature`, `top_p`, `frequency_penalty`, and `presence_penalty`.
- Leave transport, tool-calling, multimodal, and runtime message fields out of MPS scope.

## Sources
- OpenCode Go docs: https://opencode.ai/docs/go/
- MiMo OpenAI-compatible API docs: https://www.mimo-v2.com/docs/api/chat/openai-api

## Validation
- `npm ci`
- `npm run validate`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `npm run guard:params`
- `npm run lint`
- `npx prettier --check models/opencode-go/mimo-v2.5-subscription.yaml`
- `curl -fsSL https://opencode.ai/zen/go/v1/models | jq -r '.data[]?.id // empty' | rg '^mimo-v2\\.5$'`\n\nLive completion smoke was not run because there is no OpenCode Go subscription token configured in this environment.\n\nCloses #25