### PR TITLE
feat: add subscription variants for all Claude 4.x Anthropic models

### DIFF
--- a/models/anthropic/claude-haiku-4-5-20251001-subscription.yaml
+++ b/models/anthropic/claude-haiku-4-5-20251001-subscription.yaml
@@ -1,0 +1,83 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-haiku-4-5-20251001
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+        - top_p:
+            not: null
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
+      reaches this value.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+        - temperature:
+            not: null
+  - path: top_k
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    default: 0
+    range:
+      min: 0
+    group: sampling
+    applicability:
+      except:
+        thinking.type:
+          - enabled
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - enabled
+    group: reasoning
+  - path: thinking.budget_tokens
+    type: integer
+    label: Budget tokens
+    description: >-
+      Maximum token budget Anthropic may use for extended thinking before producing the final
+      answer.
+    default: 4096
+    range:
+      min: 1024
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled

--- a/models/anthropic/claude-haiku-4-5-subscription.yaml
+++ b/models/anthropic/claude-haiku-4-5-subscription.yaml
@@ -1,0 +1,84 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-haiku-4-5
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        thinking.type:
+          - adaptive
+          - enabled
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
+      reaches this value.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - adaptive
+            - enabled
+        - temperature:
+            not: 1
+  - path: top_k
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    default: 0
+    range:
+      min: 0
+    group: sampling
+    applicability:
+      except:
+        thinking.type:
+          - adaptive
+          - enabled
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - enabled
+    group: reasoning
+  - path: thinking.budget_tokens
+    type: integer
+    label: Budget tokens
+    description: >-
+      Maximum token budget Anthropic may use for extended thinking before producing the final
+      answer.
+    default: 4096
+    range:
+      min: 1024
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled

--- a/models/anthropic/claude-opus-4-1-20250805-subscription.yaml
+++ b/models/anthropic/claude-opus-4-1-20250805-subscription.yaml
@@ -1,0 +1,96 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-opus-4-1-20250805
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+        - top_p:
+            not: null
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
+      reaches this value.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+        - temperature:
+            not: null
+  - path: top_k
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    default: 0
+    range:
+      min: 0
+    group: sampling
+    applicability:
+      except:
+        thinking.type:
+          - enabled
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - enabled
+    group: reasoning
+  - path: thinking.budget_tokens
+    type: integer
+    label: Budget tokens
+    description: >-
+      Maximum token budget Anthropic may use for extended thinking before producing the final
+      answer.
+    default: 4096
+    range:
+      min: 1024
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: summarized
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - enabled

--- a/models/anthropic/claude-opus-4-20250514-subscription.yaml
+++ b/models/anthropic/claude-opus-4-20250514-subscription.yaml
@@ -1,0 +1,92 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-opus-4-20250514
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
+      reaches this value.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+  - path: top_k
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    default: 0
+    range:
+      min: 0
+    group: sampling
+    applicability:
+      except:
+        thinking.type:
+          - enabled
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - enabled
+    group: reasoning
+  - path: thinking.budget_tokens
+    type: integer
+    label: Budget tokens
+    description: >-
+      Maximum token budget Anthropic may use for extended thinking before producing the final
+      answer.
+    default: 4096
+    range:
+      min: 1024
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: summarized
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - enabled

--- a/models/anthropic/claude-opus-4-5-20251101-subscription.yaml
+++ b/models/anthropic/claude-opus-4-5-20251101-subscription.yaml
@@ -1,0 +1,106 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-opus-4-5-20251101
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+        - top_p:
+            not: null
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
+      reaches this value.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+        - temperature:
+            not: null
+  - path: top_k
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    default: 0
+    range:
+      min: 0
+    group: sampling
+    applicability:
+      except:
+        thinking.type:
+          - enabled
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - enabled
+    group: reasoning
+  - path: thinking.budget_tokens
+    type: integer
+    label: Budget tokens
+    description: >-
+      Maximum token budget Anthropic may use for extended thinking before producing the final
+      answer.
+    default: 4096
+    range:
+      min: 1024
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: summarized
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - enabled
+  - path: output_config.effort
+    type: enum
+    label: Effort
+    description: Controls Anthropic response thoroughness and token spend.
+    default: high
+    values:
+      - low
+      - medium
+      - high
+    group: reasoning

--- a/models/anthropic/claude-opus-4-6-subscription.yaml
+++ b/models/anthropic/claude-opus-4-6-subscription.yaml
@@ -1,0 +1,112 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-opus-4-6
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+            - adaptive
+        - top_p:
+            not: null
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
+      reaches this value.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+            - adaptive
+        - temperature:
+            not: null
+  - path: top_k
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    default: 0
+    range:
+      min: 0
+    group: sampling
+    applicability:
+      except:
+        thinking.type:
+          - enabled
+          - adaptive
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - adaptive
+      - enabled
+    group: reasoning
+  - path: thinking.budget_tokens
+    type: integer
+    label: Budget tokens
+    description: >-
+      Maximum token budget Anthropic may use for extended thinking before producing the final
+      answer.
+    default: 4096
+    range:
+      min: 1024
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: summarized
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - adaptive
+          - enabled
+  - path: output_config.effort
+    type: enum
+    label: Effort
+    description: Controls Anthropic response thoroughness and token spend.
+    default: high
+    values:
+      - low
+      - medium
+      - high
+      - max
+    group: reasoning

--- a/models/anthropic/claude-opus-4-7-subscription.yaml
+++ b/models/anthropic/claude-opus-4-7-subscription.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-opus-4-7
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - adaptive
+    group: reasoning
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: omitted
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - adaptive
+  - path: output_config.effort
+    type: enum
+    label: Effort
+    description: Controls Anthropic response thoroughness and token spend.
+    default: high
+    values:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    group: reasoning

--- a/models/anthropic/claude-sonnet-4-20250514-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-20250514-subscription.yaml
@@ -1,0 +1,92 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-sonnet-4-20250514
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
+      reaches this value.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+  - path: top_k
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    default: 0
+    range:
+      min: 0
+    group: sampling
+    applicability:
+      except:
+        thinking.type:
+          - enabled
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - enabled
+    group: reasoning
+  - path: thinking.budget_tokens
+    type: integer
+    label: Budget tokens
+    description: >-
+      Maximum token budget Anthropic may use for extended thinking before producing the final
+      answer.
+    default: 4096
+    range:
+      min: 1024
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: summarized
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - enabled

--- a/models/anthropic/claude-sonnet-4-5-20250929-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-5-20250929-subscription.yaml
@@ -1,0 +1,83 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-sonnet-4-5-20250929
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+        - top_p:
+            not: null
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
+      reaches this value.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+        - temperature:
+            not: null
+  - path: top_k
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    default: 0
+    range:
+      min: 0
+    group: sampling
+    applicability:
+      except:
+        thinking.type:
+          - enabled
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - enabled
+    group: reasoning
+  - path: thinking.budget_tokens
+    type: integer
+    label: Budget tokens
+    description: >-
+      Maximum token budget Anthropic may use for extended thinking before producing the final
+      answer.
+    default: 4096
+    range:
+      min: 1024
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled

--- a/models/anthropic/claude-sonnet-4-5-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-5-subscription.yaml
@@ -1,0 +1,85 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-sonnet-4-5
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        thinking.type:
+          - adaptive
+          - enabled
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
+      reaches this value.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - adaptive
+            - enabled
+        - temperature:
+            not: 1
+  - path: top_k
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    default: 0
+    range:
+      min: 0
+    group: sampling
+    applicability:
+      except:
+        thinking.type:
+          - adaptive
+          - enabled
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - adaptive
+      - enabled
+    group: reasoning
+  - path: thinking.budget_tokens
+    type: integer
+    label: Budget tokens
+    description: >-
+      Maximum token budget Anthropic may use for extended thinking before producing the final
+      answer.
+    default: 4096
+    range:
+      min: 1024
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled

--- a/models/anthropic/claude-sonnet-4-6-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-6-subscription.yaml
@@ -1,0 +1,112 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-sonnet-4-6
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+            - adaptive
+        - top_p:
+            not: null
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
+      reaches this value.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - enabled
+            - adaptive
+        - temperature:
+            not: null
+  - path: top_k
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    default: 0
+    range:
+      min: 0
+    group: sampling
+    applicability:
+      except:
+        thinking.type:
+          - enabled
+          - adaptive
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - adaptive
+      - enabled
+    group: reasoning
+  - path: thinking.budget_tokens
+    type: integer
+    label: Budget tokens
+    description: >-
+      Maximum token budget Anthropic may use for extended thinking before producing the final
+      answer.
+    default: 4096
+    range:
+      min: 1024
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: summarized
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - adaptive
+          - enabled
+  - path: output_config.effort
+    type: enum
+    label: Effort
+    description: Controls Anthropic response thoroughness and token spend.
+    default: high
+    values:
+      - low
+      - medium
+      - high
+      - max
+    group: reasoning


### PR DESCRIPTION
## What

Adds `authType: subscription` parameter definitions for all specific Claude 4.x Anthropic models. Previously only the three "latest" aliases (`claude-opus-4`, `claude-sonnet-4`, `claude-haiku-4`) had subscription variants, so subscription-mode users got **zero** params for versioned models like `claude-opus-4-7`.

## Models added (11)

| Family | Models |
|--------|--------|
| Opus   | `claude-opus-4-7`, `4-6`, `4-5-20251101`, `4-1-20250805`, `4-20250514` |
| Sonnet | `claude-sonnet-4-6`, `4-5`, `4-5-20250929`, `4-20250514` |
| Haiku  | `claude-haiku-4-5`, `4-5-20251001` |

## How

Each subscription file mirrors its existing API-key counterpart exactly — same params, same applicability rules (sampling params excluded when thinking is enabled/adaptive, etc.) — differing only in `authType: subscription`. Verified identical to the current API-key files for all 11 models.

`npm run validate` passes (139 models).