### PR TITLE
feat: add Alibaba Qwen parameters

### DIFF
--- a/models/alibaba/qwen3.5.yaml
+++ b/models/alibaba/qwen3.5.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: alibaba
+authType: api_key
+model: qwen3.5
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: extra_body.top_k
+    type: integer
+    label: Top K
+    description: Limits generation to the selected number of highest-probability tokens.
+    default: 20
+    range:
+      min: 1
+    group: sampling
+  - path: extra_body.chat_template_kwargs.enable_thinking
+    type: boolean
+    label: Enable thinking
+    description: Controls Qwen3 thinking mode when using OpenAI-compatible clients that pass provider-specific extra body fields.
+    default: true
+    group: reasoning

--- a/src/data/display.ts
+++ b/src/data/display.ts
@@ -1,6 +1,7 @@
 import type { AuthType, Model } from "../schema/model.js";
 
 const PROVIDER_LABELS: Record<string, string> = {
+  alibaba: "Alibaba",
   anthropic: "Anthropic",
   openai: "OpenAI",
   google: "Google",
@@ -48,6 +49,7 @@ const MODEL_LABEL_OVERRIDES: Record<string, string> = {
   "moonshot/moonshot-v1-8k": "Moonshot v1 8K",
   "moonshot/moonshot-v1-32k": "Moonshot v1 32K",
   "moonshot/moonshot-v1-128k": "Moonshot v1 128K",
+  "alibaba/qwen3.5": "Qwen3.5",
 };
 
 const AUTH_LABELS: Record<AuthType, string> = {


### PR DESCRIPTION
## Summary
- Add Alibaba as a provider label in the catalog UI.
- Add `alibaba/qwen3.5` API-key parameter metadata.
- Include documented Qwen OpenAI-compatible params for length, sampling, top-k, and native thinking control.

## Test plan
- [x] npm run validate
- [x] npm run test
- [x] npm run typecheck