### PR TITLE
feat: add Claude Opus 4.8 parameters

### DIFF
--- a/models/anthropic/claude-opus-4-8-subscription.yaml
+++ b/models/anthropic/claude-opus-4-8-subscription.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-opus-4-8
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - adaptive
+    group: reasoning
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: omitted
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - adaptive
+  - path: output_config.effort
+    type: enum
+    label: Effort
+    description: Controls Anthropic response thoroughness and token spend.
+    default: high
+    values:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    group: reasoning

--- a/models/anthropic/claude-opus-4-8.yaml
+++ b/models/anthropic/claude-opus-4-8.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: api_key
+model: claude-opus-4-8
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - adaptive
+    group: reasoning
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: omitted
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - adaptive
+  - path: output_config.effort
+    type: enum
+    label: Effort
+    description: Controls Anthropic response thoroughness and token spend.
+    default: high
+    values:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    group: reasoning


### PR DESCRIPTION
### 💭 Why
Anthropic shipped Claude Opus 4.8 (`claude-opus-4-8`). The catalog should list the knobs callers can set on it.

### ✨ What changed
- Add `claude-opus-4-8.yaml` (api_key) and `claude-opus-4-8-subscription.yaml`.
- Same surface as 4.7: max_tokens, adaptive thinking, effort (low/medium/high/xhigh/max).

### 👤 For users
Opus 4.8 now shows up in the catalog for both API key and subscription auth.

### 📝 Notes
4.8 rejects manual thinking budgets (`thinking.budget_tokens` returns 400), so depth is controlled by the effort dial. No temperature/top_p/top_k, matching 4.7.