### PR TITLE
fix: footer "contribute on GitHub" link points to CONTRIBUTING.md

### DIFF
--- a/src/views/partials/footer.ejs
+++ b/src/views/partials/footer.ejs
@@ -15,7 +15,7 @@
       <p>
         An open catalog of LLM parameters. MIT licensed. Data:
         <a
-          href="https://github.com/mnfst/modelparams.dev/tree/main/models"
+          href="https://github.com/mnfst/modelparams.dev/blob/main/CONTRIBUTING.md"
           class="underline hover:text-slate-700 dark:hover:text-slate-200"
           rel="noopener"
           >contribute on GitHub</a


### PR DESCRIPTION
## Summary

- The footer link labelled **"contribute on GitHub"** used to send visitors to `tree/main/models` — the raw catalog data — when the label promises contribution guidance.
- Switched the target to `blob/main/CONTRIBUTING.md` so people who click the contribute link actually land on the guide that explains how to add models, write parameters, and open a PR.
- Audited the other external GitHub links across `header.ejs`, `how_to_use.ejs`, the README, `src/data/llms.ts`, and `src/build/build.ts`. The `mnfst/modelparams.dev` and `anomalyco/models.dev` references all resolve and match their intended labels, so no other URL changes were needed.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (67/67 passing)
- [x] `npm run lint`
- [x] `npm run validate` (140 models)
- [ ] Spot-check the footer link renders correctly in the built page and opens the CONTRIBUTING guide