### PR TITLE
fix: restore build broken by the website redesign

### DIFF
--- a/src/build/render.ts
+++ b/src/build/render.ts
@@ -7,7 +7,6 @@ import {
   conditionIcon,
   modelLabel,
   paramGroupColor,
-  paramGroupColor,
   paramGroupIcon,
   paramGroupLabel,
   paramLabel,

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -365,6 +365,7 @@ function setupScrollTopButton(): void {
 
   const observer = new IntersectionObserver(
     ([entry]) => {
+      if (!entry) return;
       btn.classList.toggle("hidden", entry.isIntersecting);
       btn.classList.toggle("flex", !entry.isIntersecting);
     },


### PR DESCRIPTION
### 💭 Why
The website redesign merge (#60) left `main` failing to compile, turning CI red and blocking the `modelparams` npm release (the release gates on a clean root typecheck).

### ✨ What changed
- Drop a duplicated `paramGroupColor` import in `render.ts`.
- Guard the possibly-undefined `entry` in the scroll-top IntersectionObserver.

### 🔧 For operators
After merge, re-run the "Release modelparams" workflow with `force_level=patch` to publish the first package version.