### PR TITLE
ci: allow same-version on the first modelparams release

### DIFF
--- a/.github/workflows/release-modelparams.yml
+++ b/.github/workflows/release-modelparams.yml
@@ -99,7 +99,7 @@ jobs:
         if: steps.bump.outputs.next != ''
         env:
           NEXT: ${{ steps.bump.outputs.next }}
-        run: npm version "$NEXT" --no-git-tag-version --workspace=modelparams
+        run: npm version "$NEXT" --no-git-tag-version --allow-same-version --workspace=modelparams
 
       - name: Publish to npm
         if: steps.bump.outputs.next != ''


### PR DESCRIPTION
### 💭 Why
The first release ever failed at `npm version`: it seeds `NEXT` from `package.json` (`0.0.1`), and `npm version 0.0.1` errors with `Version not changed` because the file already says `0.0.1`.

### ✨ What changed
- Add `--allow-same-version` to the version step (no-op when it already matches; later releases still bump normally).

### 🔧 For operators
On merge, the release re-runs and publishes `modelparams@0.0.1`.