### PR TITLE
Add Claude Fable 5 model parameters

### DIFF
--- a/models/anthropic/claude-fable-5-subscription.yaml
+++ b/models/anthropic/claude-fable-5-subscription.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-fable-5
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Only adaptive thinking is supported; omit the parameter entirely to run without thinking (an explicit disabled value is rejected).
+    values:
+      - adaptive
+    group: reasoning
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: omitted
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - adaptive
+  - path: output_config.effort
+    type: enum
+    label: Effort
+    description: Controls Anthropic response thoroughness and token spend.
+    default: high
+    values:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    group: reasoning

--- a/models/anthropic/claude-fable-5.yaml
+++ b/models/anthropic/claude-fable-5.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: api_key
+model: claude-fable-5
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Only adaptive thinking is supported; omit the parameter entirely to run without thinking (an explicit disabled value is rejected).
+    values:
+      - adaptive
+    group: reasoning
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: omitted
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - adaptive
+  - path: output_config.effort
+    type: enum
+    label: Effort
+    description: Controls Anthropic response thoroughness and token spend.
+    default: high
+    values:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    group: reasoning

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -1207,6 +1207,130 @@ export const CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "model": "claude-fable-5",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 4096,
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "thinking.type",
+        "label": "Thinking mode",
+        "description": "Only adaptive thinking is supported; omit the parameter entirely to run without thinking (an explicit disabled value is rejected).",
+        "group": "reasoning",
+        "type": "enum",
+        "values": [
+          "adaptive"
+        ]
+      },
+      {
+        "path": "thinking.display",
+        "label": "Thinking display",
+        "description": "Controls whether Anthropic returns summarized or omitted thinking content.",
+        "group": "reasoning",
+        "applicability": {
+          "only": {
+            "thinking.type": [
+              "adaptive"
+            ]
+          }
+        },
+        "type": "enum",
+        "default": "omitted",
+        "values": [
+          "summarized",
+          "omitted"
+        ]
+      },
+      {
+        "path": "output_config.effort",
+        "label": "Effort",
+        "description": "Controls Anthropic response thoroughness and token spend.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "high",
+        "values": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
+    ]
+  },
+  {
+    "provider": "anthropic",
+    "authType": "subscription",
+    "model": "claude-fable-5",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 4096,
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "thinking.type",
+        "label": "Thinking mode",
+        "description": "Only adaptive thinking is supported; omit the parameter entirely to run without thinking (an explicit disabled value is rejected).",
+        "group": "reasoning",
+        "type": "enum",
+        "values": [
+          "adaptive"
+        ]
+      },
+      {
+        "path": "thinking.display",
+        "label": "Thinking display",
+        "description": "Controls whether Anthropic returns summarized or omitted thinking content.",
+        "group": "reasoning",
+        "applicability": {
+          "only": {
+            "thinking.type": [
+              "adaptive"
+            ]
+          }
+        },
+        "type": "enum",
+        "default": "omitted",
+        "values": [
+          "summarized",
+          "omitted"
+        ]
+      },
+      {
+        "path": "output_config.effort",
+        "label": "Effort",
+        "description": "Controls Anthropic response thoroughness and token spend.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "high",
+        "values": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
+    ]
+  },
+  {
+    "provider": "anthropic",
+    "authType": "api_key",
     "model": "claude-haiku-4",
     "params": [
       {

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -86,6 +86,16 @@ export const DEFAULTS = {
     top_p: 1,
     top_k: 0,
   },
+  "anthropic/claude-fable-5": {
+    max_tokens: 4096,
+    "thinking.display": "omitted",
+    "output_config.effort": "high",
+  },
+  "anthropic/claude-fable-5-subscription": {
+    max_tokens: 4096,
+    "thinking.display": "omitted",
+    "output_config.effort": "high",
+  },
   "anthropic/claude-haiku-4": {
     max_tokens: 4096,
     temperature: 1,

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -18,6 +18,8 @@ export const MODEL_IDS = [
   "anthropic/claude-3-7-sonnet-latest",
   "anthropic/claude-3-opus-20240229",
   "anthropic/claude-3-opus-latest",
+  "anthropic/claude-fable-5",
+  "anthropic/claude-fable-5-subscription",
   "anthropic/claude-haiku-4",
   "anthropic/claude-haiku-4-5",
   "anthropic/claude-haiku-4-5-20251001",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -112,6 +112,18 @@ export type ParamsById = {
     top_p: number;
     top_k: number;
   };
+  "anthropic/claude-fable-5": {
+    max_tokens: number;
+    "thinking.type": "adaptive";
+    "thinking.display": "summarized" | "omitted";
+    "output_config.effort": "low" | "medium" | "high" | "xhigh" | "max";
+  };
+  "anthropic/claude-fable-5-subscription": {
+    max_tokens: number;
+    "thinking.type": "adaptive";
+    "thinking.display": "summarized" | "omitted";
+    "output_config.effort": "low" | "medium" | "high" | "xhigh" | "max";
+  };
   "anthropic/claude-haiku-4": {
     max_tokens: number;
     temperature: number;


### PR DESCRIPTION
## What this changes

Adds Anthropic's Claude Fable 5 (`claude-fable-5`) to the catalog, with both the API-key and subscription parameter files.

## Type of change

- [x] Add a model (new YAML file under `models/`)
- [ ] Add a provider (new folder under `models/`, plus a logo)
- [ ] Add or update parameters on an existing model
- [ ] Fix incorrect data (default, range, values, applicability)
- [ ] Site or tooling (code under `src/`, docs, CI)

## Source

https://platform.claude.com/docs/en/about-claude/models/overview

Fable 5 keeps the Opus 4.7/4.8 request surface: adaptive thinking only, `thinking.display` (`summarized`/`omitted`), `output_config.effort` (`low`–`max`), and no sampling parameters (`temperature`/`top_p`/`top_k` are rejected). One difference from Opus 4.8: `thinking.type` only accepts `adaptive` — an explicit `disabled` value returns a 400; the parameter must be omitted to run without thinking. That's why `thinking.type` lists a single value with no default, per the "fewer parameters can be correct" guidance in CONTRIBUTING.

## Before opening

- [x] `npm run validate` and `npm test` pass locally
- [x] Filenames follow the convention: `models/<provider>/<model>.yaml`, or `<model>-subscription.yaml` for the subscription route
- [x] No existing parameter was removed (removals are blocked, see CONTRIBUTING)