### PR TITLE
docs: add npm usage with a type-safe OpenAI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,31 +11,45 @@
 [![npm downloads](https://img.shields.io/npm/dm/modelparams.svg)](https://www.npmjs.com/package/modelparams)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-[modelparams.dev](https://modelparams.dev) is an open-source database that lists the parameters available for popular AI models. It is heavily inspired on [models.dev](https://github.com/anomalyco/models.dev) and we use it at [Manifest](https://manifest.build/).
+Every parameter each AI model accepts, in one place. Inspired by [models.dev](https://github.com/anomalyco/models.dev); we use it at [Manifest](https://manifest.build/).
+
+## TypeScript
+
+```bash
+npm install modelparams
+```
+
+`ParamsOf<Id>` is the exact set of parameters a model accepts. Pass one it doesn't, and your code won't compile.
+
+```ts
+import type { ParamsOf } from "modelparams";
+import OpenAI from "openai";
+
+const params: ParamsOf<"openai/gpt-4.1"> = {
+  max_tokens: 1024,
+  temperature: 0.7,
+  // top_k: 40, // won't compile: gpt-4.1 has no top_k
+};
+
+await new OpenAI().chat.completions.create({ model: "gpt-4.1", messages, ...params });
+```
+
+Defaults, runtime validation, and the helper APIs are in the [package README](packages/modelparams/README.md).
 
 ## API
 
-You can access this data through an API.
+Prefer raw JSON?
 
 ```
 curl https://modelparams.dev/api/v1/models.json
 curl https://modelparams.dev/api/v1/params/gpt-5.5.json
-curl https://modelparams.dev/api/v1/params/gpt-5.5-subscription.json
 ```
 
-The catalog follows the [Model Parameters convention](docs/model-parameters-schema.md).
-The generated JSON Schema is available at
-`https://modelparams.dev/api/v1/schema.json`.
+Schema at `https://modelparams.dev/api/v1/schema.json`, per the [Model Parameters convention](docs/model-parameters-schema.md).
 
-## Adding a model or a parameter
+## Adding a model
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). The short version:
-
-1. Pick a unique ID: `<provider>/<model>` for the API-key variant, `<provider>/<model>-subscription` for the subscription variant. Example: `mistral/mistral-large`.
-2. Add a YAML file at `models/<provider>/<model>.yaml` (or `models/<provider>/<model>-subscription.yaml`).
-3. Open a PR. CI validates against the schema and rebuilds.
-
-Don't want to open a PR? [File an issue](https://github.com/mnfst/modelparams.dev/issues/new/choose) with the model and a link to the official docs, and someone will pick it up.
+Drop a YAML file in `models/<provider>/`, open a PR, and CI validates it against the schema. Details in [CONTRIBUTING.md](CONTRIBUTING.md). Can't open a PR? [File an issue](https://github.com/mnfst/modelparams.dev/issues/new/choose) with a link to the docs.
 
 ## Local development
 


### PR DESCRIPTION
### 💭 Why
The README never mentioned the `modelparams` npm package or showed how the types stop you from passing a parameter a model doesn't accept.

### ✨ What changed
- New TypeScript section: `npm install` plus an OpenAI SDK snippet built on `ParamsOf<Id>`.
- The snippet flags `top_k` on `gpt-4.1` as a compile error, verified against the generated types.
- Trimmed the intro, API, and contributing sections; deeper docs link to the package README instead of repeating it.

### 👤 For users
A reader landing on the repo sees the type-safe path first, with a copy-pasteable OpenAI example.