### PR TITLE
Add Xiaomi MiMo V2.5 parameters

### DIFF
--- a/models/xiaomi/mimo-v2.5.yaml
+++ b/models/xiaomi/mimo-v2.5.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: xiaomi
+authType: api_key
+model: mimo-v2.5
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate, covering both the thinking trace and the final answer.
+    range:
+      min: 1
+    group: generation_length
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: >-
+      Controls whether MiMo reasons step by step before answering. Enabled by default;
+      set disabled to respond directly.
+    default: enabled
+    values:
+      - enabled
+      - disabled
+    group: reasoning
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values are more focused; higher values are more varied.
+      Ignored while thinking is enabled, where it is forced to 1.0.
+    default: 1
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        thinking.type: enabled
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Nucleus sampling cutoff. Ignored while thinking is enabled, where it is forced to 0.95.
+    default: 0.95
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        thinking.type: enabled
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -13348,6 +13348,83 @@ export const CATALOG = [
     ]
   },
   {
+    "provider": "xiaomi",
+    "authType": "api_key",
+    "model": "mimo-v2.5",
+    "params": [
+      {
+        "path": "max_completion_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of tokens to generate, covering both the thinking trace and the final answer.",
+        "group": "generation_length",
+        "type": "integer",
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "thinking.type",
+        "label": "Thinking mode",
+        "description": "Controls whether MiMo reasons step by step before answering. Enabled by default; set disabled to respond directly.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "enabled",
+        "values": [
+          "enabled",
+          "disabled"
+        ]
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values are more focused; higher values are more varied. Ignored while thinking is enabled, where it is forced to 1.0.",
+        "group": "sampling",
+        "applicability": {
+          "except": {
+            "thinking.type": "enabled"
+          }
+        },
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 2,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Nucleus sampling cutoff. Ignored while thinking is enabled, where it is forced to 0.95.",
+        "group": "sampling",
+        "applicability": {
+          "except": {
+            "thinking.type": "enabled"
+          }
+        },
+        "type": "number",
+        "default": 0.95,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "response_format.type",
+        "label": "Response format",
+        "description": "Forces the response into plain text or a JSON object.",
+        "group": "output_format",
+        "type": "enum",
+        "default": "text",
+        "values": [
+          "text",
+          "json_object"
+        ]
+      }
+    ]
+  },
+  {
     "provider": "z-ai",
     "authType": "api_key",
     "model": "glm-4.5",

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -1056,6 +1056,12 @@ export const DEFAULTS = {
     top_p: 1,
     "response_format.type": "text",
   },
+  "xiaomi/mimo-v2.5": {
+    "thinking.type": "enabled",
+    temperature: 1,
+    top_p: 0.95,
+    "response_format.type": "text",
+  },
   "z-ai/glm-4.5": {
     temperature: 0.6,
     top_p: 0.95,

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -174,6 +174,7 @@ export const MODEL_IDS = [
   "xai/grok-4.20-multi-agent-0309",
   "xai/grok-4.3",
   "xai/grok-build-0.1",
+  "xiaomi/mimo-v2.5",
   "z-ai/glm-4.5",
   "z-ai/glm-4.5-air",
   "z-ai/glm-4.5-air-subscription",
@@ -211,6 +212,7 @@ export const PROVIDERS = [
   "openai",
   "perplexity",
   "xai",
+  "xiaomi",
   "z-ai"
 ] as const;
 

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -1298,6 +1298,13 @@ export type ParamsById = {
     seed: number;
     "response_format.type": "text" | "json_object" | "json_schema";
   };
+  "xiaomi/mimo-v2.5": {
+    max_completion_tokens: number;
+    "thinking.type": "enabled" | "disabled";
+    temperature: number;
+    top_p: number;
+    "response_format.type": "text" | "json_object";
+  };
   "z-ai/glm-4.5": {
     max_tokens: number;
     temperature: number;


### PR DESCRIPTION
## What this changes

Adds configurable request parameters for **Xiaomi MiMo V2.5** (`api_key`).

Covers the native MiMo Chat Completions parameters: `max_completion_tokens`, `thinking.type` (thinking is on by default; set `disabled` to answer directly), `temperature`, `top_p`, and `response_format.type`. Per the deep-thinking docs, `temperature`/`top_p` are forced to `1.0`/`0.95` while thinking is enabled, so they carry an `except: { thinking.type: enabled }` applicability rule.

## Type of change

- [x] Add a model (new YAML file under `models/`)

## Source

- Deep thinking: https://mimo.mi.com/docs/en-US/quick-start/usage-guide/text-generation/deep-thinking
- Rate limit / API: https://mimo.mi.com/docs/en-US/api/guidance/rate-limit
- Cross-checked against OpenRouter `supported_parameters` for `xiaomi/mimo-v2.5`.

Smoke-tested live through a local Manifest server routing to the real provider (OpenRouter `xiaomi/mimo-v2.5`): `max_tokens`/`temperature`/`top_p`/`response_format` and reasoning all accepted (200).

Closes #71
