### PR TITLE
Add Xiaomi MiMo V2.5-pro parameters

### DIFF
--- a/models/xiaomi/mimo-v2.5-pro.yaml
+++ b/models/xiaomi/mimo-v2.5-pro.yaml
@@ -1,0 +1,86 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: xiaomi
+authType: api_key
+model: mimo-v2.5-pro
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate, covering both the thinking trace and the final answer.
+    range:
+      min: 1
+    group: generation_length
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: >-
+      Controls whether MiMo reasons step by step before answering. Enabled by default;
+      set disabled to respond directly.
+    default: enabled
+    values:
+      - enabled
+      - disabled
+    group: reasoning
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values are more focused; higher values are more varied.
+      Ignored while thinking is enabled, where it is forced to 1.0.
+    default: 1
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        thinking.type: enabled
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Nucleus sampling cutoff. Ignored while thinking is enabled, where it is forced to 0.95.
+    default: 0.95
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        thinking.type: enabled
+  - path: presence_penalty
+    type: number
+    label: Presence penalty
+    description: Penalizes tokens that have already appeared, encouraging the model to introduce new topics.
+    default: 0
+    range:
+      min: -2
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: frequency_penalty
+    type: number
+    label: Frequency penalty
+    description: Penalizes tokens in proportion to how often they have appeared, reducing verbatim repetition.
+    default: 0
+    range:
+      min: -2
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: stop
+    type: string
+    label: Stop sequences
+    description: Up to a few sequences where generation stops; the stop text is not included in the output.
+    group: generation_length
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -13425,6 +13425,116 @@ export const CATALOG = [
     ]
   },
   {
+    "provider": "xiaomi",
+    "authType": "api_key",
+    "model": "mimo-v2.5-pro",
+    "params": [
+      {
+        "path": "max_completion_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of tokens to generate, covering both the thinking trace and the final answer.",
+        "group": "generation_length",
+        "type": "integer",
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "thinking.type",
+        "label": "Thinking mode",
+        "description": "Controls whether MiMo reasons step by step before answering. Enabled by default; set disabled to respond directly.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "enabled",
+        "values": [
+          "enabled",
+          "disabled"
+        ]
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values are more focused; higher values are more varied. Ignored while thinking is enabled, where it is forced to 1.0.",
+        "group": "sampling",
+        "applicability": {
+          "except": {
+            "thinking.type": "enabled"
+          }
+        },
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 2,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Nucleus sampling cutoff. Ignored while thinking is enabled, where it is forced to 0.95.",
+        "group": "sampling",
+        "applicability": {
+          "except": {
+            "thinking.type": "enabled"
+          }
+        },
+        "type": "number",
+        "default": 0.95,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "presence_penalty",
+        "label": "Presence penalty",
+        "description": "Penalizes tokens that have already appeared, encouraging the model to introduce new topics.",
+        "group": "sampling",
+        "type": "number",
+        "default": 0,
+        "range": {
+          "min": -2,
+          "max": 2,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "frequency_penalty",
+        "label": "Frequency penalty",
+        "description": "Penalizes tokens in proportion to how often they have appeared, reducing verbatim repetition.",
+        "group": "sampling",
+        "type": "number",
+        "default": 0,
+        "range": {
+          "min": -2,
+          "max": 2,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "stop",
+        "label": "Stop sequences",
+        "description": "Up to a few sequences where generation stops; the stop text is not included in the output.",
+        "group": "generation_length",
+        "type": "string"
+      },
+      {
+        "path": "response_format.type",
+        "label": "Response format",
+        "description": "Forces the response into plain text or a JSON object.",
+        "group": "output_format",
+        "type": "enum",
+        "default": "text",
+        "values": [
+          "text",
+          "json_object"
+        ]
+      }
+    ]
+  },
+  {
     "provider": "z-ai",
     "authType": "api_key",
     "model": "glm-4.5",

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -1062,6 +1062,14 @@ export const DEFAULTS = {
     top_p: 0.95,
     "response_format.type": "text",
   },
+  "xiaomi/mimo-v2.5-pro": {
+    "thinking.type": "enabled",
+    temperature: 1,
+    top_p: 0.95,
+    presence_penalty: 0,
+    frequency_penalty: 0,
+    "response_format.type": "text",
+  },
   "z-ai/glm-4.5": {
     temperature: 0.6,
     top_p: 0.95,

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -175,6 +175,7 @@ export const MODEL_IDS = [
   "xai/grok-4.3",
   "xai/grok-build-0.1",
   "xiaomi/mimo-v2.5",
+  "xiaomi/mimo-v2.5-pro",
   "z-ai/glm-4.5",
   "z-ai/glm-4.5-air",
   "z-ai/glm-4.5-air-subscription",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -1305,6 +1305,16 @@ export type ParamsById = {
     top_p: number;
     "response_format.type": "text" | "json_object";
   };
+  "xiaomi/mimo-v2.5-pro": {
+    max_completion_tokens: number;
+    "thinking.type": "enabled" | "disabled";
+    temperature: number;
+    top_p: number;
+    presence_penalty: number;
+    frequency_penalty: number;
+    stop: string;
+    "response_format.type": "text" | "json_object";
+  };
   "z-ai/glm-4.5": {
     max_tokens: number;
     temperature: number;


### PR DESCRIPTION
## What this changes

Adds configurable request parameters for **Xiaomi MiMo V2.5-pro** (`api_key`).

Same native MiMo shape as MiMo V2.5 — `max_completion_tokens`, `thinking.type` (default `enabled`), `temperature`, `top_p`, `response_format.type` — plus the extra knobs the pro tier accepts: `presence_penalty`, `frequency_penalty`, and `stop`. `temperature`/`top_p` carry the `except: { thinking.type: enabled }` rule since the deep-thinking docs force them to `1.0`/`0.95` while thinking is on.

## Type of change

- [x] Add a model (new YAML file under `models/`)

## Source

- Deep thinking: https://mimo.mi.com/docs/en-US/quick-start/usage-guide/text-generation/deep-thinking
- Cross-checked against OpenRouter `supported_parameters` for `xiaomi/mimo-v2.5-pro` (which lists `frequency_penalty`, `presence_penalty`, `stop`).

Smoke-tested live through a local Manifest server routing to the real provider (OpenRouter `xiaomi/mimo-v2.5-pro`): standard params + penalties + `stop` all accepted (200).

Closes #70
