### PR TITLE
Add NVIDIA Nemotron-3-Ultra (subscription) parameters

### DIFF
--- a/models/nvidia/nemotron-3-ultra-subscription.yaml
+++ b/models/nvidia/nemotron-3-ultra-subscription.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: nvidia
+authType: subscription
+model: nemotron-3-ultra
+params:
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied. Not recommended to modify both temperature and top_p in the same call.
+    default: 1
+    range:
+      max: 1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability. Not recommended to modify both temperature and top_p in the same call.
+    default: 0.95
+    range:
+      max: 1
+    group: sampling
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate. Generation stops when this limit is reached.
+    default: 16384
+    range:
+      min: 1
+      max: 32768
+    group: generation_length
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls the reasoning mode. 'none' disables reasoning tokens, 'medium' enables efficient reasoning, and 'high' enables full reasoning.
+    default: high
+    values:
+      - none
+      - medium
+      - high
+    group: reasoning
+  - path: reasoning_budget
+    type: integer
+    label: Reasoning budget
+    description: Maximum number of tokens the model may use for internal reasoning before being forced to end the reasoning trace. Use -1 to disable budget enforcement.
+    default: 16384
+    range:
+      min: -1
+      max: 32768
+    group: reasoning
+  - path: stop
+    type: string
+    label: Stop
+    description: A string or list of strings where the API will stop generating further tokens. The returned text will not contain the stop sequence.
+    group: generation_length

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -10634,6 +10634,79 @@ export const CATALOG = [
   },
   {
     "provider": "nvidia",
+    "authType": "subscription",
+    "model": "nemotron-3-ultra",
+    "params": [
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied. Not recommended to modify both temperature and top_p in the same call.",
+        "group": "sampling",
+        "type": "number",
+        "default": 1,
+        "range": {
+          "max": 1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability. Not recommended to modify both temperature and top_p in the same call.",
+        "group": "sampling",
+        "type": "number",
+        "default": 0.95,
+        "range": {
+          "max": 1
+        }
+      },
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of tokens to generate. Generation stops when this limit is reached.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 16384,
+        "range": {
+          "min": 1,
+          "max": 32768
+        }
+      },
+      {
+        "path": "reasoning_effort",
+        "label": "Reasoning effort",
+        "description": "Controls the reasoning mode. 'none' disables reasoning tokens, 'medium' enables efficient reasoning, and 'high' enables full reasoning.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "high",
+        "values": [
+          "none",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "path": "reasoning_budget",
+        "label": "Reasoning budget",
+        "description": "Maximum number of tokens the model may use for internal reasoning before being forced to end the reasoning trace. Use -1 to disable budget enforcement.",
+        "group": "reasoning",
+        "type": "integer",
+        "default": 16384,
+        "range": {
+          "min": -1,
+          "max": 32768
+        }
+      },
+      {
+        "path": "stop",
+        "label": "Stop",
+        "description": "A string or list of strings where the API will stop generating further tokens. The returned text will not contain the stop sequence.",
+        "group": "generation_length",
+        "type": "string"
+      }
+    ]
+  },
+  {
+    "provider": "nvidia",
     "authType": "api_key",
     "model": "nemotron-content-safety-reasoning-4b",
     "params": [

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -798,6 +798,13 @@ export const DEFAULTS = {
     reasoning_effort: "high",
     reasoning_budget: 16384,
   },
+  "nvidia/nemotron-3-ultra-subscription": {
+    temperature: 1,
+    top_p: 0.95,
+    max_tokens: 16384,
+    reasoning_effort: "high",
+    reasoning_budget: 16384,
+  },
   "nvidia/nemotron-content-safety-reasoning-4b": {
     temperature: 1,
     top_p: 1,

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -120,6 +120,7 @@ export const MODEL_IDS = [
   "nvidia/nemotron-3-nano-30b-a3b",
   "nvidia/nemotron-3-super-120b-a12b",
   "nvidia/nemotron-3-ultra-550b-a55b",
+  "nvidia/nemotron-3-ultra-subscription",
   "nvidia/nemotron-content-safety-reasoning-4b",
   "nvidia/nemotron-mini-4b-instruct",
   "nvidia/riva-translate-4b-instruct-v1.1",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -992,6 +992,14 @@ export type ParamsById = {
     seed: number;
     stop: string;
   };
+  "nvidia/nemotron-3-ultra-subscription": {
+    temperature: number;
+    top_p: number;
+    max_tokens: number;
+    reasoning_effort: "none" | "medium" | "high";
+    reasoning_budget: number;
+    stop: string;
+  };
   "nvidia/nemotron-content-safety-reasoning-4b": {
     temperature: number;
     top_p: number;


### PR DESCRIPTION
## What this changes

Adds parameters for **NVIDIA Nemotron-3-Ultra** on the **subscription** route (Ollama Cloud, `$20/mo`), filed as #74. The API-key entry already exists as `nemotron-3-ultra-550b-a55b`; this adds the subscription variant under the model id Ollama Cloud serves (`nemotron-3-ultra`).

Mirrors the existing `nemotron-3-ultra-550b-a55b` entry's user-facing toggles: `temperature`, `top_p`, `max_tokens`, `reasoning_effort` (`none`/`medium`/`high`, default `high`), `reasoning_budget`, and `stop`.

## Type of change

- [x] Add a model (new YAML file under `models/`)

## Source

- Model card: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
- Param shape mirrors the existing `models/nvidia/nemotron-3-ultra-550b-a55b.yaml` (same model, API-key route).
- Available on Ollama Cloud as `nemotron-3-ultra` (confirmed via the live model listing).

Smoke-tested live through a local Manifest server. The Ollama Cloud key on hand is expired, so the sampling + reasoning params were exercised against the same model on OpenRouter (`nvidia/nemotron-3-ultra-550b-a55b:free`): all accepted (200).

Closes #74
