### PR TITLE
fix: drop redundant 'LLM model' wording across the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # modelparams.dev
 
-> An open, community-maintained catalog of LLM model parameters.
+> An open, community-maintained catalog of model parameters.
 
 [![npm version](https://img.shields.io/npm/v/modelparams.svg)](https://www.npmjs.com/package/modelparams)
 [![npm downloads](https://img.shields.io/npm/dm/modelparams.svg)](https://www.npmjs.com/package/modelparams)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modelparams.dev",
   "version": "0.1.0",
-  "description": "An open catalog of LLM model parameters. The community-maintained source of truth for every knob you can turn.",
+  "description": "An open catalog of model parameters. The community-maintained source of truth for every knob you can turn.",
   "type": "module",
   "private": true,
   "license": "MIT",

--- a/packages/modelparams/README.md
+++ b/packages/modelparams/README.md
@@ -1,6 +1,6 @@
 # modelparams
 
-> **Typed LLM model parameters for TypeScript.** Generated from the open [modelparams.dev](https://modelparams.dev) catalog.
+> **Typed model parameters for TypeScript.** Generated from the open [modelparams.dev](https://modelparams.dev) catalog.
 
 ```bash
 npm install modelparams

--- a/packages/modelparams/package.json
+++ b/packages/modelparams/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modelparams",
   "version": "0.0.1",
-  "description": "TypeScript types and runtime data for LLM model parameters. Generated from the modelparams.dev open catalog.",
+  "description": "TypeScript types and runtime data for model parameters. Generated from the modelparams.dev open catalog.",
   "keywords": [
     "llm",
     "ai",

--- a/src/build/render-model.ts
+++ b/src/build/render-model.ts
@@ -20,7 +20,7 @@ export function modelPageTitle(model: Model): string {
 export function modelPageDescription(model: Model): string {
   const who = `${providerLabel(model.provider)} ${modelLabel(model)}${authNote(model)}`;
   if (model.params.length === 0) {
-    return `${who}: no parameters documented yet. Browse the open catalog of LLM model parameters on ${SITE_NAME}.`;
+    return `${who}: no parameters documented yet. Browse the open catalog of model parameters on ${SITE_NAME}.`;
   }
   const paths = model.params.map((param) => param.path);
   const sample = paths.slice(0, 4).join(", ");

--- a/src/build/render.ts
+++ b/src/build/render.ts
@@ -104,7 +104,7 @@ export async function renderIndex(opts: RenderOptions): Promise<string> {
 
   return renderShell(
     {
-      title: `${SITE_NAME} — Open catalog of LLM model parameters`,
+      title: `${SITE_NAME} — Open catalog of model parameters`,
       description: SITE_DESCRIPTION,
       canonicalUrl: `${SITE_URL}/`,
       structuredData: buildHomeStructuredData(

--- a/src/client/og.svg
+++ b/src/client/og.svg
@@ -8,9 +8,9 @@
   </g>
   <text x="168" y="133" font-family="DejaVu Sans" font-weight="bold" font-size="36" fill="#0f172a">modelparams.dev</text>
 
-  <text x="80" y="320" font-family="DejaVu Sans" font-weight="bold" font-size="76" fill="#0f172a">Every LLM parameter,</text>
+  <text x="80" y="320" font-family="DejaVu Sans" font-weight="bold" font-size="76" fill="#0f172a">Every parameter,</text>
   <text x="80" y="408" font-family="DejaVu Sans" font-weight="bold" font-size="76" fill="#6366f1">for every model.</text>
 
-  <text x="80" y="486" font-family="DejaVu Sans" font-size="32" fill="#475569">An open catalog of LLM model parameters</text>
+  <text x="80" y="486" font-family="DejaVu Sans" font-size="32" fill="#475569">An open catalog of model parameters</text>
   <text x="80" y="556" font-family="DejaVu Sans" font-size="23" fill="#94a3b8">Search · filter · JSON API · llms.txt · MIT licensed</text>
 </svg>

--- a/src/data/llms.ts
+++ b/src/data/llms.ts
@@ -23,7 +23,7 @@ function guideIntro(siteUrl: string): string[] {
   return [
     "# How to use modelparams.dev",
     "",
-    `[modelparams.dev](${siteUrl}) is an open, community-maintained catalog of LLM model`,
+    `[modelparams.dev](${siteUrl}) is an open, community-maintained catalog of model`,
     "parameters. Each entry shows the knobs you can turn — type, default, range, and the",
     "conditions that gate it.",
     "",
@@ -152,7 +152,7 @@ export function buildLlmsTxt(siteUrl: string, models: Model[]): string {
   const lines: string[] = [
     "# modelparams.dev",
     "",
-    "> An open, community-maintained catalog of LLM model parameters — every knob you can",
+    "> An open, community-maintained catalog of model parameters — every knob you can",
     "> turn, for every model, with API-key and subscription variants tracked separately.",
     "",
     "All data is machine-readable: CORS-enabled static JSON validated against a published JSON",

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -7,7 +7,7 @@ export const SITE_NAME = "modelparams.dev";
 export const SITE_URL = process.env.SITE_URL ?? "https://modelparams.dev";
 
 export const SITE_DESCRIPTION =
-  "An open, community-maintained catalog of LLM model parameters. Search and filter every knob you can turn — API-key and subscription variants tracked separately.";
+  "An open, community-maintained catalog of model parameters. Search and filter every knob you can turn — API-key and subscription variants tracked separately.";
 
 /** Path to the social-share image, relative to the site root. */
 export const OG_IMAGE_PATH = "/assets/og.png";

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -1,10 +1,10 @@
 <section class="hero-cover -mt-[1px]">
   <div class="mx-auto max-w-6xl px-4 pb-24 pt-16 sm:px-6 sm:pb-28 sm:pt-20 lg:px-8 lg:pb-32 lg:pt-24">
     <h1 class="text-balance font-bold tracking-tight" style="font-size:4.5rem;line-height:1.05">
-      Every LLM parameter,<br />for every model.
+      Every parameter,<br />for every model.
     </h1>
     <p class="mt-4 max-w-2xl text-pretty text-base text-slate-600 dark:text-slate-400 sm:text-lg">
-      An open, community-maintained catalog of LLM model parameters.
+      An open, community-maintained catalog of model parameters.
       Browse the UI below, query the API, or install the npm package.
     </p>
 

--- a/src/views/layout.ejs
+++ b/src/views/layout.ejs
@@ -16,7 +16,7 @@
     <meta property="og:image" content="<%= ogImageUrl %>" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="modelparams.dev — an open catalog of LLM model parameters" />
+    <meta property="og:image:alt" content="modelparams.dev — an open catalog of model parameters" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="<%= title %>" />
     <meta name="twitter:description" content="<%= description %>" />

--- a/src/views/partials/footer.ejs
+++ b/src/views/partials/footer.ejs
@@ -14,7 +14,7 @@
           </span>
           <span class="text-sm font-semibold text-slate-900 dark:text-white">modelparams.dev</span>
         </div>
-        <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">An open catalog of LLM model parameters.</p>
+        <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">An open catalog of model parameters.</p>
       </div>
 
       <!-- Column 2: Resources -->

--- a/src/views/partials/how_to_use.ejs
+++ b/src/views/partials/how_to_use.ejs
@@ -50,7 +50,7 @@
     <section class="space-y-3">
       <p>
         <a href="/" class="font-medium text-accent hover:text-accent-hover">modelparams.dev</a>
-        is an open, community-maintained catalog of LLM model parameters. Each entry shows the
+        is an open, community-maintained catalog of model parameters. Each entry shows the
         knobs you can turn — type, default, range, and the conditions that gate it.
       </p>
       <p>


### PR DESCRIPTION
### 💭 Why
"LLM model parameters" is redundant. An LLM is a model, so it reads as "Large Language Model model parameters". The homepage H1 had the same overlap: "Every LLM parameter ... for every model".

### ✨ What changed
- Homepage H1 is now "Every parameter, for every model."
- Replaced "LLM model parameters" with "model parameters" across site copy, meta tags, page titles, llms.txt, and READMEs (13 files).

### 👤 For users
Cleaner headline and tagline. Page titles and social/meta descriptions no longer repeat "model".

### 📝 Notes
The rendered social card (og.png) is a separate design that already said "AI model parameters", so it's untouched. og.svg (a source asset, not the rendered card) was updated for consistency.