### PR TITLE
feat: add per-parameter pages for long-tail search

### DIFF
--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -9,21 +9,30 @@ import {
 import { loadAllModels } from "../data/load.js";
 import { buildLlmsFullTxt, buildLlmsTxt } from "../data/llms.js";
 import { listModelParamsResponses } from "../data/model-params.js";
+import { buildParameterIndex } from "../data/parameters.js";
 import {
   DIST_API_DIR,
   DIST_ASSETS_DIR,
   DIST_DIR,
   MODELS_DIR,
+  REPO_ROOT,
 } from "../data/paths.js";
 import { SITE_URL } from "../data/site.js";
-import { GLOSSARY_PATH, modelPagePath, providerPagePath } from "../data/urls.js";
+import {
+  GLOSSARY_PATH,
+  modelPagePath,
+  parameterPagePath,
+  providerPagePath,
+} from "../data/urls.js";
 import { modelId, type Model } from "../schema/model.js";
 import { buildModelJsonSchema } from "../schema/generate.js";
 import { bundleClientScript, compileStyles, copyStaticAssets } from "./assets.js";
+import { gitLastmodMap, modelLastmod } from "./lastmod.js";
 import { renderIndex } from "./render.js";
 import { renderApiPage } from "./render-api.js";
 import { renderGlossaryPage } from "./render-glossary.js";
 import { renderModelPage } from "./render-model.js";
+import { renderParameterPage } from "./render-parameter.js";
 import { renderProviderPage } from "./render-provider.js";
 
 async function cleanDist(): Promise<void> {
@@ -54,19 +63,32 @@ async function writeRobotsAndSitemap(models: Model[]): Promise<void> {
   // Sitemaps list canonical, indexable HTML pages only — the JSON API and the
   // .txt agent files are intentionally excluded (they're not search results).
   const today = new Date().toISOString().slice(0, 10);
-  const entries: { path: string; priority: string }[] = [
-    { path: "/", priority: "1.0" },
-    { path: GLOSSARY_PATH, priority: "0.7" },
+  const dates = gitLastmodMap(REPO_ROOT);
+  // Aggregate pages (home, glossary, providers, parameters) track the build date;
+  // each model URL carries the commit date of its own YAML so lastmod stays honest.
+  const entries: { path: string; priority: string; lastmod: string }[] = [
+    { path: "/", priority: "1.0", lastmod: today },
+    { path: GLOSSARY_PATH, priority: "0.7", lastmod: today },
     ...uniqueProviders(models).map((provider) => ({
       path: providerPagePath(provider),
       priority: "0.8",
+      lastmod: today,
     })),
-    ...models.map((model) => ({ path: modelPagePath(model), priority: "0.6" })),
+    ...buildParameterIndex(models).map((detail) => ({
+      path: parameterPagePath(detail.path),
+      priority: "0.7",
+      lastmod: today,
+    })),
+    ...models.map((model) => ({
+      path: modelPagePath(model),
+      priority: "0.6",
+      lastmod: modelLastmod(model, dates, today),
+    })),
   ];
   const body = entries
     .map(
-      ({ path: loc, priority }) =>
-        `  <url><loc>${SITE_URL}${loc}</loc><lastmod>${today}</lastmod><priority>${priority}</priority></url>`,
+      ({ path: loc, priority, lastmod }) =>
+        `  <url><loc>${SITE_URL}${loc}</loc><lastmod>${lastmod}</lastmod><priority>${priority}</priority></url>`,
     )
     .join("\n");
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
@@ -95,6 +117,24 @@ async function writeHtmlPages(models: Model[]): Promise<void> {
 
   await fs.writeFile(path.join(DIST_DIR, "glossary.html"), await renderGlossaryPage(models), "utf8");
   await fs.writeFile(path.join(DIST_DIR, "api.html"), await renderApiPage(models), "utf8");
+}
+
+async function writeParameterPages(models: Model[]): Promise<void> {
+  const details = buildParameterIndex(models);
+  const dir = path.join(DIST_DIR, "parameters");
+  await fs.mkdir(dir, { recursive: true });
+  const seen = new Set<string>();
+  for (const detail of details) {
+    if (seen.has(detail.slug)) {
+      throw new Error(`Duplicate parameter slug "${detail.slug}" (path "${detail.path}")`);
+    }
+    seen.add(detail.slug);
+    await fs.writeFile(
+      path.join(dir, `${detail.slug}.html`),
+      await renderParameterPage(detail, models),
+      "utf8",
+    );
+  }
 }
 
 async function writeApiIndex(modelCount: number): Promise<void> {
@@ -158,8 +198,9 @@ export async function build(): Promise<{ models: number }> {
   console.log("Bundling client + styles...");
   await Promise.all([bundleClientScript(), compileStyles(), copyStaticAssets()]);
 
-  console.log("Rendering model, provider, and glossary pages...");
+  console.log("Rendering model, provider, parameter, and glossary pages...");
   await writeHtmlPages(models);
+  await writeParameterPages(models);
 
   await writeLlmsFiles(models);
   await writeRobotsAndSitemap(models);

--- a/src/build/lastmod.ts
+++ b/src/build/lastmod.ts
@@ -1,0 +1,45 @@
+// Per-file last-modified dates for the sitemap, read from git so each model URL's
+// <lastmod> reflects when its YAML actually changed — not the build time. Falls back
+// gracefully (empty map → callers use the build date) when git or history is absent,
+// so the build never depends on a full clone.
+
+import { execFileSync } from "node:child_process";
+import { authSuffix, type Model } from "../schema/model.js";
+
+/** Repo-relative path of a model's source YAML, e.g. models/openai/gpt-4o.yaml. */
+export function modelSourcePath(model: Model): string {
+  return `models/${model.provider}/${model.model}${authSuffix(model.authType)}.yaml`;
+}
+
+/**
+ * Map of repo-relative path → ISO date (YYYY-MM-DD) of the most recent commit that
+ * touched it, for everything under models/. One `git log` call; empty on any failure.
+ */
+export function gitLastmodMap(repoRoot: string): Map<string, string> {
+  const map = new Map<string, string>();
+  let out: string;
+  try {
+    out = execFileSync(
+      "git",
+      ["-C", repoRoot, "log", "--format=%cs", "--name-only", "--", "models"],
+      { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+    );
+  } catch {
+    return map;
+  }
+  let date = "";
+  for (const line of out.split("\n")) {
+    const trimmed = line.trim();
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      date = trimmed;
+    } else if (trimmed && date && !map.has(trimmed)) {
+      map.set(trimmed, date);
+    }
+  }
+  return map;
+}
+
+/** A model's git lastmod date, or the supplied fallback when unknown. */
+export function modelLastmod(model: Model, dates: Map<string, string>, fallback: string): string {
+  return dates.get(modelSourcePath(model)) ?? fallback;
+}

--- a/src/build/render-glossary.ts
+++ b/src/build/render-glossary.ts
@@ -11,11 +11,11 @@ import { hubLinks, renderShell, viewHelpers } from "./render.js";
 const GLOSSARY_TITLE = `LLM parameter glossary · ${SITE_NAME}`;
 
 const GLOSSARY_DESCRIPTION =
-  "Every LLM API parameter in the catalog, defined: what temperature, top_p, max_tokens, reasoning effort and the rest do, with their types and which models support them.";
+  "Every LLM API parameter in the catalog, defined: what temperature, top_p, max_tokens, reasoning effort and the rest do. Open any parameter for its default and range on every model that accepts it.";
 
 function glossaryIntro(groups: GlossaryGroup[]): string {
   const total = groups.reduce((sum, groupItem) => sum + groupItem.entries.length, 0);
-  return `${total} parameters appear across the catalog. This page defines each one, grouped by what it controls, and notes its type and how many models expose it. Definitions come from the same community-maintained data as the JSON API.`;
+  return `${total} parameters appear across the catalog. This page defines each one, grouped by what it controls. Open any parameter for the full breakdown — its default, range, and conditions on every model that accepts it. Definitions come from the same community-maintained data as the JSON API.`;
 }
 
 export async function renderGlossaryPage(allModels: Model[]): Promise<string> {

--- a/src/build/render-model.ts
+++ b/src/build/render-model.ts
@@ -1,10 +1,12 @@
 import path from "node:path";
 import ejs from "ejs";
-import { modelLabel, providerLabel } from "../data/display.js";
+import { describeApplicability } from "../data/applicability.js";
+import { modelLabel, paramGroupLabel, providerLabel } from "../data/display.js";
+import { groupParams } from "../data/group.js";
 import { VIEWS_DIR } from "../data/paths.js";
 import { SITE_NAME, SITE_URL } from "../data/site.js";
 import { absolute, modelJsonPath, modelPagePath, providerPagePath } from "../data/urls.js";
-import { modelId, type Model } from "../schema/model.js";
+import { modelId, type Model, type Parameter } from "../schema/model.js";
 import { buildModelStructuredData } from "./structured-data.js";
 import { hubLinks, renderShell, viewHelpers } from "./render.js";
 
@@ -27,6 +29,40 @@ export function modelPageDescription(model: Model): string {
   const more = paths.length > 4 ? ", and more" : "";
   const count = `${model.params.length} API parameter${model.params.length === 1 ? "" : "s"}`;
   return `All ${count} for ${who}: ${sample}${more}. See each type, default, range, and the conditions that gate it.`;
+}
+
+/** A short, factual clause describing a parameter's default, range, values, and gate. */
+function paramFact(param: Parameter): string {
+  const bits: string[] = [];
+  if (param.default !== undefined) bits.push(`defaults to ${JSON.stringify(param.default)}`);
+  if ((param.type === "integer" || param.type === "number") && param.range) {
+    const { min, max } = param.range;
+    if (min !== undefined && max !== undefined) bits.push(`range ${min}–${max}`);
+    else if (min !== undefined) bits.push(`minimum ${min}`);
+    else if (max !== undefined) bits.push(`maximum ${max}`);
+  }
+  if (param.type === "enum") {
+    const values = param.values.map((value) => JSON.stringify(value));
+    const shown = values.slice(0, 6).join(", ");
+    bits.push(`accepts ${shown}${values.length > 6 ? ", …" : ""}`);
+  }
+  const applicability = describeApplicability(param.applicability);
+  if (applicability.only.length > 0) bits.push(`only when ${applicability.only.join(" and ")}`);
+  else if (applicability.except.length > 0) bits.push(`not when ${applicability.except.join(" or ")}`);
+  return bits.join(", ");
+}
+
+export interface ParamProseGroup {
+  label: string;
+  clauses: { path: string; fact: string }[];
+}
+
+/** Per-group prose summary of the parameter set — readable, exact-match-friendly text. */
+export function modelParamProse(model: Model): ParamProseGroup[] {
+  return groupParams(model.params).map(({ group, params }) => ({
+    label: paramGroupLabel(group),
+    clauses: params.map((param) => ({ path: param.path, fact: paramFact(param) })),
+  }));
 }
 
 export function modelIntro(model: Model): string {
@@ -57,6 +93,7 @@ export async function renderModelPage(model: Model, allModels: Model[]): Promise
     jsonPath: modelJsonPath(model),
     modelJson: JSON.stringify({ $schema: "https://modelparams.dev/api/v1/schema.json", ...model }, null, 2),
     isSubscription: model.authType === "subscription",
+    proseGroups: modelParamProse(model),
   });
 
   const description = modelPageDescription(model);

--- a/src/build/render-parameter.ts
+++ b/src/build/render-parameter.ts
@@ -1,0 +1,90 @@
+import path from "node:path";
+import ejs from "ejs";
+import { paramGroupLabel } from "../data/display.js";
+import {
+  buildParameterIndex,
+  modelsWithoutParameter,
+  type ParameterDetail,
+} from "../data/parameters.js";
+import { VIEWS_DIR } from "../data/paths.js";
+import { SITE_NAME, SITE_URL } from "../data/site.js";
+import { GLOSSARY_PATH, absolute, parameterPagePath } from "../data/urls.js";
+import { type Model, type Parameter } from "../schema/model.js";
+import { buildParameterStructuredData } from "./structured-data.js";
+import { hubLinks, renderShell, viewHelpers } from "./render.js";
+
+const RELATED_LIMIT = 12;
+
+export function parameterPageTitle(detail: ParameterDetail): string {
+  return `${detail.label} (${detail.path}) parameter — defaults & ranges · ${SITE_NAME}`;
+}
+
+export function parameterPageDescription(detail: ParameterDetail): string {
+  const group = paramGroupLabel(detail.group).toLowerCase();
+  const models = `${detail.modelCount} model${detail.modelCount === 1 ? "" : "s"}`;
+  return `${detail.label} (${detail.path}) is an LLM ${group} parameter. Compare its type, default, and valid range across the ${models} in the catalog that accept it.`;
+}
+
+function rangeOf(param: Parameter): { min?: number; max?: number } | undefined {
+  return (param.type === "integer" || param.type === "number") && param.range
+    ? param.range
+    : undefined;
+}
+
+/** Most common default across the models that set one, or a "varies" note. */
+function defaultSummary(detail: ParameterDetail): string {
+  const defaults = detail.usages
+    .map((u) => u.param.default)
+    .filter((d): d is NonNullable<typeof d> => d !== undefined)
+    .map((d) => JSON.stringify(d));
+  if (defaults.length === 0) return "no default";
+  const unique = [...new Set(defaults)];
+  return unique.length === 1 ? unique[0]! : "varies by model";
+}
+
+/** Widest numeric span any model allows, e.g. "0 – 2". */
+function rangeSummary(detail: ParameterDetail): string {
+  let min: number | undefined;
+  let max: number | undefined;
+  for (const usage of detail.usages) {
+    const range = rangeOf(usage.param);
+    if (range?.min !== undefined) min = min === undefined ? range.min : Math.min(min, range.min);
+    if (range?.max !== undefined) max = max === undefined ? range.max : Math.max(max, range.max);
+  }
+  if (min === undefined && max === undefined) return "";
+  return `${min ?? "−∞"} – ${max ?? "+∞"}`;
+}
+
+function relatedParameters(detail: ParameterDetail, allModels: Model[]): ParameterDetail[] {
+  return buildParameterIndex(allModels)
+    .filter((other) => other.group === detail.group && other.path !== detail.path)
+    .slice(0, RELATED_LIMIT);
+}
+
+export async function renderParameterPage(
+  detail: ParameterDetail,
+  allModels: Model[],
+): Promise<string> {
+  const description = parameterPageDescription(detail);
+  const body = await ejs.renderFile(path.join(VIEWS_DIR, "parameter.ejs"), {
+    detail,
+    helpers: viewHelpers,
+    groupLabel: paramGroupLabel(detail.group),
+    defaultSummary: defaultSummary(detail),
+    rangeSummary: rangeSummary(detail),
+    related: relatedParameters(detail, allModels),
+    notDocumented: modelsWithoutParameter(detail, allModels),
+    glossaryPath: GLOSSARY_PATH,
+  });
+
+  return renderShell(
+    {
+      title: parameterPageTitle(detail),
+      description,
+      canonicalUrl: absolute(SITE_URL, parameterPagePath(detail.path)),
+      structuredData: buildParameterStructuredData(detail, description, SITE_URL),
+      providerHubs: hubLinks(allModels),
+    },
+    body,
+  );
+}

--- a/src/build/render.ts
+++ b/src/build/render.ts
@@ -17,7 +17,13 @@ import { usageGuideMarkdown } from "../data/llms.js";
 import { logoFor } from "../data/logos.js";
 import { VIEWS_DIR } from "../data/paths.js";
 import { OG_IMAGE_PATH, SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "../data/site.js";
-import { absolute, modelPagePath, providerPagePath } from "../data/urls.js";
+import {
+  absolute,
+  modelPagePath,
+  parameterAnchorId,
+  parameterPagePath,
+  providerPagePath,
+} from "../data/urls.js";
 import { modelId, type Catalog, type Model } from "../schema/model.js";
 import { buildHomeStructuredData } from "./structured-data.js";
 
@@ -38,6 +44,8 @@ export const viewHelpers = {
   groupParams,
   logoFor,
   modelPagePath,
+  parameterPagePath,
+  parameterAnchorId,
   providerPagePath,
 };
 

--- a/src/build/structured-data.ts
+++ b/src/build/structured-data.ts
@@ -3,12 +3,14 @@
 
 import { modelLabel, paramLabel, providerLabel } from "../data/display.js";
 import type { GlossaryGroup } from "../data/glossary.js";
+import type { ParameterDetail } from "../data/parameters.js";
 import { SITE_DESCRIPTION, SITE_NAME } from "../data/site.js";
 import {
   GLOSSARY_PATH,
   absolute,
   modelJsonPath,
   modelPagePath,
+  parameterPagePath,
   providerPagePath,
 } from "../data/urls.js";
 import { type Model } from "../schema/model.js";
@@ -160,6 +162,40 @@ export function buildProviderStructuredData(
     { name: providerLabel(provider), path: providerPagePath(provider) },
   ]);
   return graph([crumbs, itemList]);
+}
+
+export function buildParameterStructuredData(
+  detail: ParameterDetail,
+  description: string,
+  siteUrl: string,
+): string {
+  const pagePath = parameterPagePath(detail.path);
+  const definedTerm = {
+    "@type": "DefinedTerm",
+    "@id": `${siteUrl}${pagePath}#term`,
+    name: detail.label,
+    termCode: detail.path,
+    description,
+    url: absolute(siteUrl, pagePath),
+    inDefinedTermSet: `${siteUrl}${GLOSSARY_PATH}#termset`,
+  };
+  const itemList = {
+    "@type": "ItemList",
+    name: `Models that support ${detail.path}`,
+    numberOfItems: detail.modelCount,
+    itemListElement: detail.usages.map((usage, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: absolute(siteUrl, modelPagePath(usage.model)),
+      name: `${usage.providerName} ${usage.modelName}`,
+    })),
+  };
+  const crumbs = breadcrumb(siteUrl, [
+    { name: "Home", path: "/" },
+    { name: "Glossary", path: GLOSSARY_PATH },
+    { name: detail.label, path: pagePath },
+  ]);
+  return graph([crumbs, definedTerm, itemList]);
 }
 
 export function buildGlossaryStructuredData(groups: GlossaryGroup[], siteUrl: string): string {

--- a/src/data/llms.ts
+++ b/src/data/llms.ts
@@ -2,6 +2,8 @@ import { describeApplicability } from "./applicability.js";
 import { buildProviderFacets } from "./catalog.js";
 import { authLabel, modelLabel, paramGroupLabel, providerLabel } from "./display.js";
 import { groupParams } from "./group.js";
+import { buildParameterIndex } from "./parameters.js";
+import { parameterPagePath } from "./urls.js";
 import { modelId, type Model, type Parameter } from "../schema/model.js";
 
 const REPO_URL = "https://github.com/mnfst/modelparams.dev";
@@ -168,8 +170,14 @@ export function buildLlmsTxt(siteUrl: string, models: Model[]): string {
     "## Guides",
     `- [Usage guide + full parameter dump](${siteUrl}/llms-full.txt): How to call the API plus every model's parameters inline.`,
     "",
-    "## Models",
+    "## Parameters",
   ];
+  for (const detail of buildParameterIndex(models)) {
+    lines.push(
+      `- [${detail.path}](${siteUrl}${parameterPagePath(detail.path)}): ${detail.label} — default, range, and the ${plural(detail.modelCount, "model")} that accept it.`,
+    );
+  }
+  lines.push("", "## Models");
   for (const model of sortById(models)) {
     lines.push(
       `- [${modelId(model)}](${modelJsonUrl(siteUrl, model)}): ${modelTitle(model)} — ${plural(model.params.length, "parameter")}.`,

--- a/src/data/parameters.ts
+++ b/src/data/parameters.ts
@@ -1,0 +1,145 @@
+// Per-parameter index: one detail object per unique parameter path, carrying the
+// full list of models that expose it (with each model's own type, default, range
+// and conditions). Powers the /parameters/<slug> pages and their structured data.
+//
+// buildGlossary aggregates the same data down to one summary row per path for the
+// /glossary hub; this keeps the per-model detail the dedicated pages need.
+
+import { modelLabel, paramLabel, providerLabel } from "./display.js";
+import { parameterSlug } from "./urls.js";
+import { ParameterGroup, modelId, type Model, type Parameter } from "../schema/model.js";
+
+export interface ParameterUsage {
+  id: string;
+  provider: string;
+  providerName: string;
+  modelName: string;
+  model: Model;
+  param: Parameter;
+}
+
+export interface ParameterDetail {
+  path: string;
+  slug: string;
+  label: string;
+  group: string;
+  description: string;
+  types: string[];
+  providers: string[];
+  modelCount: number;
+  usages: ParameterUsage[];
+}
+
+interface Bucket {
+  path: string;
+  group: string;
+  labels: Map<string, number>;
+  descriptions: Map<string, number>;
+  types: Set<string>;
+  providers: Set<string>;
+  usages: ParameterUsage[];
+}
+
+/** Pick the most frequent string, breaking ties toward the more detailed one. */
+function mostCommon(counts: Map<string, number>): string {
+  return (
+    [...counts.entries()].sort((a, b) => b[1] - a[1] || b[0].length - a[0].length)[0]?.[0] ?? ""
+  );
+}
+
+function aggregate(models: Model[]): Map<string, Bucket> {
+  const acc = new Map<string, Bucket>();
+  for (const model of models) {
+    for (const param of model.params) {
+      let bucket = acc.get(param.path);
+      if (!bucket) {
+        bucket = {
+          path: param.path,
+          group: param.group,
+          labels: new Map(),
+          descriptions: new Map(),
+          types: new Set(),
+          providers: new Set(),
+          usages: [],
+        };
+        acc.set(param.path, bucket);
+      }
+      bucket.labels.set(param.label, (bucket.labels.get(param.label) ?? 0) + 1);
+      bucket.descriptions.set(
+        param.description,
+        (bucket.descriptions.get(param.description) ?? 0) + 1,
+      );
+      bucket.types.add(param.type);
+      bucket.providers.add(model.provider);
+      bucket.usages.push({
+        id: modelId(model),
+        provider: model.provider,
+        providerName: providerLabel(model.provider),
+        modelName: modelLabel(model),
+        model,
+        param,
+      });
+    }
+  }
+  return acc;
+}
+
+function toDetail(bucket: Bucket): ParameterDetail {
+  const usages = [...bucket.usages].sort(
+    (a, b) =>
+      a.providerName.localeCompare(b.providerName) || a.modelName.localeCompare(b.modelName),
+  );
+  return {
+    path: bucket.path,
+    slug: parameterSlug(bucket.path),
+    label: paramLabel(bucket.path, mostCommon(bucket.labels)),
+    group: bucket.group,
+    description: mostCommon(bucket.descriptions),
+    types: [...bucket.types].sort(),
+    providers: [...bucket.providers].sort(),
+    modelCount: new Set(bucket.usages.map((u) => u.id)).size,
+    usages,
+  };
+}
+
+const GROUP_ORDER = new Map<string, number>(
+  ParameterGroup.options.map((group, index) => [group, index]),
+);
+
+/**
+ * Every unique parameter, ordered by schema group then by how many models expose
+ * it (most-supported first) — the same ordering the glossary uses, so the hub and
+ * the detail pages agree.
+ */
+export function buildParameterIndex(models: Model[]): ParameterDetail[] {
+  return [...aggregate(models).values()]
+    .map(toDetail)
+    .sort(
+      (a, b) =>
+        (GROUP_ORDER.get(a.group) ?? 0) - (GROUP_ORDER.get(b.group) ?? 0) ||
+        b.modelCount - a.modelCount ||
+        a.path.localeCompare(b.path),
+    );
+}
+
+/** Models that don't (yet) document a given parameter path, grouped by provider. */
+export function modelsWithoutParameter(
+  detail: ParameterDetail,
+  allModels: Model[],
+): { provider: string; providerName: string; models: Model[] }[] {
+  const has = new Set(detail.usages.map((u) => u.id));
+  const byProvider = new Map<string, Model[]>();
+  for (const model of allModels) {
+    if (has.has(modelId(model))) continue;
+    const list = byProvider.get(model.provider) ?? [];
+    list.push(model);
+    byProvider.set(model.provider, list);
+  }
+  return [...byProvider.entries()]
+    .map(([provider, models]) => ({
+      provider,
+      providerName: providerLabel(provider),
+      models: models.sort((a, b) => modelLabel(a).localeCompare(modelLabel(b))),
+    }))
+    .sort((a, b) => a.providerName.localeCompare(b.providerName));
+}

--- a/src/data/urls.ts
+++ b/src/data/urls.ts
@@ -16,8 +16,31 @@ export function providerPagePath(provider: string): string {
   return `/providers/${provider}`;
 }
 
-/** Parameter glossary page. */
+/** Parameter glossary page — the hub that links out to each parameter page. */
 export const GLOSSARY_PATH = "/glossary";
+
+/**
+ * URL-safe slug for a parameter path: lowercased, with nested-path dots turned into
+ * hyphens, e.g. `thinking.type` → `thinking-type`. Underscores are kept so that
+ * `top_p` stays `top_p` and a dotted path never collides with its snake_case twin
+ * (e.g. `reasoning.effort` → `reasoning-effort` vs `reasoning_effort`).
+ */
+export function parameterSlug(path: string): string {
+  return path
+    .toLowerCase()
+    .replace(/\./g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** Canonical HTML page for a single parameter, e.g. /parameters/temperature. */
+export function parameterPagePath(path: string): string {
+  return `/parameters/${parameterSlug(path)}`;
+}
+
+/** In-page anchor id for a parameter row on a model page, e.g. param-top-p. */
+export function parameterAnchorId(path: string): string {
+  return `param-${parameterSlug(path)}`;
+}
 
 /** Existing JSON API endpoint for a model (unchanged; referenced for linking). */
 export function modelJsonPath(model: ModelRef): string {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2,10 +2,12 @@ import express from "express";
 import { buildCapabilityFacets, buildCatalog, buildProviderFacets } from "../data/catalog.js";
 import { buildLlmsFullTxt, buildLlmsTxt } from "../data/llms.js";
 import { findModelParams } from "../data/model-params.js";
+import { buildParameterIndex } from "../data/parameters.js";
 import { DIST_ASSETS_DIR } from "../data/paths.js";
 import { buildModelJsonSchema } from "../schema/generate.js";
 import { renderIndex } from "../build/render.js";
 import { renderModelPage } from "../build/render-model.js";
+import { renderParameterPage } from "../build/render-parameter.js";
 import { renderProviderPage } from "../build/render-provider.js";
 import { renderGlossaryPage } from "../build/render-glossary.js";
 import { renderApiPage } from "../build/render-api.js";
@@ -55,6 +57,21 @@ export function makeApp(loadModels: LoadModels): express.Express {
       const models = await loadModels();
       res.setHeader("Cache-Control", "no-store");
       res.type("html").send(await renderGlossaryPage(models));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get("/parameters/:slug", async (req, res, next) => {
+    try {
+      const models = await loadModels();
+      const detail = buildParameterIndex(models).find((d) => d.slug === req.params.slug);
+      if (!detail) {
+        res.status(404).type("text/plain").send("Unknown parameter");
+        return;
+      }
+      res.setHeader("Cache-Control", "no-store");
+      res.type("html").send(await renderParameterPage(detail, models));
     } catch (err) {
       next(err);
     }

--- a/src/views/glossary.ejs
+++ b/src/views/glossary.ejs
@@ -18,14 +18,14 @@
     <% for (const entry of groupItem.entries) { %>
     <div class="py-3 sm:flex sm:gap-6">
       <dt class="sm:w-64 sm:shrink-0">
-        <span class="font-medium text-slate-900 dark:text-slate-100"><%= entry.label %></span>
+        <a href="<%= helpers.parameterPagePath(entry.path) %>" class="font-medium text-accent hover:text-accent-hover"><%= entry.label %></a>
         <% for (const t of entry.types) { %> <span class="rounded bg-warm-tag px-1.5 py-0.5 font-mono text-[10px] text-slate-600 dark:bg-[#262626] dark:text-slate-400"><%= t %></span><% } %>
         <code class="mt-0.5 block font-mono text-xs text-slate-500 dark:text-slate-400"><%= entry.path %></code>
       </dt>
       <dd class="mt-1 flex-1 text-sm text-slate-700 dark:text-slate-300 sm:mt-0">
         <p><%= entry.description %></p>
         <p class="mt-2 text-xs text-slate-500 dark:text-slate-400">
-          <%= entry.modelCount %> model<%= entry.modelCount === 1 ? "" : "s" %> <span class="mx-1 text-slate-400 dark:text-slate-600">/</span>
+          <a href="<%= helpers.parameterPagePath(entry.path) %>" class="font-medium text-accent hover:text-accent-hover"><%= entry.modelCount %> model<%= entry.modelCount === 1 ? "" : "s" %></a> <span class="mx-1 text-slate-400 dark:text-slate-600">/</span>
           <% entry.providers.forEach(function (provider, i) { %><a href="<%= helpers.providerPagePath(provider) %>" class="text-accent hover:text-accent-hover"><%= helpers.providerLabel(provider) %></a><%= i < entry.providers.length - 1 ? ", " : "" %><% }) %>
         </p>
       </dd>

--- a/src/views/model.ejs
+++ b/src/views/model.ejs
@@ -28,15 +28,40 @@
   </p>
 </section>
 
+<% if (model.params.length >= 2) { %>
+<nav class="mt-6 flex flex-wrap gap-2" aria-label="Jump to parameter">
+  <% for (const param of model.params) { %>
+  <a href="#<%= helpers.parameterAnchorId(param.path) %>" class="rounded-full border border-slate-200 bg-white px-2.5 py-1 font-mono text-xs text-slate-600 hover:border-slate-300 hover:text-accent dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:hover:border-slate-700"><%= param.path %></a>
+  <% } %>
+</nav>
+<% } %>
+
 <section class="mt-8" aria-label="Parameters">
   <% if (model.params.length === 0) { %>
   <p class="text-sm italic text-slate-500 dark:text-slate-400">
     No parameters documented yet.
   </p>
   <% } else { %>
-  <%- include("partials/param_table", { params: model.params, helpers: helpers }) %>
+  <%- include("partials/param_table", { params: model.params, helpers: helpers, detail: true }) %>
   <% } %>
 </section>
+
+<% if (proseGroups.length > 0) { %>
+<section class="mt-10" aria-label="Parameter summary">
+  <h2 class="text-slate-900 dark:text-slate-100"><%= providerName %> <%= modelName %> parameters in brief</h2>
+  <p class="mt-2 max-w-2xl text-sm text-slate-600 dark:text-slate-300">
+    <%= providerName %> <%= modelName %><% if (isSubscription) { %> via subscription<% } %> documents <%= model.params.length %> API parameter<%= model.params.length === 1 ? "" : "s" %>, grouped by what they control:
+  </p>
+  <ul class="mt-3 max-w-2xl space-y-2 text-sm text-slate-700 dark:text-slate-300">
+    <% for (const grp of proseGroups) { %>
+    <li>
+      <span class="font-medium text-slate-900 dark:text-slate-100"><%= grp.label %>:</span>
+      <% grp.clauses.forEach(function (clause, i) { %><code class="font-mono text-slate-600 dark:text-slate-300"><%= clause.path %></code><% if (clause.fact) { %> <%= clause.fact %><% } %><%= i < grp.clauses.length - 1 ? "; " : "." %> <% }) %>
+    </li>
+    <% } %>
+  </ul>
+</section>
+<% } %>
 
 <h2 class="mt-8 text-slate-900 dark:text-slate-100">Resources</h2>
 <div class="mt-3 grid grid-cols-1 text-sm sm:grid-cols-2 lg:grid-cols-4">

--- a/src/views/parameter.ejs
+++ b/src/views/parameter.ejs
@@ -1,0 +1,156 @@
+<%- include("partials/breadcrumbs", { items: [
+  { name: "Home", href: "/" },
+  { name: "Glossary", href: glossaryPath },
+  { name: detail.label }
+] }) %>
+
+<section class="pt-6">
+  <div class="flex flex-wrap items-center gap-2.5">
+    <span class="inline-flex items-center gap-1.5 bg-slate-900 px-2.5 py-1 text-xs font-medium text-white dark:bg-white dark:text-slate-900">
+      <span class="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center" aria-hidden="true"><%- helpers.paramGroupIcon(detail.group) %></span>
+      <%= groupLabel %>
+    </span>
+    <% for (const t of detail.types) { %>
+    <span class="rounded bg-warm-tag px-1.5 py-0.5 font-mono text-[10px] text-slate-600 dark:bg-[#262626] dark:text-slate-400"><%= t %></span>
+    <% } %>
+    <span class="text-xs tabular-nums text-slate-500 dark:text-slate-400"><%= detail.modelCount %> model<%= detail.modelCount === 1 ? "" : "s" %></span>
+  </div>
+  <h1 class="mt-3 flex flex-wrap items-baseline gap-x-3 gap-y-1 text-balance font-bold tracking-tight">
+    <span><%= detail.label %></span>
+    <code class="font-mono text-base font-normal text-slate-500 dark:text-slate-400"><%= detail.path %></code>
+  </h1>
+  <p class="mt-3 max-w-2xl text-pretty text-sm text-slate-600 dark:text-slate-300 sm:text-base">
+    <%= detail.description %>
+  </p>
+  <dl class="mt-4 flex flex-wrap gap-x-8 gap-y-2 text-sm">
+    <div class="flex items-center gap-2">
+      <dt class="text-slate-500 dark:text-slate-400">Type</dt>
+      <dd class="font-mono text-slate-900 dark:text-slate-100"><%= detail.types.join(", ") %></dd>
+    </div>
+    <div class="flex items-center gap-2">
+      <dt class="text-slate-500 dark:text-slate-400">Default</dt>
+      <dd class="font-mono text-slate-900 dark:text-slate-100"><%= defaultSummary %></dd>
+    </div>
+    <% if (rangeSummary) { %>
+    <div class="flex items-center gap-2">
+      <dt class="text-slate-500 dark:text-slate-400">Range</dt>
+      <dd class="font-mono text-slate-900 dark:text-slate-100"><%= rangeSummary %></dd>
+    </div>
+    <% } %>
+  </dl>
+</section>
+
+<section class="mt-8" aria-label="Default and range by model">
+  <h2 class="text-slate-900 dark:text-slate-100"><code class="font-mono"><%= detail.path %></code> by model</h2>
+  <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">
+    The exact type, default, range, and conditions for <code class="font-mono"><%= detail.path %></code> on each model that documents it.
+  </p>
+  <div class="-mx-1 mt-4 overflow-x-auto px-1">
+    <table class="params-table w-full min-w-[48rem] text-left text-sm">
+      <thead class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        <tr>
+          <th scope="col" class="py-2 pr-3 font-medium">Model</th>
+          <th scope="col" class="w-32 py-2 pr-3 font-medium">Provider</th>
+          <th scope="col" class="w-28 py-2 pr-3 font-medium">Type</th>
+          <th scope="col" class="w-20 py-2 pr-3 font-medium">Default</th>
+          <th scope="col" class="w-40 py-2 pr-3 font-medium">Range / values</th>
+          <th scope="col" class="w-56 py-2 font-medium">Condition</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% for (const usage of detail.usages) { %>
+        <%
+          const param = usage.param;
+          const applicability = helpers.describeApplicability(param.applicability);
+          const hasCondition = applicability.only.length > 0 || applicability.except.length > 0;
+          let rangeText = "—";
+          if (param.type === "enum") {
+            rangeText = param.values.join(" | ");
+          } else if ((param.type === "number" || param.type === "integer") && param.range) {
+            const lo = param.range.min !== undefined ? param.range.min : "−∞";
+            const hi = param.range.max !== undefined ? param.range.max : "+∞";
+            rangeText = `${lo}…${hi}${param.range.step ? ` step ${param.range.step}` : ""}`;
+          }
+        %>
+        <tr>
+          <td class="py-2 pr-3 align-top">
+            <a href="<%= helpers.modelPagePath(usage.model) %>" class="font-medium text-accent hover:text-accent-hover"><%= usage.modelName %></a>
+            <% if (usage.model.authType === "subscription") { %>
+            <span class="ml-1.5 rounded bg-emerald-100 px-1 py-0.5 text-[10px] font-medium text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-200"><%= helpers.authLabel(usage.model.authType) %></span>
+            <% } %>
+          </td>
+          <td class="py-2 pr-3 align-top">
+            <a href="<%= helpers.providerPagePath(usage.provider) %>" class="text-slate-600 hover:text-accent dark:text-slate-300"><%= usage.providerName %></a>
+          </td>
+          <td class="py-2 pr-3 align-top font-mono text-xs text-slate-600 dark:text-slate-300"><%= param.type %></td>
+          <td class="py-2 pr-3 align-top font-mono text-xs text-slate-600 dark:text-slate-300">
+            <% if (param.default === undefined) { %><span class="text-slate-400">—</span><% } else { %><%= JSON.stringify(param.default) %><% } %>
+          </td>
+          <td class="py-2 pr-3 align-top font-mono text-xs text-slate-600 dark:text-slate-300"><%= rangeText %></td>
+          <td class="py-2 align-top text-xs leading-snug text-slate-700 dark:text-slate-300">
+            <% if (!hasCondition) { %>
+            <span class="text-slate-300 dark:text-slate-700" aria-label="No condition">—</span>
+            <% } else { %>
+            <% if (applicability.only.length > 0) { %><div><span class="font-semibold">Only when</span> <%= applicability.only.join(" and ") %></div><% } %>
+            <% if (applicability.except.length > 0) { %><div><span class="font-semibold">Not when</span> <%= applicability.except.join(" or ") %></div><% } %>
+            <% } %>
+          </td>
+        </tr>
+        <% } %>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<% if (notDocumented.length > 0) { %>
+<section class="mt-10">
+  <details class="group">
+    <summary class="flex cursor-pointer list-none items-center gap-2 text-slate-900 dark:text-slate-100">
+      <svg class="h-4 w-4 shrink-0 text-slate-400 transition-transform group-open:rotate-90" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><path d="M6.5 4l3.5 4-3.5 4" /></svg>
+      <h2 class="text-base font-semibold">Models without <code class="font-mono"><%= detail.path %></code> documented yet</h2>
+    </summary>
+    <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
+      These models don't list <code class="font-mono"><%= detail.path %></code> in the catalog. That may mean the provider doesn't accept it, or it simply hasn't been added yet — the data is community-maintained.
+    </p>
+    <% for (const grp of notDocumented) { %>
+    <div class="mt-3">
+      <p class="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400"><%= grp.providerName %></p>
+      <div class="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-sm">
+        <% for (const m of grp.models) { %>
+        <a href="<%= helpers.modelPagePath(m) %>" class="text-accent hover:text-accent-hover"><%= helpers.modelLabel(m) %></a>
+        <% } %>
+      </div>
+    </div>
+    <% } %>
+  </details>
+</section>
+<% } %>
+
+<% if (related.length > 0) { %>
+<section class="mt-10">
+  <h2 class="text-slate-900 dark:text-slate-100">Related <%= groupLabel.toLowerCase() %> parameters</h2>
+  <div class="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+    <% for (const other of related) { %>
+    <a href="<%= helpers.parameterPagePath(other.path) %>" class="flex flex-col border border-slate-200 bg-white px-4 py-3 transition-colors hover:border-slate-300 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-700">
+      <span class="truncate text-sm font-medium text-slate-900 dark:text-slate-100"><%= other.label %></span>
+      <code class="mt-0.5 truncate font-mono text-xs text-slate-500 dark:text-slate-400"><%= other.path %></code>
+    </a>
+    <% } %>
+  </div>
+</section>
+<% } %>
+
+<section class="mt-10 border-t border-slate-200 pt-6 dark:border-slate-800">
+  <h2 class="text-slate-900 dark:text-slate-100">Resources</h2>
+  <div class="mt-3 grid grid-cols-2 text-sm lg:grid-cols-3">
+    <a href="<%= glossaryPath %>" class="inline-flex items-center justify-center gap-2 border border-slate-200 bg-white px-4 py-3 text-accent hover:bg-warm-hover hover:text-accent-hover dark:border-slate-800 dark:bg-slate-900 dark:hover:bg-slate-800 sm:-mr-px">
+      All parameters
+    </a>
+    <a href="/api" class="inline-flex items-center justify-center gap-2 border border-slate-200 bg-white px-4 py-3 text-accent hover:bg-warm-hover hover:text-accent-hover dark:border-slate-800 dark:bg-slate-900 dark:hover:bg-slate-800 sm:-mr-px">
+      Use the API
+    </a>
+    <a href="/" class="inline-flex items-center justify-center gap-2 border border-slate-200 bg-white px-4 py-3 text-accent hover:bg-warm-hover hover:text-accent-hover dark:border-slate-800 dark:bg-slate-900 dark:hover:bg-slate-800">
+      Full catalog
+    </a>
+  </div>
+</section>

--- a/src/views/partials/param_table.ejs
+++ b/src/views/partials/param_table.ejs
@@ -1,5 +1,9 @@
 <%
   const groups = helpers.groupParams(params);
+  // `detail` mode (model pages) links each param to its page and gives the row an
+  // anchor id. Off by default so the homepage's repeated tables stay link-light
+  // and don't emit duplicate ids.
+  const detailMode = typeof detail !== "undefined" && detail;
 %>
 <div class="-mx-1 overflow-x-auto px-1">
   <% for (const groupItem of groups) { %>
@@ -39,11 +43,16 @@
             typeDetail = `(${lo}…${hi}${param.range.step ? ` step ${param.range.step}` : ""})`;
           }
         %>
-        <tr>
+        <tr<% if (detailMode) { %> id="<%= helpers.parameterAnchorId(param.path) %>" class="scroll-mt-24"<% } %>>
           <td class="py-2 pr-3 align-top">
             <div class="font-medium text-slate-900 dark:text-slate-100"><%= helpers.paramLabel(param.path, param.label) %></div>
+            <% if (detailMode) { %>
+            <a href="<%= helpers.parameterPagePath(param.path) %>" class="mt-0.5 inline-block rounded bg-warm-tag px-1.5 py-0.5 font-mono text-xs text-accent hover:text-accent-hover dark:bg-slate-800"
+              ><%= param.path %></a>
+            <% } else { %>
             <code class="mt-0.5 inline-block rounded bg-warm-tag px-1.5 py-0.5 font-mono text-xs text-slate-600 dark:bg-slate-800 dark:text-slate-300"
               ><%= param.path %></code>
+            <% } %>
           </td>
           <td class="py-2 pr-3 align-top font-mono text-xs text-slate-600 dark:text-slate-300">
             <%= param.type %>

--- a/tests/parameters.test.ts
+++ b/tests/parameters.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { buildParameterIndex, modelsWithoutParameter } from "../src/data/parameters.js";
+import { parameterPagePath, parameterSlug } from "../src/data/urls.js";
+import type { Model } from "../src/schema/model.js";
+
+function model(
+  provider: string,
+  name: string,
+  params: Model["params"],
+  authType: Model["authType"] = "api_key",
+): Model {
+  return { provider, authType, model: name, params } as Model;
+}
+
+const topP = {
+  path: "top_p",
+  type: "number",
+  label: "Top P",
+  description: "Nucleus sampling.",
+  group: "sampling",
+} as Model["params"][number];
+
+const maxTokens = {
+  path: "max_tokens",
+  type: "integer",
+  label: "Max tokens",
+  description: "Output cap.",
+  group: "generation_length",
+} as Model["params"][number];
+
+function temperature(over: Record<string, unknown> = {}): Model["params"][number] {
+  return {
+    path: "temperature",
+    type: "number",
+    label: "Temperature",
+    description: "Controls randomness.",
+    group: "sampling",
+    ...over,
+  } as Model["params"][number];
+}
+
+describe("parameterSlug / parameterPagePath", () => {
+  it("turns nested-path dots into hyphens but keeps underscores", () => {
+    expect(parameterSlug("temperature")).toBe("temperature");
+    expect(parameterSlug("top_p")).toBe("top_p");
+    expect(parameterSlug("thinking.type")).toBe("thinking-type");
+    expect(parameterSlug("max_completion_tokens")).toBe("max_completion_tokens");
+    expect(parameterPagePath("top_p")).toBe("/parameters/top_p");
+  });
+
+  it("keeps a dotted path distinct from its snake_case twin", () => {
+    expect(parameterSlug("reasoning.effort")).toBe("reasoning-effort");
+    expect(parameterSlug("reasoning_effort")).toBe("reasoning_effort");
+  });
+});
+
+describe("buildParameterIndex", () => {
+  const models = [
+    model("openai", "gpt-4o", [
+      temperature({ default: 1, range: { min: 0, max: 2 } }),
+      topP,
+      maxTokens,
+    ]),
+    model("anthropic", "claude", [temperature({ default: 1, range: { min: 0, max: 1 } })]),
+  ];
+  const index = buildParameterIndex(models);
+
+  it("produces one detail per unique path with a slug and model count", () => {
+    const temp = index.find((d) => d.path === "temperature");
+    expect(temp?.slug).toBe("temperature");
+    expect(temp?.modelCount).toBe(2);
+    expect(temp?.providers).toEqual(["anthropic", "openai"]);
+    expect(temp?.usages).toHaveLength(2);
+  });
+
+  it("keeps each model's own constraints in its usage", () => {
+    const temp = index.find((d) => d.path === "temperature")!;
+    const openai = temp.usages.find((u) => u.provider === "openai");
+    const anthropic = temp.usages.find((u) => u.provider === "anthropic");
+    expect(openai?.param.type === "number" && openai.param.range).toEqual({ min: 0, max: 2 });
+    expect(anthropic?.param.type === "number" && anthropic.param.range).toEqual({ min: 0, max: 1 });
+  });
+
+  it("orders by schema group, then by how many models expose the parameter", () => {
+    expect(index[0]?.group).toBe("generation_length");
+    const sampling = index.filter((d) => d.group === "sampling").map((d) => d.path);
+    expect(sampling).toEqual(["temperature", "top_p"]);
+  });
+});
+
+describe("modelsWithoutParameter", () => {
+  it("lists models that don't document the parameter, grouped by provider", () => {
+    const models = [
+      model("openai", "gpt-4o", [temperature(), topP]),
+      model("anthropic", "claude", [temperature()]),
+    ];
+    const topPDetail = buildParameterIndex(models).find((d) => d.path === "top_p")!;
+    const without = modelsWithoutParameter(topPDetail, models);
+    const anthropic = without.find((g) => g.provider === "anthropic");
+    expect(anthropic?.models.map((m) => m.model)).toContain("claude");
+    expect(without.find((g) => g.provider === "openai")).toBeUndefined();
+  });
+});

--- a/tests/render-meta.test.ts
+++ b/tests/render-meta.test.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect } from "vitest";
-import { modelPageDescription, modelPageTitle } from "../src/build/render-model.js";
+import {
+  modelPageDescription,
+  modelPageTitle,
+  modelParamProse,
+} from "../src/build/render-model.js";
 import { providerPageDescription, providerPageTitle } from "../src/build/render-provider.js";
-import { modelJsonPath, modelPagePath, providerPagePath } from "../src/data/urls.js";
+import { parameterPageDescription, parameterPageTitle } from "../src/build/render-parameter.js";
+import { buildParameterIndex } from "../src/data/parameters.js";
+import {
+  modelJsonPath,
+  modelPagePath,
+  parameterPagePath,
+  parameterSlug,
+  providerPagePath,
+} from "../src/data/urls.js";
 import type { Model } from "../src/schema/model.js";
 
 function model(over: Partial<Model> = {}): Model {
@@ -30,6 +42,31 @@ describe("url helpers", () => {
     );
     expect(modelJsonPath(model())).toBe("/api/v1/models/anthropic/claude-opus-4-7.json");
     expect(providerPagePath("openai")).toBe("/providers/openai");
+  });
+
+  it("slugs parameter paths for their pages", () => {
+    expect(parameterSlug("top_p")).toBe("top_p");
+    expect(parameterSlug("thinking.type")).toBe("thinking-type");
+    expect(parameterPagePath("top_p")).toBe("/parameters/top_p");
+  });
+});
+
+describe("parameter page meta", () => {
+  it("titles and describes a parameter with its path and model count", () => {
+    const detail = buildParameterIndex([model()])[0]!;
+    expect(parameterPageTitle(detail)).toContain("temperature");
+    expect(parameterPageTitle(detail)).toContain("modelparams.dev");
+    const desc = parameterPageDescription(detail);
+    expect(desc).toContain("temperature");
+    expect(desc).toContain("1 model");
+  });
+});
+
+describe("modelParamProse", () => {
+  it("groups parameters into labelled clauses keyed by path", () => {
+    const groups = modelParamProse(model());
+    const sampling = groups.find((g) => g.label === "Sampling");
+    expect(sampling?.clauses.some((c) => c.path === "temperature")).toBe(true);
   });
 });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -171,6 +171,23 @@ describe("GET /glossary", () => {
   });
 });
 
+describe("GET /parameters/:slug", () => {
+  it("renders a parameter page for a known parameter", async () => {
+    const res = await get("/parameters/temperature");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const body = await res.text();
+    expect(body).toContain("<!doctype html>");
+    expect(body).toContain("temperature");
+  });
+
+  it("404s for an unknown parameter", async () => {
+    const res = await get("/parameters/not-a-parameter");
+    expect(res.status).toBe(404);
+    expect(await res.text()).toBe("Unknown parameter");
+  });
+});
+
 describe("GET /providers/:provider", () => {
   it("renders a hub for a known provider", async () => {
     const res = await get("/providers/anthropic");

--- a/tests/structured-data.test.ts
+++ b/tests/structured-data.test.ts
@@ -3,9 +3,11 @@ import {
   buildGlossaryStructuredData,
   buildHomeStructuredData,
   buildModelStructuredData,
+  buildParameterStructuredData,
   buildProviderStructuredData,
 } from "../src/build/structured-data.js";
 import { buildGlossary } from "../src/data/glossary.js";
+import { buildParameterIndex } from "../src/data/parameters.js";
 import type { Model } from "../src/schema/model.js";
 
 const SITE = "https://modelparams.dev";
@@ -80,5 +82,20 @@ describe("buildGlossaryStructuredData", () => {
 
     expect(json).toContain('"@type":"DefinedTermSet"');
     expect(json).toContain('"termCode":"temperature"');
+  });
+});
+
+describe("buildParameterStructuredData", () => {
+  it("emits a DefinedTerm, breadcrumb, and a model ItemList", () => {
+    const detail = buildParameterIndex([model()])[0]!;
+    const json = buildParameterStructuredData(detail, "desc", SITE);
+
+    expect(json).toContain('"@type":"DefinedTerm"');
+    expect(json).toContain('"termCode":"temperature"');
+    expect(json).toContain(`${SITE}/parameters/temperature#term`);
+    expect(json).toContain('"@type":"BreadcrumbList"');
+    expect(json).toContain('"@type":"ItemList"');
+    expect(json).toContain(`${SITE}/models/anthropic/claude-opus-4-7`);
+    expect(json).not.toContain("modelparameters.dev");
   });
 });


### PR DESCRIPTION
### 💭 Why
The catalog ranks one model at a time, but parameters had no page of their own. Searches like "gpt-4o temperature range" or "what is top_p" had nowhere to land. Everything lived on one shared glossary page.

### ✨ What changed
- New page per parameter at `/parameters/<slug>` with a by-model table of each model's default, range, and gating conditions.
- Glossary is now the hub that links to every parameter page.
- Model pages get jump-nav, per-row anchors, links to each parameter page, and a plain-language parameter summary.
- Sitemap `lastmod` reads each model's git commit date instead of the build date.
- Parameter pages added to the sitemap and `llms.txt`, with `DefinedTerm` structured data.

### 👤 For users
Anyone searching for a single parameter lands on a dedicated page showing its default and valid range across every model that accepts it (temperature alone covers 143 models).

### 🔧 For operators
After deploy, resubmit `sitemap.xml` in Google Search Console so the 60 new parameter URLs get crawled.

### 📝 Notes
Adds 60 parameter pages (sitemap grows to 275 URLs). A build-time guard rejects slug collisions. Model-by-parameter pages are deliberately left for later, once these are indexed.