### PR TITLE
feat: boost long-tail SEO for parameter and model pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7210,7 +7210,7 @@
       }
     },
     "packages/modelparams": {
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
         "tsd": "^0.31.0"

--- a/packages/modelparams/README.md
+++ b/packages/modelparams/README.md
@@ -8,6 +8,8 @@ npm install modelparams
 
 Stop guessing which knobs each model accepts. Get autocomplete on every parameter, compile-time errors on typos and unsupported settings, and the catalog's defaults at runtime — for every provider in one tiny zero-dependency package.
 
+**Catalog & API:** [browse the catalog](https://modelparams.dev) · [JSON API](https://modelparams.dev/api/v1/models.json) · [API docs](https://modelparams.dev/api) · [llms.txt](https://modelparams.dev/llms.txt)
+
 ## Why
 
 You're calling `claude-opus-4-7` with `frequency_penalty` set. TypeScript doesn't tell you the param doesn't exist. The provider silently ignores it. Your evals drift. Multiply by every model in your router.

--- a/src/build/render-model.ts
+++ b/src/build/render-model.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import ejs from "ejs";
 import { describeApplicability } from "../data/applicability.js";
 import { modelLabel, paramGroupLabel, providerLabel } from "../data/display.js";
+import { modelFaq } from "../data/faq.js";
 import { groupParams } from "../data/group.js";
 import { VIEWS_DIR } from "../data/paths.js";
 import { SITE_NAME, SITE_URL } from "../data/site.js";
@@ -82,10 +83,12 @@ export async function renderModelPage(model: Model, allModels: Model[]): Promise
     .filter((other) => other.provider === model.provider && modelId(other) !== modelId(model))
     .sort((a, b) => modelLabel(a).localeCompare(modelLabel(b)));
 
+  const faqs = modelFaq(model);
   const body = await ejs.renderFile(path.join(VIEWS_DIR, "model.ejs"), {
     model,
     helpers: viewHelpers,
     siblings,
+    faqs,
     intro: modelIntro(model),
     providerName: providerLabel(model.provider),
     modelName: modelLabel(model),
@@ -102,7 +105,7 @@ export async function renderModelPage(model: Model, allModels: Model[]): Promise
       title: modelPageTitle(model),
       description,
       canonicalUrl: absolute(SITE_URL, modelPagePath(model)),
-      structuredData: buildModelStructuredData(model, description, SITE_URL),
+      structuredData: buildModelStructuredData(model, description, SITE_URL, faqs),
       providerHubs: hubLinks(allModels),
     },
     body,

--- a/src/build/render.ts
+++ b/src/build/render.ts
@@ -16,7 +16,7 @@ import { groupParams } from "../data/group.js";
 import { usageGuideMarkdown } from "../data/llms.js";
 import { logoFor } from "../data/logos.js";
 import { VIEWS_DIR } from "../data/paths.js";
-import { OG_IMAGE_PATH, SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "../data/site.js";
+import { OG_IMAGE_PATH, SITE_NAME, SITE_URL } from "../data/site.js";
 import {
   absolute,
   modelPagePath,
@@ -102,6 +102,25 @@ export interface RenderOptions {
   analytics?: boolean;
 }
 
+/** Concrete, query-shaped homepage title — names the surface, carries the live model count. */
+export function homeTitle(modelCount: number): string {
+  return `Compare model parameters across ${modelCount} models · ${SITE_NAME}`;
+}
+
+/**
+ * Benefit-first homepage description that names real parameters (the ones users
+ * actually search) plus live counts, instead of the generic site blurb.
+ */
+export function homeDescription(
+  modelCount: number,
+  providerCount: number,
+  sampleParams: string[],
+): string {
+  const lead =
+    sampleParams.length > 0 ? `Compare ${sampleParams.join(", ")}, and every other ` : "Compare every ";
+  return `${lead}API parameter — defaults, ranges, and the conditions that gate each — across ${modelCount} models from ${providerCount} providers. An open, community-maintained catalog.`;
+}
+
 export async function renderIndex(opts: RenderOptions): Promise<string> {
   const body = await ejs.renderFile(path.join(VIEWS_DIR, "index.ejs"), {
     models: opts.catalog.models,
@@ -110,10 +129,11 @@ export async function renderIndex(opts: RenderOptions): Promise<string> {
     helpers: viewHelpers,
   });
 
+  const sampleParams = opts.capabilities.slice(0, 3).map((cap) => cap.path);
   return renderShell(
     {
-      title: `${SITE_NAME} — Open catalog of model parameters`,
-      description: SITE_DESCRIPTION,
+      title: homeTitle(opts.catalog.models.length),
+      description: homeDescription(opts.catalog.models.length, opts.providers.length, sampleParams),
       canonicalUrl: `${SITE_URL}/`,
       structuredData: buildHomeStructuredData(
         opts.catalog.models,

--- a/src/build/structured-data.ts
+++ b/src/build/structured-data.ts
@@ -2,6 +2,7 @@
 // they can be unit-tested without touching the filesystem or the renderer.
 
 import { modelLabel, paramLabel, providerLabel } from "../data/display.js";
+import type { ModelFaq } from "../data/faq.js";
 import type { GlossaryGroup } from "../data/glossary.js";
 import type { ParameterDetail } from "../data/parameters.js";
 import { SITE_DESCRIPTION, SITE_NAME } from "../data/site.js";
@@ -14,6 +15,9 @@ import {
   providerPagePath,
 } from "../data/urls.js";
 import { type Model } from "../schema/model.js";
+
+const REPO_URL = "https://github.com/mnfst/modelparams.dev";
+const NPM_URL = "https://www.npmjs.com/package/modelparams";
 
 interface Crumb {
   name: string;
@@ -36,6 +40,17 @@ function graph(nodes: unknown[]): string {
   return JSON.stringify({ "@context": "https://schema.org", "@graph": nodes });
 }
 
+function organizationNode(siteUrl: string) {
+  return {
+    "@type": "Organization",
+    "@id": `${siteUrl}/#org`,
+    name: SITE_NAME,
+    url: `${siteUrl}/`,
+    description: SITE_DESCRIPTION,
+    sameAs: [REPO_URL, NPM_URL],
+  };
+}
+
 function homeWebsiteNode(siteUrl: string) {
   return {
     "@type": "WebSite",
@@ -43,6 +58,7 @@ function homeWebsiteNode(siteUrl: string) {
     url: `${siteUrl}/`,
     name: SITE_NAME,
     description: SITE_DESCRIPTION,
+    publisher: { "@id": `${siteUrl}/#org` },
     potentialAction: {
       "@type": "SearchAction",
       target: { "@type": "EntryPoint", urlTemplate: `${siteUrl}/?q={search_term_string}` },
@@ -61,7 +77,7 @@ function homeDatasetNode(siteUrl: string, imageUrl: string) {
     image: imageUrl,
     license: "https://opensource.org/licenses/MIT",
     isAccessibleForFree: true,
-    creator: { "@type": "Organization", name: SITE_NAME, url: `${siteUrl}/` },
+    creator: { "@id": `${siteUrl}/#org` },
     distribution: {
       "@type": "DataDownload",
       encodingFormat: "application/json",
@@ -97,16 +113,30 @@ export function buildHomeStructuredData(
   imageUrl: string,
 ): string {
   return graph([
+    organizationNode(siteUrl),
     homeWebsiteNode(siteUrl),
     homeDatasetNode(siteUrl, imageUrl),
     homeItemListNode(models, siteUrl),
   ]);
 }
 
+function faqPageNode(faqs: ModelFaq[], model: Model, siteUrl: string) {
+  return {
+    "@type": "FAQPage",
+    "@id": `${siteUrl}${modelPagePath(model)}#faq`,
+    mainEntity: faqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: { "@type": "Answer", text: faq.answer },
+    })),
+  };
+}
+
 export function buildModelStructuredData(
   model: Model,
   description: string,
   siteUrl: string,
+  faqs: ModelFaq[] = [],
 ): string {
   const name = `${providerLabel(model.provider)} ${modelLabel(model)} parameters`;
   const dataset = {
@@ -136,7 +166,9 @@ export function buildModelStructuredData(
     { name: providerLabel(model.provider), path: providerPagePath(model.provider) },
     { name: modelLabel(model), path: modelPagePath(model) },
   ]);
-  return graph([crumbs, dataset]);
+  const nodes: unknown[] = [crumbs, dataset];
+  if (faqs.length > 0) nodes.push(faqPageNode(faqs, model, siteUrl));
+  return graph(nodes);
 }
 
 export function buildProviderStructuredData(

--- a/src/data/faq.ts
+++ b/src/data/faq.ts
@@ -1,0 +1,60 @@
+// Data-driven FAQ for a model page. Pure function of the catalog entry so it can
+// back both the visible Q&A section and the FAQPage JSON-LD without duplicating
+// logic. The questions mirror real long-tail queries ("what is the default
+// temperature for <model>") and every answer is derived from the tracked data.
+
+import { modelLabel, providerLabel } from "./display.js";
+import type { Model, Parameter } from "../schema/model.js";
+
+export interface ModelFaq {
+  question: string;
+  answer: string;
+}
+
+/** Widely-searched sampling knobs, in the order we surface them when present. */
+const FAQ_PARAMS = ["temperature", "top_p", "max_tokens", "top_k"];
+const MAX_FAQS = 5;
+
+function subjectOf(model: Model): string {
+  const auth = model.authType === "subscription" ? " (subscription)" : "";
+  return `${providerLabel(model.provider)} ${modelLabel(model)}${auth}`;
+}
+
+function defaultAnswer(param: Parameter, subject: string): string {
+  let answer = `The default ${param.path} for ${subject} is ${JSON.stringify(param.default)}`;
+  if ((param.type === "integer" || param.type === "number") && param.range) {
+    const { min, max } = param.range;
+    if (min !== undefined && max !== undefined)
+      answer += `, within a valid range of ${min} to ${max}`;
+    else if (min !== undefined) answer += `, with a minimum of ${min}`;
+    else if (max !== undefined) answer += `, with a maximum of ${max}`;
+  }
+  return `${answer}.`;
+}
+
+/** Up to five Q&A pairs for a model, or none when it has no documented parameters. */
+export function modelFaq(model: Model): ModelFaq[] {
+  if (model.params.length === 0) return [];
+  const subject = subjectOf(model);
+  const paths = model.params.map((param) => param.path);
+  const faqs: ModelFaq[] = [
+    {
+      question: `How many parameters does ${subject} accept?`,
+      answer: `${subject} accepts ${model.params.length} API parameter${
+        model.params.length === 1 ? "" : "s"
+      }: ${paths.slice(0, 6).join(", ")}${paths.length > 6 ? ", and more" : ""}.`,
+    },
+  ];
+  const byPath = new Map(model.params.map((param) => [param.path, param]));
+  for (const path of FAQ_PARAMS) {
+    if (faqs.length >= MAX_FAQS) break;
+    const param = byPath.get(path);
+    if (param && param.default !== undefined) {
+      faqs.push({
+        question: `What is the default ${path} for ${subject}?`,
+        answer: defaultAnswer(param, subject),
+      });
+    }
+  }
+  return faqs;
+}

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -268,6 +268,29 @@
   </p>
 </section>
 
+<% if (capabilities.length > 0) { %>
+<section class="mt-12 border-t border-slate-200 pt-8 dark:border-slate-800" aria-label="Browse by parameter">
+  <div class="flex items-baseline justify-between gap-3">
+    <h2 class="text-slate-900 dark:text-slate-100">Browse by parameter</h2>
+    <a href="/glossary" class="shrink-0 text-sm font-medium text-accent hover:text-accent-hover">All parameters →</a>
+  </div>
+  <p class="mt-2 max-w-2xl text-sm text-slate-600 dark:text-slate-300">
+    Open any parameter to see its default, range, and every model that accepts it.
+  </p>
+  <div class="mt-4 flex flex-wrap gap-2">
+    <% for (const cap of capabilities) { %>
+    <a
+      href="<%= helpers.parameterPagePath(cap.path) %>"
+      class="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2.5 py-1 font-mono text-xs text-slate-600 hover:border-slate-300 hover:text-accent dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:hover:border-slate-700"
+    >
+      <%= cap.path %>
+      <span class="tabular-nums text-slate-400 dark:text-slate-500"><%= cap.count %></span>
+    </a>
+    <% } %>
+  </div>
+</section>
+<% } %>
+
 <button
   type="button"
   data-scroll-top

--- a/src/views/model.ejs
+++ b/src/views/model.ejs
@@ -48,7 +48,7 @@
 
 <% if (proseGroups.length > 0) { %>
 <section class="mt-10" aria-label="Parameter summary">
-  <h2 class="text-slate-900 dark:text-slate-100"><%= providerName %> <%= modelName %> parameters in brief</h2>
+  <h2 class="text-slate-900 dark:text-slate-100"><%= providerName %> <%= modelName %> API parameters in brief</h2>
   <p class="mt-2 max-w-2xl text-sm text-slate-600 dark:text-slate-300">
     <%= providerName %> <%= modelName %><% if (isSubscription) { %> via subscription<% } %> documents <%= model.params.length %> API parameter<%= model.params.length === 1 ? "" : "s" %>, grouped by what they control:
   </p>
@@ -60,6 +60,20 @@
     </li>
     <% } %>
   </ul>
+</section>
+<% } %>
+
+<% if (faqs.length > 0) { %>
+<section class="mt-10" aria-label="Frequently asked questions">
+  <h2 class="text-slate-900 dark:text-slate-100">Frequently asked questions</h2>
+  <dl class="mt-3 max-w-2xl space-y-4">
+    <% for (const faq of faqs) { %>
+    <div>
+      <dt class="font-medium text-slate-900 dark:text-slate-100"><%= faq.question %></dt>
+      <dd class="mt-1 text-sm text-slate-600 dark:text-slate-300"><%= faq.answer %></dd>
+    </div>
+    <% } %>
+  </dl>
 </section>
 <% } %>
 

--- a/tests/faq.test.ts
+++ b/tests/faq.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { modelFaq } from "../src/data/faq.js";
+import type { Model } from "../src/schema/model.js";
+
+function model(over: Partial<Model> = {}): Model {
+  return {
+    provider: "anthropic",
+    authType: "api_key",
+    model: "claude-opus-4-7",
+    params: [
+      {
+        path: "temperature",
+        type: "number",
+        label: "Temperature",
+        description: "Sampling temperature.",
+        default: 1,
+        range: { min: 0, max: 2 },
+        group: "sampling",
+      },
+      {
+        path: "max_tokens",
+        type: "integer",
+        label: "Max tokens",
+        description: "Maximum output tokens.",
+        default: 4096,
+        range: { min: 1 },
+        group: "generation_length",
+      },
+    ],
+    ...over,
+  } as Model;
+}
+
+describe("modelFaq", () => {
+  it("leads with the parameter count and names the model", () => {
+    const faqs = modelFaq(model());
+    expect(faqs[0]!.question).toBe("How many parameters does Anthropic Claude Opus 4.7 accept?");
+    expect(faqs[0]!.answer).toContain("2 API parameters");
+    expect(faqs[0]!.answer).toContain("temperature");
+  });
+
+  it("answers default questions with the value and range from the data", () => {
+    const faqs = modelFaq(model());
+    const temp = faqs.find((f) => f.question.includes("default temperature"));
+    expect(temp?.answer).toBe(
+      "The default temperature for Anthropic Claude Opus 4.7 is 1, within a valid range of 0 to 2.",
+    );
+    const maxTokens = faqs.find((f) => f.question.includes("default max_tokens"));
+    expect(maxTokens?.answer).toContain("with a minimum of 1");
+  });
+
+  it("marks the subscription variant in the subject", () => {
+    const faqs = modelFaq(model({ authType: "subscription" }));
+    expect(faqs[0]!.question).toContain("Anthropic Claude Opus 4.7 (subscription)");
+  });
+
+  it("skips parameters without a documented default", () => {
+    const faqs = modelFaq(
+      model({
+        params: [
+          {
+            path: "top_p",
+            type: "number",
+            label: "Top P",
+            description: "Nucleus.",
+            group: "sampling",
+          },
+        ],
+      }),
+    );
+    expect(faqs).toHaveLength(1);
+    expect(faqs[0]!.question).toContain("How many parameters");
+  });
+
+  it("returns nothing for a model with no parameters", () => {
+    expect(modelFaq(model({ params: [] }))).toEqual([]);
+  });
+});

--- a/tests/render-meta.test.ts
+++ b/tests/render-meta.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { homeDescription, homeTitle } from "../src/build/render.js";
 import {
   modelPageDescription,
   modelPageTitle,
@@ -80,6 +81,22 @@ describe("model page meta", () => {
     const desc = modelPageDescription(model());
     expect(desc).toContain("Anthropic Claude Opus 4.7");
     expect(desc).toContain("temperature");
+  });
+});
+
+describe("home page meta", () => {
+  it("names the surface and carries the live model count in the title", () => {
+    expect(homeTitle(198)).toBe("Compare model parameters across 198 models · modelparams.dev");
+  });
+
+  it("leads the description with real parameters and live counts", () => {
+    const desc = homeDescription(198, 15, ["temperature", "top_p", "max_tokens"]);
+    expect(desc).toContain("Compare temperature, top_p, max_tokens");
+    expect(desc).toContain("198 models from 15 providers");
+  });
+
+  it("still reads cleanly when no sample parameters are available", () => {
+    expect(homeDescription(198, 15, [])).toContain("Compare every API parameter");
   });
 });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -160,6 +160,14 @@ describe("GET / (home)", () => {
     expect(body).toContain("<!doctype html>");
     expect(body).toContain("modelparams.dev");
   });
+
+  it("carries a concrete title and a crawlable browse-by-parameter section", async () => {
+    const body = await get("/").then((r) => r.text());
+    expect(body).toContain("Compare model parameters across 3 models");
+    expect(body).toContain("Browse by parameter");
+    expect(body).toContain('href="/parameters/temperature"');
+    expect(body).toContain('href="/parameters/max_tokens"');
+  });
 });
 
 describe("GET /glossary", () => {
@@ -215,6 +223,13 @@ describe("GET /models/:provider/:slug", () => {
     const res = await get("/models/anthropic/does-not-exist");
     expect(res.status).toBe(404);
     expect(await res.text()).toBe("Unknown model");
+  });
+
+  it("renders a data-driven FAQ with a FAQPage node", async () => {
+    const body = await get("/models/anthropic/claude-opus-4-7").then((r) => r.text());
+    expect(body).toContain("Frequently asked questions");
+    expect(body).toContain("What is the default temperature for Anthropic Claude Opus 4.7?");
+    expect(body).toContain('"@type":"FAQPage"');
   });
 });
 

--- a/tests/structured-data.test.ts
+++ b/tests/structured-data.test.ts
@@ -47,6 +47,16 @@ describe("buildHomeStructuredData", () => {
     expect(json).not.toContain("modelparameters.dev");
     expect(listItemCount(json)).toBe(60);
   });
+
+  it("publishes an Organization node linked to GitHub and npm", () => {
+    const json = buildHomeStructuredData([model()], SITE, `${SITE}/assets/og.png`);
+
+    expect(json).toContain('"@type":"Organization"');
+    expect(json).toContain(`"@id":"${SITE}/#org"`);
+    expect(json).toContain("https://github.com/mnfst/modelparams.dev");
+    expect(json).toContain("https://www.npmjs.com/package/modelparams");
+    expect(json).toContain(`"publisher":{"@id":"${SITE}/#org"}`);
+  });
 });
 
 describe("buildModelStructuredData", () => {
@@ -58,6 +68,20 @@ describe("buildModelStructuredData", () => {
     expect(json).toContain(`${SITE}/api/v1/models/anthropic/claude-opus-4-7.json`);
     expect(json).toContain(`"item":"${SITE}/models/anthropic/claude-opus-4-7"`);
     expect(json).toContain('"name":"temperature"');
+  });
+
+  it("appends a FAQPage node only when faqs are supplied", () => {
+    const withoutFaqs = buildModelStructuredData(model(), "desc", SITE);
+    expect(withoutFaqs).not.toContain('"@type":"FAQPage"');
+
+    const withFaqs = buildModelStructuredData(model(), "desc", SITE, [
+      { question: "What is the default temperature?", answer: "The default is 1." },
+    ]);
+    expect(withFaqs).toContain(`"@id":"${SITE}/models/anthropic/claude-opus-4-7#faq"`);
+    expect(withFaqs).toContain('"@type":"FAQPage"');
+    expect(withFaqs).toContain('"@type":"Question"');
+    expect(withFaqs).toContain('"@type":"Answer"');
+    expect(withFaqs).toContain('"text":"The default is 1."');
   });
 });
 


### PR DESCRIPTION
### 💭 Why
The site gets impressions for specific parameter and model queries, but those long-tail pages were hard for Google to reach. The homepage passed no link equity to the per-parameter pages, and its title was generic.

### ✨ What changed
- Homepage: new crawlable "Browse by parameter" section linking all 60 parameter pages plus the glossary.
- Homepage title and description now name real parameters (temperature, top_p, max_tokens) with live model and provider counts.
- Homepage JSON-LD gains an Organization node with sameAs to GitHub and npm.
- Model pages: data-driven FAQ built from the catalog (visible Q&A plus FAQPage JSON-LD).
- Model heading reworded to reinforce the "API parameters" phrasing.
- npm README links back to the API docs, JSON API, and llms.txt.
- Synced the packages/modelparams version in the lockfile (0.0.0 to 0.0.1).

### 👤 For users
Searchers looking for a specific parameter or model default land on the matching page. Each model page answers common questions inline, like the default temperature or the token limit.

### 📝 Notes
- No comparison ("A vs B") pages by design, to avoid thin content on a young domain.
- New pure module src/data/faq.ts backs both the visible FAQ and the FAQPage schema.