### PR TITLE
feat: add openai/gpt-5.6-luna

### DIFF
--- a/models/openai/gpt-5.6-luna.yaml
+++ b/models/openai/gpt-5.6-luna.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: openai
+authType: api_key
+model: gpt-5.6-luna
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 16
+    group: generation_length
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning the model should perform before producing an answer.
+    default: none
+    values:
+      - none
+      - low
+      - medium
+      - high
+    group: reasoning

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -12447,6 +12447,38 @@ export const CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "model": "gpt-5.6-luna",
+    "params": [
+      {
+        "path": "max_completion_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 4096,
+        "range": {
+          "min": 16
+        }
+      },
+      {
+        "path": "reasoning_effort",
+        "label": "Reasoning effort",
+        "description": "Controls how much reasoning the model should perform before producing an answer.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "none",
+        "values": [
+          "none",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ]
+  },
+  {
+    "provider": "openai",
+    "authType": "api_key",
     "model": "o1",
     "params": [
       {

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -996,6 +996,10 @@ export const DEFAULTS = {
     "reasoning.summary": "auto",
     "text.verbosity": "medium",
   },
+  "openai/gpt-5.6-luna": {
+    max_completion_tokens: 4096,
+    reasoning_effort: "none",
+  },
   "openai/o1": {
     max_completion_tokens: 4096,
     reasoning_effort: "medium",

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -162,6 +162,7 @@ export const MODEL_IDS = [
   "openai/gpt-5.5-pro",
   "openai/gpt-5.5-pro-subscription",
   "openai/gpt-5.5-subscription",
+  "openai/gpt-5.6-luna",
   "openai/o1",
   "openai/o1-mini",
   "openai/o1-preview",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -1198,6 +1198,10 @@ export type ParamsById = {
     "reasoning.summary": "auto" | "concise" | "detailed" | "none";
     "text.verbosity": "low" | "medium" | "high";
   };
+  "openai/gpt-5.6-luna": {
+    max_completion_tokens: number;
+    reasoning_effort: "none" | "low" | "medium" | "high";
+  };
   "openai/o1": {
     max_completion_tokens: number;
     reasoning_effort: "low" | "medium" | "high" | "xhigh";


### PR DESCRIPTION
### ✨ What changed
- Adds `gpt-5.6-luna` (openai, api_key) to the catalog, params cloned from `openai/gpt-5.1.yaml`.

### 💭 Why
OpenAI shipped the GPT-5.6 family to public GA on July 9 2026; the catalog doesn't list it yet.

### 📝 Notes
- Liveness ✅ verified on api.openai.com 2026-07-11 (model executes; rejects `max_tokens`, requires `max_completion_tokens` — matches the cloned param surface). Params are sibling-cloned pending individual probing.
- Also served end-to-end through a Manifest instance (openai:api_key connection).
- Source: https://releasebot.io/updates/openai
- Auto-proposed by manifest-model-watch.