### PR TITLE
feat: add anthropic/claude-sonnet-5

### DIFF
--- a/models/anthropic/claude-sonnet-5.yaml
+++ b/models/anthropic/claude-sonnet-5.yaml
@@ -1,0 +1,94 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: api_key
+model: claude-sonnet-5
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - adaptive
+        - top_p:
+            not: null
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
+      reaches this value.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        - thinking.type:
+            - adaptive
+        - temperature:
+            not: null
+  - path: top_k
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    default: 0
+    range:
+      min: 0
+    group: sampling
+    applicability:
+      except:
+        thinking.type:
+          - adaptive
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: disabled
+    values:
+      - disabled
+      - adaptive
+    group: reasoning
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: summarized
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - adaptive
+  - path: output_config.effort
+    type: enum
+    label: Effort
+    description: Controls Anthropic response thoroughness and token spend.
+    default: high
+    values:
+      - low
+      - medium
+      - high
+      - max
+    group: reasoning


### PR DESCRIPTION
### ✨ What changed
- Adds `claude-sonnet-5` (anthropic, api_key) with its real July-2026 param surface: `thinking.type` is now `disabled|adaptive` only (manual `enabled` extended thinking removed on this model, so `thinking.budget_tokens` is gone too).

### 💭 Why
Anthropic released Claude Sonnet 5 on June 30 2026 with adaptive thinking replacing manual extended thinking; the catalog has no entry.

### 📝 Notes
- Smoke ✅: every param individually verified against api.anthropic.com on 2026-07-11 (including the `thinking.type=enabled` rejection: the API answers *use adaptive* — which is how this surface was derived, not guessed).
- Source: https://www.anthropic.com/claude/sonnet
- Auto-proposed by manifest-model-watch.