### PR TITLE
chore: commit codegen output for claude-sonnet-5

### DIFF
--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -4679,6 +4679,141 @@ export const CATALOG = [
     ]
   },
   {
+    "provider": "anthropic",
+    "authType": "api_key",
+    "model": "claude-sonnet-5",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 4096,
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "applicability": {
+          "except": [
+            {
+              "thinking.type": [
+                "adaptive"
+              ]
+            },
+            {
+              "top_p": {
+                "not": null
+              }
+            }
+          ]
+        },
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens whose cumulative probability reaches this value.",
+        "group": "sampling",
+        "applicability": {
+          "except": [
+            {
+              "thinking.type": [
+                "adaptive"
+              ]
+            },
+            {
+              "temperature": {
+                "not": null
+              }
+            }
+          ]
+        },
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "top_k",
+        "label": "Top K",
+        "description": "Limits token sampling to the top K most likely next tokens.",
+        "group": "sampling",
+        "applicability": {
+          "except": {
+            "thinking.type": [
+              "adaptive"
+            ]
+          }
+        },
+        "type": "integer",
+        "default": 0,
+        "range": {
+          "min": 0
+        }
+      },
+      {
+        "path": "thinking.type",
+        "label": "Thinking mode",
+        "description": "Controls the Anthropic thinking mode values supported by this model.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "disabled",
+        "values": [
+          "disabled",
+          "adaptive"
+        ]
+      },
+      {
+        "path": "thinking.display",
+        "label": "Thinking display",
+        "description": "Controls whether Anthropic returns summarized or omitted thinking content.",
+        "group": "reasoning",
+        "applicability": {
+          "only": {
+            "thinking.type": [
+              "adaptive"
+            ]
+          }
+        },
+        "type": "enum",
+        "default": "summarized",
+        "values": [
+          "summarized",
+          "omitted"
+        ]
+      },
+      {
+        "path": "output_config.effort",
+        "label": "Effort",
+        "description": "Controls Anthropic response thoroughness and token spend.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "high",
+        "values": [
+          "low",
+          "medium",
+          "high",
+          "max"
+        ]
+      }
+    ]
+  },
+  {
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-a-03-2025",

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -330,6 +330,15 @@ export const DEFAULTS = {
     "thinking.type": "disabled",
     "thinking.budget_tokens": 4096,
   },
+  "anthropic/claude-sonnet-5": {
+    max_tokens: 4096,
+    temperature: 1,
+    top_p: 1,
+    top_k: 0,
+    "thinking.type": "disabled",
+    "thinking.display": "summarized",
+    "output_config.effort": "high",
+  },
   "cohere/command-a-03-2025": {
     temperature: 0.3,
     p: 0.75,

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -48,6 +48,7 @@ export const MODEL_IDS = [
   "anthropic/claude-sonnet-4-6",
   "anthropic/claude-sonnet-4-6-subscription",
   "anthropic/claude-sonnet-4-subscription",
+  "anthropic/claude-sonnet-5",
   "cohere/command-a-03-2025",
   "cohere/command-a-plus-05-2026",
   "cohere/command-a-reasoning-08-2025",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -358,6 +358,15 @@ export type ParamsById = {
     "thinking.type": "disabled" | "adaptive" | "enabled";
     "thinking.budget_tokens": number;
   };
+  "anthropic/claude-sonnet-5": {
+    max_tokens: number;
+    temperature: number;
+    top_p: number;
+    top_k: number;
+    "thinking.type": "disabled" | "adaptive";
+    "thinking.display": "summarized" | "omitted";
+    "output_config.effort": "low" | "medium" | "high" | "max";
+  };
   "cohere/command-a-03-2025": {
     max_tokens: number;
     stop_sequences: string;


### PR DESCRIPTION
PR #92 added anthropic/claude-sonnet-5 to the catalog without committing the regenerated files in packages/modelparams/src/generated, so the codegen drift check now fails on main and on every open PR's merge ref (#89, #90, #91).

This commits the codegen output for claude-sonnet-5. Generated files only, no manual edits.