### PR TITLE
feat: add google/gemma-4-26b-a4b-it

### DIFF
--- a/models/google/gemma-4-26b-a4b-it.yaml
+++ b/models/google/gemma-4-26b-a4b-it.yaml
@@ -1,0 +1,67 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: google
+authType: api_key
+model: gemma-4-26b-a4b-it
+params:
+  - path: generationConfig.maxOutputTokens
+    type: integer
+    label: Max output tokens
+    description: Maximum number of tokens to include in a response candidate.
+    range:
+      min: 1
+      max: 65536
+    group: generation_length
+  - path: generationConfig.temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    default: 1
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: generationConfig.topP
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: generationConfig.topK
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    default: 64
+    range:
+      min: 0
+    group: sampling
+  - path: generationConfig.seed
+    type: integer
+    label: Seed
+    description: Optional seed used for decoding when reproducible sampling is desired.
+    group: sampling
+  - path: generationConfig.thinkingConfig.thinkingBudget
+    type: integer
+    label: Thinking budget
+    description: Number of thinking tokens Gemini should use; -1 uses dynamic thinking, 0 disables thinking, and fixed budgets start at 512 tokens.
+    default: 0
+    group: reasoning
+  - path: generationConfig.thinkingConfig.includeThoughts
+    type: boolean
+    label: Include thoughts
+    description: Controls whether Gemini returns available thought summaries in the response parts.
+    default: false
+    group: reasoning
+  - path: generationConfig.responseMimeType
+    type: enum
+    label: Response MIME type
+    description: MIME type for generated text candidates.
+    default: text/plain
+    values:
+      - text/plain
+      - application/json
+    group: output_format

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -7280,6 +7280,96 @@ export const CATALOG = [
     ]
   },
   {
+    "provider": "google",
+    "authType": "api_key",
+    "model": "gemma-4-26b-a4b-it",
+    "params": [
+      {
+        "path": "generationConfig.maxOutputTokens",
+        "label": "Max output tokens",
+        "description": "Maximum number of tokens to include in a response candidate.",
+        "group": "generation_length",
+        "type": "integer",
+        "range": {
+          "min": 1,
+          "max": 65536
+        }
+      },
+      {
+        "path": "generationConfig.temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 2,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "generationConfig.topP",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.",
+        "group": "sampling",
+        "type": "number",
+        "default": 0.95,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "generationConfig.topK",
+        "label": "Top K",
+        "description": "Limits token sampling to the top K most likely next tokens.",
+        "group": "sampling",
+        "type": "integer",
+        "default": 64,
+        "range": {
+          "min": 0
+        }
+      },
+      {
+        "path": "generationConfig.seed",
+        "label": "Seed",
+        "description": "Optional seed used for decoding when reproducible sampling is desired.",
+        "group": "sampling",
+        "type": "integer"
+      },
+      {
+        "path": "generationConfig.thinkingConfig.thinkingBudget",
+        "label": "Thinking budget",
+        "description": "Number of thinking tokens Gemini should use; -1 uses dynamic thinking, 0 disables thinking, and fixed budgets start at 512 tokens.",
+        "group": "reasoning",
+        "type": "integer",
+        "default": 0
+      },
+      {
+        "path": "generationConfig.thinkingConfig.includeThoughts",
+        "label": "Include thoughts",
+        "description": "Controls whether Gemini returns available thought summaries in the response parts.",
+        "group": "reasoning",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "path": "generationConfig.responseMimeType",
+        "label": "Response MIME type",
+        "description": "MIME type for generated text candidates.",
+        "group": "output_format",
+        "type": "enum",
+        "default": "text/plain",
+        "values": [
+          "text/plain",
+          "application/json"
+        ]
+      }
+    ]
+  },
+  {
     "provider": "meta",
     "authType": "api_key",
     "model": "Llama-3.3-70B-Instruct",

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -533,6 +533,14 @@ export const DEFAULTS = {
     "generationConfig.thinkingConfig.includeThoughts": false,
     "generationConfig.responseMimeType": "text/plain",
   },
+  "google/gemma-4-26b-a4b-it": {
+    "generationConfig.temperature": 1,
+    "generationConfig.topP": 0.95,
+    "generationConfig.topK": 64,
+    "generationConfig.thinkingConfig.thinkingBudget": 0,
+    "generationConfig.thinkingConfig.includeThoughts": false,
+    "generationConfig.responseMimeType": "text/plain",
+  },
   "meta/Llama-3.3-70B-Instruct": {
     "response_format.type": "text",
   },

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -72,6 +72,7 @@ export const MODEL_IDS = [
   "google/gemini-3.1-flash-lite-subscription",
   "google/gemini-3.1-pro-preview-subscription",
   "google/gemini-3.5-flash",
+  "google/gemma-4-26b-a4b-it",
   "meta/Llama-3.3-70B-Instruct",
   "meta/Llama-3.3-8B-Instruct",
   "meta/Llama-4-Maverick-17B-128E-Instruct-FP8",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -616,6 +616,16 @@ export type ParamsById = {
     "generationConfig.thinkingConfig.includeThoughts": boolean;
     "generationConfig.responseMimeType": "text/plain" | "application/json";
   };
+  "google/gemma-4-26b-a4b-it": {
+    "generationConfig.maxOutputTokens": number;
+    "generationConfig.temperature": number;
+    "generationConfig.topP": number;
+    "generationConfig.topK": number;
+    "generationConfig.seed": number;
+    "generationConfig.thinkingConfig.thinkingBudget": number;
+    "generationConfig.thinkingConfig.includeThoughts": boolean;
+    "generationConfig.responseMimeType": "text/plain" | "application/json";
+  };
   "meta/Llama-3.3-70B-Instruct": {
     max_completion_tokens: number;
     temperature: number;


### PR DESCRIPTION
### ✨ What changed
- Adds `gemma-4-26b-a4b-it` (google) to the catalog, params cloned from `google/gemini-2.5-flash-lite.yaml`.

### 💭 Why
The provider serves it but the catalog doesn't list it.

### 📝 Notes
- Liveness ✅ only: the model answers on its real endpoint, but params are sibling-cloned, not individually probed. Review the param surface.
- Draft PR, auto-proposed by the modelparams agent.