### PR TITLE
feat: add GPT-OSS, GLM-5.2, and Gemma 4

### DIFF
--- a/models/google/gemma-4-26b-a4b-it.yaml
+++ b/models/google/gemma-4-26b-a4b-it.yaml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: google
+authType: api_key
+model: gemma-4-26b-a4b-it
+params:
+  - path: generationConfig.maxOutputTokens
+    type: integer
+    label: Max output tokens
+    description: Maximum number of tokens to include in a response candidate.
+    range:
+      min: 1
+    group: generation_length
+  - path: generationConfig.temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: generationConfig.topP
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to the selected cumulative probability.
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: generationConfig.topK
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    range:
+      min: 0
+    group: sampling
+  - path: generationConfig.seed
+    type: integer
+    label: Seed
+    description: Optional seed used in decoding when reproducible sampling is desired.
+    group: sampling
+  - path: generationConfig.thinkingConfig.thinkingLevel
+    type: enum
+    label: Thinking level
+    description: Toggles Gemma 4's internal reasoning process.
+    values:
+      - minimal
+      - high
+    group: reasoning
+  - path: generationConfig.responseMimeType
+    type: enum
+    label: Response MIME type
+    description: MIME type for generated text candidates.
+    default: text/plain
+    values:
+      - text/plain
+      - application/json
+    group: output_format

--- a/models/google/gemma-4-31b-it.yaml
+++ b/models/google/gemma-4-31b-it.yaml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: google
+authType: api_key
+model: gemma-4-31b-it
+params:
+  - path: generationConfig.maxOutputTokens
+    type: integer
+    label: Max output tokens
+    description: Maximum number of tokens to include in a response candidate.
+    range:
+      min: 1
+    group: generation_length
+  - path: generationConfig.temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: generationConfig.topP
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to the selected cumulative probability.
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: generationConfig.topK
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    range:
+      min: 0
+    group: sampling
+  - path: generationConfig.seed
+    type: integer
+    label: Seed
+    description: Optional seed used in decoding when reproducible sampling is desired.
+    group: sampling
+  - path: generationConfig.thinkingConfig.thinkingLevel
+    type: enum
+    label: Thinking level
+    description: Toggles Gemma 4's internal reasoning process.
+    values:
+      - minimal
+      - high
+    group: reasoning
+  - path: generationConfig.responseMimeType
+    type: enum
+    label: Response MIME type
+    description: MIME type for generated text candidates.
+    default: text/plain
+    values:
+      - text/plain
+      - application/json
+    group: output_format

--- a/models/openai/gpt-oss-120b.yaml
+++ b/models/openai/gpt-oss-120b.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: openai
+authType: api_key
+model: gpt-oss-120b
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    range:
+      min: 1
+      max: 131072
+    group: generation_length
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning the model should perform before producing an answer.
+    values:
+      - low
+      - medium
+      - high
+    group: reasoning

--- a/models/openai/gpt-oss-20b.yaml
+++ b/models/openai/gpt-oss-20b.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: openai
+authType: api_key
+model: gpt-oss-20b
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    range:
+      min: 1
+      max: 131072
+    group: generation_length
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning the model should perform before producing an answer.
+    values:
+      - low
+      - medium
+      - high
+    group: reasoning

--- a/models/z-ai/glm-5.2-subscription.yaml
+++ b/models/z-ai/glm-5.2-subscription.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: z-ai
+authType: subscription
+model: glm-5.2
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    default: 65536
+    range:
+      min: 1
+      max: 131072
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        do_sample: false
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        do_sample: false
+  - path: do_sample
+    type: boolean
+    label: Do sample
+    description: When false, the model uses greedy decoding and ignores temperature and top_p.
+    default: true
+    group: sampling
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Toggles the model's extended reasoning before it produces the final answer.
+    default: enabled
+    values:
+      - enabled
+      - disabled
+    group: reasoning
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning the model performs when thinking is enabled.
+    default: max
+    values:
+      - max
+      - xhigh
+      - high
+      - medium
+      - low
+      - minimal
+      - none
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/models/z-ai/glm-5.2.yaml
+++ b/models/z-ai/glm-5.2.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: z-ai
+authType: api_key
+model: glm-5.2
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    default: 65536
+    range:
+      min: 1
+      max: 131072
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        do_sample: false
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        do_sample: false
+  - path: do_sample
+    type: boolean
+    label: Do sample
+    description: When false, the model uses greedy decoding and ignores temperature and top_p.
+    default: true
+    group: sampling
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Toggles the model's extended reasoning before it produces the final answer.
+    default: enabled
+    values:
+      - enabled
+      - disabled
+    group: reasoning
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning the model performs when thinking is enabled.
+    default: max
+    values:
+      - max
+      - xhigh
+      - high
+      - medium
+      - low
+      - minimal
+      - none
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -218,6 +218,7 @@ describe("provider catalog rows", () => {
     const byId = new Map(models.map((model) => [modelId(model), model]));
     const sharedModels = [
       "glm-5.1",
+      "glm-5.2",
       "glm-5-turbo",
       "glm-5",
       "glm-4.7",


### PR DESCRIPTION
### ✨ What changed
- Adds GPT-OSS 20B and 120B model parameter entries.
- Adds GLM-5.2 API-key and subscription entries.
- Adds the two Gemini API-hosted Gemma 4 instruction models.
- Checks GLM-5.2 route parameter parity.

### 💭 Why
The catalog was missing these current provider models and their configurable request parameters.

### 📝 Notes
- [OpenAI GPT-OSS docs](https://developers.openai.com/api/docs/models/gpt-oss-120b)
- [Z.ai GLM-5.2 API docs](https://docs.z.ai/api-reference/llm/chat-completion)
- [Gemma on the Gemini API](https://ai.google.dev/gemma/docs/core/gemma_on_gemini_api)
- Live smoke tests await Z.ai and Gemini API credentials. OpenAI lists zero gpt-oss API rate limits across all tiers.