### PR TITLE
feat: add GPT-OSS 20B parameters

### DIFF
--- a/models/openai/gpt-oss-20b.yaml
+++ b/models/openai/gpt-oss-20b.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: openai
+authType: api_key
+model: gpt-oss-20b
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    range:
+      min: 1
+      max: 131072
+    group: generation_length
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning the model should perform before producing an answer.
+    values:
+      - low
+      - medium
+      - high
+    group: reasoning


### PR DESCRIPTION
### ✨ What changed
- Adds the GPT-OSS 20B parameter entry.

### 💭 Why
The catalog was missing GPT-OSS 20B request parameters.

### 📝 Notes
- [OpenAI GPT-OSS docs](https://developers.openai.com/api/docs/models/gpt-oss-20b)
- OpenRouter smoke passed with `reasoning_effort: low` and `max_completion_tokens: 8`.
- Local validation, tests, and build pass.