### PR TITLE
feat: add GLM-5.2 parameters

### DIFF
--- a/models/z-ai/glm-5.2-subscription.yaml
+++ b/models/z-ai/glm-5.2-subscription.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: z-ai
+authType: subscription
+model: glm-5.2
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    default: 65536
+    range:
+      min: 1
+      max: 131072
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        do_sample: false
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        do_sample: false
+  - path: do_sample
+    type: boolean
+    label: Do sample
+    description: When false, the model uses greedy decoding and ignores temperature and top_p.
+    default: true
+    group: sampling
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Toggles the model's extended reasoning before it produces the final answer.
+    default: enabled
+    values:
+      - enabled
+      - disabled
+    group: reasoning
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning the model performs when thinking is enabled.
+    default: max
+    values:
+      - max
+      - xhigh
+      - high
+      - medium
+      - low
+      - minimal
+      - none
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/models/z-ai/glm-5.2.yaml
+++ b/models/z-ai/glm-5.2.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: z-ai
+authType: api_key
+model: glm-5.2
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    default: 65536
+    range:
+      min: 1
+      max: 131072
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        do_sample: false
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        do_sample: false
+  - path: do_sample
+    type: boolean
+    label: Do sample
+    description: When false, the model uses greedy decoding and ignores temperature and top_p.
+    default: true
+    group: sampling
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Toggles the model's extended reasoning before it produces the final answer.
+    default: enabled
+    values:
+      - enabled
+      - disabled
+    group: reasoning
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning the model performs when thinking is enabled.
+    default: max
+    values:
+      - max
+      - xhigh
+      - high
+      - medium
+      - low
+      - minimal
+      - none
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -218,6 +218,7 @@ describe("provider catalog rows", () => {
     const byId = new Map(models.map((model) => [modelId(model), model]));
     const sharedModels = [
       "glm-5.1",
+      "glm-5.2",
       "glm-5-turbo",
       "glm-5",
       "glm-4.7",


### PR DESCRIPTION
### ✨ What changed
- Adds GLM-5.2 API-key and subscription parameter entries.
- Checks API-key and subscription route parity.

### 💭 Why
The catalog was missing GLM-5.2 request parameters.

### 📝 Notes
- [Z.ai GLM-5.2 API docs](https://docs.z.ai/api-reference/llm/chat-completion)
- OpenRouter smoke passed with reasoning, sampling, and token controls.
- Local validation, tests, and build pass.