### PR TITLE
feat: add Gemma 4 26B parameters

### DIFF
--- a/models/google/gemma-4-26b-a4b-it.yaml
+++ b/models/google/gemma-4-26b-a4b-it.yaml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: google
+authType: api_key
+model: gemma-4-26b-a4b-it
+params:
+  - path: generationConfig.maxOutputTokens
+    type: integer
+    label: Max output tokens
+    description: Maximum number of tokens to include in a response candidate.
+    range:
+      min: 1
+    group: generation_length
+  - path: generationConfig.temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: generationConfig.topP
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to the selected cumulative probability.
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: generationConfig.topK
+    type: integer
+    label: Top K
+    description: Limits token sampling to the top K most likely next tokens.
+    range:
+      min: 0
+    group: sampling
+  - path: generationConfig.seed
+    type: integer
+    label: Seed
+    description: Optional seed used in decoding when reproducible sampling is desired.
+    group: sampling
+  - path: generationConfig.thinkingConfig.thinkingLevel
+    type: enum
+    label: Thinking level
+    description: Toggles Gemma 4's internal reasoning process.
+    values:
+      - minimal
+      - high
+    group: reasoning
+  - path: generationConfig.responseMimeType
+    type: enum
+    label: Response MIME type
+    description: MIME type for generated text candidates.
+    default: text/plain
+    values:
+      - text/plain
+      - application/json
+    group: output_format


### PR DESCRIPTION
### ✨ What changed
- Adds the Gemini API-hosted Gemma 4 26B A4B entry.

### 💭 Why
The catalog was missing Gemma 4 26B request parameters.

### 📝 Notes
- [Gemma on the Gemini API](https://ai.google.dev/gemma/docs/core/gemma_on_gemini_api)
- OpenRouter smoke passed with generation controls.
- Local validation, tests, and build pass.