### PR TITLE
feat: add xAI Grok 4.5 parameters

### DIFF
--- a/models/xai/grok-4.5-subscription.yaml
+++ b/models/xai/grok-4.5-subscription.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: xai
+authType: subscription
+model: grok-4.5
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max completion tokens
+    description: Upper bound for visible output tokens generated in the chat completion.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    default: 1
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: seed
+    type: integer
+    label: Seed
+    description: Optional seed used for decoding when reproducible sampling is desired.
+    group: sampling
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning Grok performs before responding. Reasoning cannot be disabled for this model.
+    default: high
+    values:
+      - low
+      - medium
+      - high
+    group: reasoning
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Controls whether the model returns text, JSON mode output, or structured JSON schema output.
+    default: text
+    values:
+      - text
+      - json_object
+      - json_schema
+    group: output_format

--- a/models/xai/grok-4.5.yaml
+++ b/models/xai/grok-4.5.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: xai
+authType: api_key
+model: grok-4.5
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max completion tokens
+    description: Upper bound for visible output tokens generated in the chat completion.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    default: 1
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: seed
+    type: integer
+    label: Seed
+    description: Optional seed used for decoding when reproducible sampling is desired.
+    group: sampling
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning Grok performs before responding. Reasoning cannot be disabled for this model.
+    default: high
+    values:
+      - low
+      - medium
+      - high
+    group: reasoning
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Controls whether the model returns text, JSON mode output, or structured JSON schema output.
+    default: text
+    values:
+      - text
+      - json_object
+      - json_schema
+    group: output_format


### PR DESCRIPTION
### What changed

- Add xAI Grok 4.5 API-key parameters.
- Add matching xAI OAuth subscription parameters.

### Why

Manifest supports xAI API-key and OAuth subscription routes for the same native API.

### Validation

- `npm run validate`
- `npm test`
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run guard:params -- --base mp/add-openai-gpt-5.6-luna`

Live smoke was not run because no xAI credential is available in this workspace.

Docs: https://docs.x.ai/developers/model-capabilities/text/reasoning
