### PR TITLE
feat: add groq/qwen3-32b parameters

### DIFF
--- a/models/groq/qwen3-32b.yaml
+++ b/models/groq/qwen3-32b.yaml
@@ -1,0 +1,89 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: groq
+authType: api_key
+model: qwen3-32b
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    default: 1
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: frequency_penalty
+    type: number
+    label: Frequency penalty
+    description: Penalizes tokens by how often they have appeared, reducing verbatim repetition.
+    default: 0
+    range:
+      min: -2
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: presence_penalty
+    type: number
+    label: Presence penalty
+    description: Penalizes tokens that have already appeared, encouraging the model to introduce new topics.
+    default: 0
+    range:
+      min: -2
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: seed
+    type: integer
+    label: Seed
+    description: Seed used for best-effort deterministic sampling when reproducible outputs are desired.
+    group: sampling
+  - path: stop
+    type: string
+    label: Stop
+    description: A string or list of strings where the API will stop generating further tokens. Groq accepts up to four stop sequences.
+    group: generation_length
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls whether the model reasons before answering. 'none' disables reasoning; 'default' lets the model reason.
+    default: default
+    values:
+      - none
+      - default
+    group: reasoning
+  - path: reasoning_format
+    type: enum
+    label: Reasoning format
+    description: Controls how reasoning tokens are returned — hidden from the response, raw within the content, or parsed into a separate field.
+    values:
+      - hidden
+      - raw
+      - parsed
+    group: reasoning
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/src/data/logos.ts
+++ b/src/data/logos.ts
@@ -28,6 +28,7 @@ const SLUG_TO_LOBE: Record<string, string> = {
   moonshot: "moonshot",
   alibaba: "alibabacloud-color",
   "z-ai": "zai",
+  groq: "groq",
 };
 
 const cache = new Map<string, string | null>();


### PR DESCRIPTION
Adds parameter coverage for **groq/qwen3-32b** (Groq-served Qwen3-32B). Addresses #84.

New provider `groq` (api_key), plus a lobe-icons logo mapping.

### Parameters (10)
`max_completion_tokens`, `temperature`, `top_p`, `frequency_penalty`, `presence_penalty`, `seed`, `stop`, `reasoning_effort`, `reasoning_format`, `response_format.type`.

### Verified against the live Groq API
Every parameter was smoke-tested against `POST /openai/v1/chat/completions` with `model: qwen/qwen3-32b` (Groq's API model string; the catalog id flattens the `qwen/` prefix, consistent with how `nvidia/*` is stored). Each returned `200`; an unsupported param like `top_k` returns `400`, so acceptance is real.

- `reasoning_effort` values are `none` / `default` — confirmed by the API's own validation error: *"`reasoning_effort` must be one of `none` or `default`"*. `low`/`medium`/`high` are rejected on qwen3 (those are for gpt-oss).
- `frequency_penalty` / `presence_penalty` are accepted (200), so they're listed even though Groq notes they're currently behavioral no-ops.

Validated locally: `npm run validate`, `npm test`, `npm run guard:params`, `npm run typecheck`, `npm run build` all pass.