### PR TITLE
feat: add cerebras/zai-glm-4.7 parameters

### DIFF
--- a/models/cerebras/zai-glm-4.7.yaml
+++ b/models/cerebras/zai-glm-4.7.yaml
@@ -1,0 +1,85 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: cerebras
+authType: api_key
+model: zai-glm-4.7
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate, including reasoning tokens.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied. Adjust this or top_p, not both.
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: frequency_penalty
+    type: number
+    label: Frequency penalty
+    description: Penalizes tokens by how often they have appeared, reducing verbatim repetition.
+    default: 0
+    range:
+      min: -2
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: presence_penalty
+    type: number
+    label: Presence penalty
+    description: Penalizes tokens that have already appeared, encouraging the model to introduce new topics.
+    default: 0
+    range:
+      min: -2
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: seed
+    type: integer
+    label: Seed
+    description: Seed used for best-effort deterministic sampling when reproducible outputs are desired.
+    group: sampling
+  - path: stop
+    type: string
+    label: Stop
+    description: A string or list of strings where the API will stop generating further tokens. Cerebras accepts up to four stop sequences.
+    group: generation_length
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning the model performs before answering. 'none' disables reasoning.
+    values:
+      - none
+      - low
+      - medium
+      - high
+    group: reasoning
+  - path: clear_thinking
+    type: boolean
+    label: Clear thinking
+    description: When true, the model's thinking from previous turns is excluded from the conversation context; when false, it is preserved, which is useful for agentic workflows.
+    default: true
+    group: reasoning
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/src/data/logos.ts
+++ b/src/data/logos.ts
@@ -29,6 +29,7 @@ const SLUG_TO_LOBE: Record<string, string> = {
   alibaba: "alibabacloud-color",
   "z-ai": "zai",
   groq: "groq",
+  cerebras: "cerebras-color",
 };
 
 const cache = new Map<string, string | null>();


### PR DESCRIPTION
Adds parameter coverage for **cerebras/zai-glm-4.7** (Cerebras-served GLM-4.7). Addresses #85.

New provider `cerebras` (api_key), plus a lobe-icons logo mapping.

### Parameters (10)
`max_completion_tokens`, `temperature`, `top_p`, `frequency_penalty`, `presence_penalty`, `seed`, `stop`, `reasoning_effort`, `clear_thinking`, `response_format.type`.

### Verified against the live Cerebras API
Every parameter was smoke-tested against `POST /v1/chat/completions` with `model: zai-glm-4.7`. Each returned `200`; an unsupported param like `top_k` returns `400`, so acceptance is real.

- `reasoning_effort` values are `none` / `low` / `medium` / `high` — confirmed by the API's own validation error: *"Input should be 'none', 'low', 'medium' or 'high'"* (`default` is rejected, unlike Groq's build of the same knob).
- `clear_thinking` (boolean, default `true`) is GLM-4.7-specific — controls whether prior-turn thinking is kept in context.

Validated locally: `npm run validate`, `npm test`, `npm run guard:params`, `npm run typecheck`, `npm run build` all pass.