### PR TITLE
feat: add openai/gpt-4o-mini-search-preview

### DIFF
--- a/models/openai/gpt-4o-mini-search-preview.yaml
+++ b/models/openai/gpt-4o-mini-search-preview.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: openai
+authType: api_key
+model: gpt-4o-mini-search-preview
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 1
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
+      reaches this value.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -11913,6 +11913,50 @@ export const CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "model": "gpt-4o-mini-search-preview",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 4096,
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 2,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens whose cumulative probability reaches this value.",
+        "group": "sampling",
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      }
+    ]
+  },
+  {
+    "provider": "openai",
+    "authType": "api_key",
     "model": "gpt-5",
     "params": [
       {

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -923,6 +923,11 @@ export const DEFAULTS = {
     temperature: 1,
     top_p: 1,
   },
+  "openai/gpt-4o-mini-search-preview": {
+    max_tokens: 4096,
+    temperature: 1,
+    top_p: 1,
+  },
   "openai/gpt-5": {
     max_completion_tokens: 4096,
     reasoning_effort: "medium",

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -142,6 +142,7 @@ export const MODEL_IDS = [
   "openai/gpt-4o",
   "openai/gpt-4o-2024-11-20",
   "openai/gpt-4o-mini",
+  "openai/gpt-4o-mini-search-preview",
   "openai/gpt-5",
   "openai/gpt-5-chat-latest",
   "openai/gpt-5-mini",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -1131,6 +1131,11 @@ export type ParamsById = {
     temperature: number;
     top_p: number;
   };
+  "openai/gpt-4o-mini-search-preview": {
+    max_tokens: number;
+    temperature: number;
+    top_p: number;
+  };
   "openai/gpt-5": {
     max_completion_tokens: number;
     reasoning_effort: "minimal" | "low" | "medium" | "high";


### PR DESCRIPTION
### ✨ What changed
- Adds `gpt-4o-mini-search-preview` (openai) to the catalog, params cloned from `openai/gpt-4o-mini.yaml`.

### 💭 Why
The provider serves it but the catalog doesn't list it.

### 📝 Notes
- Liveness ✅ only: the model answers on its real endpoint, but params are sibling-cloned, not individually probed. Review the param surface.
- Draft PR, auto-proposed by the modelparams agent.