### PR TITLE
feat: add openai/gpt-5.2-chat-latest

### DIFF
--- a/models/openai/gpt-5.2-chat-latest.yaml
+++ b/models/openai/gpt-5.2-chat-latest.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: openai
+authType: api_key
+model: gpt-5.2-chat-latest
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 16
+    group: generation_length
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning the model should perform before producing an answer.
+    default: medium
+    values:
+      - none
+      - low
+      - medium
+      - high
+      - xhigh
+    group: reasoning

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -12188,6 +12188,39 @@ export const CATALOG = [
   },
   {
     "provider": "openai",
+    "authType": "api_key",
+    "model": "gpt-5.2-chat-latest",
+    "params": [
+      {
+        "path": "max_completion_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 4096,
+        "range": {
+          "min": 16
+        }
+      },
+      {
+        "path": "reasoning_effort",
+        "label": "Reasoning effort",
+        "description": "Controls how much reasoning the model should perform before producing an answer.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "medium",
+        "values": [
+          "none",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    ]
+  },
+  {
+    "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.2-codex",
     "params": [

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -956,6 +956,10 @@ export const DEFAULTS = {
     max_completion_tokens: 4096,
     reasoning_effort: "medium",
   },
+  "openai/gpt-5.2-chat-latest": {
+    max_completion_tokens: 4096,
+    reasoning_effort: "medium",
+  },
   "openai/gpt-5.2-codex-subscription": {
     "reasoning.effort": "medium",
     "reasoning.summary": "auto",

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -150,6 +150,7 @@ export const MODEL_IDS = [
   "openai/gpt-5.1-codex-max-subscription",
   "openai/gpt-5.1-codex-subscription",
   "openai/gpt-5.2",
+  "openai/gpt-5.2-chat-latest",
   "openai/gpt-5.2-codex-subscription",
   "openai/gpt-5.2-subscription",
   "openai/gpt-5.3-codex",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -1164,6 +1164,10 @@ export type ParamsById = {
     max_completion_tokens: number;
     reasoning_effort: "none" | "low" | "medium" | "high" | "xhigh";
   };
+  "openai/gpt-5.2-chat-latest": {
+    max_completion_tokens: number;
+    reasoning_effort: "none" | "low" | "medium" | "high" | "xhigh";
+  };
   "openai/gpt-5.2-codex-subscription": {
     "reasoning.effort": "minimal" | "low" | "medium" | "high" | "xhigh";
     "reasoning.summary": "auto" | "concise" | "detailed" | "none";


### PR DESCRIPTION
### ✨ What changed
- Adds `gpt-5.2-chat-latest` (openai) to the catalog, params cloned from `openai/gpt-5.2.yaml`.

### 💭 Why
The provider serves it but the catalog doesn't list it.

### 📝 Notes
- Liveness ✅ only: the model answers on its real endpoint, but params are sibling-cloned, not individually probed. Review the param surface.
- Draft PR, auto-proposed by the modelparams agent.