### PR TITLE
feat: add openai/gpt-5.3-chat-latest

### DIFF
--- a/models/openai/gpt-5.3-chat-latest.yaml
+++ b/models/openai/gpt-5.3-chat-latest.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: openai
+authType: api_key
+model: gpt-5.3-chat-latest
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 16
+    group: generation_length
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning the model should perform before producing an answer.
+    default: medium
+    values:
+      - low
+      - medium
+      - high
+      - xhigh
+    group: reasoning

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -12287,6 +12287,38 @@ export const CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "model": "gpt-5.3-chat-latest",
+    "params": [
+      {
+        "path": "max_completion_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 4096,
+        "range": {
+          "min": 16
+        }
+      },
+      {
+        "path": "reasoning_effort",
+        "label": "Reasoning effort",
+        "description": "Controls how much reasoning the model should perform before producing an answer.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "medium",
+        "values": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    ]
+  },
+  {
+    "provider": "openai",
+    "authType": "api_key",
     "model": "gpt-5.3-codex",
     "params": [
       {

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -966,6 +966,10 @@ export const DEFAULTS = {
     "reasoning.summary": "auto",
     "text.verbosity": "medium",
   },
+  "openai/gpt-5.3-chat-latest": {
+    max_completion_tokens: 4096,
+    reasoning_effort: "medium",
+  },
   "openai/gpt-5.3-codex": {
     max_completion_tokens: 4096,
     reasoning_effort: "medium",

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -152,6 +152,7 @@ export const MODEL_IDS = [
   "openai/gpt-5.2",
   "openai/gpt-5.2-codex-subscription",
   "openai/gpt-5.2-subscription",
+  "openai/gpt-5.3-chat-latest",
   "openai/gpt-5.3-codex",
   "openai/gpt-5.3-codex-spark-subscription",
   "openai/gpt-5.3-codex-subscription",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -1174,6 +1174,10 @@ export type ParamsById = {
     "reasoning.summary": "auto" | "concise" | "detailed" | "none";
     "text.verbosity": "low" | "medium" | "high";
   };
+  "openai/gpt-5.3-chat-latest": {
+    max_completion_tokens: number;
+    reasoning_effort: "low" | "medium" | "high" | "xhigh";
+  };
   "openai/gpt-5.3-codex": {
     max_completion_tokens: number;
     reasoning_effort: "low" | "medium" | "high" | "xhigh";


### PR DESCRIPTION
### ✨ What changed
- Adds `gpt-5.3-chat-latest` (openai) to the catalog, params cloned from `openai/gpt-5.3-codex.yaml`.

### 💭 Why
The provider serves it but the catalog doesn't list it.

### 📝 Notes
- Liveness ✅ only: the model answers on its real endpoint, but params are sibling-cloned, not individually probed. Review the param surface.
- Draft PR, auto-proposed by the modelparams agent.