### PR TITLE
feat: add openai/chat-latest

### DIFF
--- a/models/openai/chat-latest.yaml
+++ b/models/openai/chat-latest.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: openai
+authType: api_key
+model: chat-latest
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 1
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens whose cumulative probability
+      reaches this value.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -11473,6 +11473,50 @@ export const CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "model": "chat-latest",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 4096,
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 2,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens whose cumulative probability reaches this value.",
+        "group": "sampling",
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      }
+    ]
+  },
+  {
+    "provider": "openai",
+    "authType": "api_key",
     "model": "chatgpt-4o-latest",
     "params": [
       {

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -873,6 +873,11 @@ export const DEFAULTS = {
     max_tokens: 1024,
     expert_type: "auto",
   },
+  "openai/chat-latest": {
+    max_tokens: 4096,
+    temperature: 1,
+    top_p: 1,
+  },
   "openai/chatgpt-4o-latest": {
     max_tokens: 4096,
     temperature: 1,

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -132,6 +132,7 @@ export const MODEL_IDS = [
   "nvidia/nemotron-mini-4b-instruct",
   "nvidia/riva-translate-4b-instruct-v1.1",
   "nvidia/usdcode-llama-3.1-70b-instruct",
+  "openai/chat-latest",
   "openai/chatgpt-4o-latest",
   "openai/gpt-3.5-turbo",
   "openai/gpt-4-turbo",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -1081,6 +1081,11 @@ export type ParamsById = {
     max_tokens: number;
     expert_type: "auto" | "code" | "knowledge" | "helperfunction";
   };
+  "openai/chat-latest": {
+    max_tokens: number;
+    temperature: number;
+    top_p: number;
+  };
   "openai/chatgpt-4o-latest": {
     max_tokens: number;
     temperature: number;


### PR DESCRIPTION
### ✨ What changed
- Adds `chat-latest` (openai) to the catalog, params cloned from `openai/chatgpt-4o-latest.yaml`.

### 💭 Why
The provider serves it but the catalog doesn't list it.

### 📝 Notes
- Liveness ✅ only: the model answers on its real endpoint, but params are sibling-cloned, not individually probed. Review the param surface.
- Draft PR, auto-proposed by the modelparams agent.