### PR TITLE
feat: add moonshot/kimi-k3

### DIFF
--- a/models/moonshot/kimi-k3.yaml
+++ b/models/moonshot/kimi-k3.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: moonshot
+authType: api_key
+model: kimi-k3
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the chat completion.
+    range:
+      min: 1
+    group: generation_length
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: >-
+      Controls whether Kimi reasons step by step before answering, or responds directly when set to
+      disabled.
+    values:
+      - enabled
+      - disabled
+    group: reasoning
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/models/moonshot/kimi-k3.yaml
+++ b/models/moonshot/kimi-k3.yaml
@@ -23,9 +23,10 @@ params:
   - path: response_format.type
     type: enum
     label: Response format
-    description: Forces the response into plain text or a JSON object.
+    description: Forces the response into plain text, a JSON object, or JSON matching a provided schema.
     default: text
     values:
       - text
       - json_object
+      - json_schema
     group: output_format

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -10145,6 +10145,46 @@ export const CATALOG = [
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "model": "kimi-k3",
+    "params": [
+      {
+        "path": "max_completion_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of tokens to generate in the chat completion.",
+        "group": "generation_length",
+        "type": "integer",
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "thinking.type",
+        "label": "Thinking mode",
+        "description": "Controls whether Kimi reasons step by step before answering, or responds directly when set to disabled.",
+        "group": "reasoning",
+        "type": "enum",
+        "values": [
+          "enabled",
+          "disabled"
+        ]
+      },
+      {
+        "path": "response_format.type",
+        "label": "Response format",
+        "description": "Forces the response into plain text or a JSON object.",
+        "group": "output_format",
+        "type": "enum",
+        "default": "text",
+        "values": [
+          "text",
+          "json_object"
+        ]
+      }
+    ]
+  },
+  {
+    "provider": "moonshot",
+    "authType": "api_key",
     "model": "moonshot-v1-128k",
     "params": [
       {

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -10171,13 +10171,14 @@ export const CATALOG = [
       {
         "path": "response_format.type",
         "label": "Response format",
-        "description": "Forces the response into plain text or a JSON object.",
+        "description": "Forces the response into plain text, a JSON object, or JSON matching a provided schema.",
         "group": "output_format",
         "type": "enum",
         "default": "text",
         "values": [
           "text",
-          "json_object"
+          "json_object",
+          "json_schema"
         ]
       }
     ]

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -749,6 +749,9 @@ export const DEFAULTS = {
   "moonshot/kimi-k2.7-code-subscription": {
     "response_format.type": "text",
   },
+  "moonshot/kimi-k3": {
+    "response_format.type": "text",
+  },
   "moonshot/moonshot-v1-128k": {
     temperature: 0.3,
     top_p: 1,

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -113,6 +113,7 @@ export const MODEL_IDS = [
   "moonshot/kimi-k2.6-subscription",
   "moonshot/kimi-k2.7-code-highspeed-subscription",
   "moonshot/kimi-k2.7-code-subscription",
+  "moonshot/kimi-k3",
   "moonshot/moonshot-v1-128k",
   "moonshot/moonshot-v1-32k",
   "moonshot/moonshot-v1-8k",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -938,6 +938,11 @@ export type ParamsById = {
     max_completion_tokens: number;
     "response_format.type": "text" | "json_object";
   };
+  "moonshot/kimi-k3": {
+    max_completion_tokens: number;
+    "thinking.type": "enabled" | "disabled";
+    "response_format.type": "text" | "json_object";
+  };
   "moonshot/moonshot-v1-128k": {
     max_completion_tokens: number;
     temperature: number;

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -941,7 +941,7 @@ export type ParamsById = {
   "moonshot/kimi-k3": {
     max_completion_tokens: number;
     "thinking.type": "enabled" | "disabled";
-    "response_format.type": "text" | "json_object";
+    "response_format.type": "text" | "json_object" | "json_schema";
   };
   "moonshot/moonshot-v1-128k": {
     max_completion_tokens: number;


### PR DESCRIPTION
### ✨ What changed
- Adds `kimi-k3` (moonshot, api_key) to the catalog, params cloned from `moonshot/kimi-k2.5.yaml` and then individually probed live.
- Adds `json_schema` to `response_format.type` — the live probe surfaced it as a third accepted value (Moonshot's error enum: `'text', 'json_object', 'json_schema'`) and structured output was verified end-to-end.

### 💭 Why
Moonshot AI announced it (new model) and the catalog doesn't list it yet.

### 📝 Notes
- Smoke ✅ (full tier): every declared param probed against `api.moonshot.ai/v1/chat/completions` on 2026-07-17, all served as exact id `kimi-k3`:
  - baseline + `max_completion_tokens` (1 and 8) → 200
  - `thinking.type` enabled / disabled → 200; negative control `zzz_invalid` → 400 "invalid value for thinking type"
  - `response_format.type` text / json_object / json_schema (schema honored: `{"name":"Bob","age":30}`) → 200; negative control → 400 naming the real enum
- Source: https://platform.kimi.ai/docs/models
- Auto-proposed by manifest-model-watch; upgraded liveness → full tier by a follow-up probe run.

Companion Manifest PR: mnfst/manifest#2520 (Kimi Coding Plan knownModels).
