### PR TITLE
feat: add moonshot/moonshot-v1-8k-vision-preview

### DIFF
--- a/models/moonshot/moonshot-v1-8k-vision-preview.yaml
+++ b/models/moonshot/moonshot-v1-8k-vision-preview.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: moonshot
+authType: api_key
+model: moonshot-v1-8k-vision-preview
+params:
+  - path: max_completion_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the chat completion.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: >-
+      Controls randomness. Lower values make outputs more focused; higher values make them more
+      varied.
+    default: 0.3
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: >-
+      Controls nucleus sampling by limiting generation to tokens within the selected cumulative
+      probability.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: n
+    type: integer
+    label: Number of completions
+    description: How many chat completion choices to generate for the request.
+    default: 1
+    range:
+      min: 1
+      max: 5
+    group: generation_length
+  - path: presence_penalty
+    type: number
+    label: Presence penalty
+    description: >-
+      Penalizes tokens that have already appeared, encouraging the model to talk about new topics.
+    default: 0
+    range:
+      min: -2
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: frequency_penalty
+    type: number
+    label: Frequency penalty
+    description: Penalizes tokens by how often they have appeared, reducing verbatim repetition.
+    default: 0
+    range:
+      min: -2
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -11306,6 +11306,99 @@ export const CATALOG = [
     ]
   },
   {
+    "provider": "moonshot",
+    "authType": "api_key",
+    "model": "moonshot-v1-8k-vision-preview",
+    "params": [
+      {
+        "path": "max_completion_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of tokens to generate in the chat completion.",
+        "group": "generation_length",
+        "type": "integer",
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "type": "number",
+        "default": 0.3,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.",
+        "group": "sampling",
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "n",
+        "label": "Number of completions",
+        "description": "How many chat completion choices to generate for the request.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 1,
+        "range": {
+          "min": 1,
+          "max": 5
+        }
+      },
+      {
+        "path": "presence_penalty",
+        "label": "Presence penalty",
+        "description": "Penalizes tokens that have already appeared, encouraging the model to talk about new topics.",
+        "group": "sampling",
+        "type": "number",
+        "default": 0,
+        "range": {
+          "min": -2,
+          "max": 2,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "frequency_penalty",
+        "label": "Frequency penalty",
+        "description": "Penalizes tokens by how often they have appeared, reducing verbatim repetition.",
+        "group": "sampling",
+        "type": "number",
+        "default": 0,
+        "range": {
+          "min": -2,
+          "max": 2,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "response_format.type",
+        "label": "Response format",
+        "description": "Forces the response into plain text or a JSON object.",
+        "group": "output_format",
+        "type": "enum",
+        "default": "text",
+        "values": [
+          "text",
+          "json_object"
+        ]
+      }
+    ]
+  },
+  {
     "provider": "nvidia",
     "authType": "api_key",
     "model": "gliner-pii",

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -849,6 +849,14 @@ export const DEFAULTS = {
     frequency_penalty: 0,
     "response_format.type": "text",
   },
+  "moonshot/moonshot-v1-8k-vision-preview": {
+    temperature: 0.3,
+    top_p: 1,
+    n: 1,
+    presence_penalty: 0,
+    frequency_penalty: 0,
+    "response_format.type": "text",
+  },
   "nvidia/gliner-pii": {
     threshold: 0.5,
     chunk_length: 384,

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -132,6 +132,7 @@ export const MODEL_IDS = [
   "moonshot/moonshot-v1-128k",
   "moonshot/moonshot-v1-32k",
   "moonshot/moonshot-v1-8k",
+  "moonshot/moonshot-v1-8k-vision-preview",
   "nvidia/gliner-pii",
   "nvidia/llama-3.1-nemoguard-8b-topic-control",
   "nvidia/llama-3.1-nemotron-nano-8b-v1",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -1068,6 +1068,15 @@ export type ParamsById = {
     frequency_penalty: number;
     "response_format.type": "text" | "json_object";
   };
+  "moonshot/moonshot-v1-8k-vision-preview": {
+    max_completion_tokens: number;
+    temperature: number;
+    top_p: number;
+    n: number;
+    presence_penalty: number;
+    frequency_penalty: number;
+    "response_format.type": "text" | "json_object";
+  };
   "nvidia/gliner-pii": {
     threshold: number;
     chunk_length: number;


### PR DESCRIPTION
### ✨ What changed
- Adds `moonshot-v1-8k-vision-preview` (moonshot) to the catalog, params cloned from `moonshot/moonshot-v1-8k.yaml`.

### 💭 Why
The provider serves it but the catalog doesn't list it.

### 📝 Notes
- Liveness ✅ only: the model answers on its real endpoint, but params are sibling-cloned, not individually probed. Review the param surface.
- Draft PR, auto-proposed by the modelparams agent.