### PR TITLE
feat: add alibaba/qwen3.5-omni-plus

### DIFF
--- a/models/alibaba/qwen3.5-omni-plus.yaml
+++ b/models/alibaba/qwen3.5-omni-plus.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: alibaba
+authType: api_key
+model: qwen3.5-omni-plus
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: extra_body.top_k
+    type: integer
+    label: Top K
+    description: Limits generation to the selected number of highest-probability tokens.
+    default: 20
+    range:
+      min: 1
+    group: sampling
+  - path: extra_body.chat_template_kwargs.enable_thinking
+    type: boolean
+    label: Enable thinking
+    description: Controls Qwen3 thinking mode when using OpenAI-compatible clients that pass provider-specific extra body fields.
+    default: true
+    group: reasoning

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -411,6 +411,66 @@ export const CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "model": "qwen3.5-omni-plus",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "type": "number",
+        "range": {
+          "min": 0,
+          "max": 2,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.",
+        "group": "sampling",
+        "type": "number",
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "extra_body.top_k",
+        "label": "Top K",
+        "description": "Limits generation to the selected number of highest-probability tokens.",
+        "group": "sampling",
+        "type": "integer",
+        "default": 20,
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "extra_body.chat_template_kwargs.enable_thinking",
+        "label": "Enable thinking",
+        "description": "Controls Qwen3 thinking mode when using OpenAI-compatible clients that pass provider-specific extra body fields.",
+        "group": "reasoning",
+        "type": "boolean",
+        "default": true
+      }
+    ]
+  },
+  {
+    "provider": "alibaba",
+    "authType": "api_key",
     "model": "qwen3.6-flash",
     "params": [
       {

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -31,6 +31,10 @@ export const DEFAULTS = {
     "extra_body.top_k": 20,
     "extra_body.chat_template_kwargs.enable_thinking": true,
   },
+  "alibaba/qwen3.5-omni-plus": {
+    "extra_body.top_k": 20,
+    "extra_body.chat_template_kwargs.enable_thinking": true,
+  },
   "alibaba/qwen3.6-flash": {
     "extra_body.top_k": 20,
     "extra_body.enable_thinking": true,

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -9,6 +9,7 @@ export const MODEL_IDS = [
   "alibaba/qwen3-max",
   "alibaba/qwen3.5",
   "alibaba/qwen3.5-flash",
+  "alibaba/qwen3.5-omni-plus",
   "alibaba/qwen3.6-flash",
   "alibaba/qwen3.7-max",
   "alibaba/qwen3.7-plus",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -54,6 +54,13 @@ export type ParamsById = {
     "extra_body.top_k": number;
     "extra_body.chat_template_kwargs.enable_thinking": boolean;
   };
+  "alibaba/qwen3.5-omni-plus": {
+    max_tokens: number;
+    temperature: number;
+    top_p: number;
+    "extra_body.top_k": number;
+    "extra_body.chat_template_kwargs.enable_thinking": boolean;
+  };
   "alibaba/qwen3.6-flash": {
     max_completion_tokens: number;
     temperature: number;


### PR DESCRIPTION
### ✨ What changed
- Adds `qwen3.5-omni-plus` (alibaba) to the catalog, params cloned from `alibaba/qwen3.5-flash.yaml`.

### 💭 Why
The provider serves it but the catalog doesn't list it.

### 📝 Notes
- Liveness ✅ only: the model answers on its real endpoint, but params are sibling-cloned, not individually probed. Review the param surface.
- Draft PR, auto-proposed by the modelparams agent.