### PR TITLE
feat: add Claude Opus 5 parameters

### DIFF
--- a/models/anthropic/claude-opus-5-subscription.yaml
+++ b/models/anthropic/claude-opus-5-subscription.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: subscription
+model: claude-opus-5
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: adaptive
+    values:
+      - disabled
+      - adaptive
+    group: reasoning
+    applicability:
+      except:
+        output_config.effort:
+          - xhigh
+          - max
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: omitted
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - adaptive
+  - path: output_config.effort
+    type: enum
+    label: Effort
+    description: Controls Anthropic response thoroughness and token spend.
+    default: high
+    values:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    group: reasoning

--- a/models/anthropic/claude-opus-5.yaml
+++ b/models/anthropic/claude-opus-5.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: api_key
+model: claude-opus-5
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    default: 4096
+    range:
+      min: 1
+    group: generation_length
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Controls the Anthropic thinking mode values supported by this model.
+    default: adaptive
+    values:
+      - disabled
+      - adaptive
+    group: reasoning
+    applicability:
+      except:
+        output_config.effort:
+          - xhigh
+          - max
+  - path: thinking.display
+    type: enum
+    label: Thinking display
+    description: Controls whether Anthropic returns summarized or omitted thinking content.
+    default: omitted
+    values:
+      - summarized
+      - omitted
+    group: reasoning
+    applicability:
+      only:
+        thinking.type:
+          - adaptive
+  - path: output_config.effort
+    type: enum
+    label: Effort
+    description: Controls Anthropic response thoroughness and token spend.
+    default: high
+    values:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    group: reasoning

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -3759,6 +3759,150 @@ export const CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "model": "claude-opus-5",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 4096,
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "thinking.type",
+        "label": "Thinking mode",
+        "description": "Controls the Anthropic thinking mode values supported by this model.",
+        "group": "reasoning",
+        "applicability": {
+          "except": {
+            "output_config.effort": [
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        "type": "enum",
+        "default": "adaptive",
+        "values": [
+          "disabled",
+          "adaptive"
+        ]
+      },
+      {
+        "path": "thinking.display",
+        "label": "Thinking display",
+        "description": "Controls whether Anthropic returns summarized or omitted thinking content.",
+        "group": "reasoning",
+        "applicability": {
+          "only": {
+            "thinking.type": [
+              "adaptive"
+            ]
+          }
+        },
+        "type": "enum",
+        "default": "omitted",
+        "values": [
+          "summarized",
+          "omitted"
+        ]
+      },
+      {
+        "path": "output_config.effort",
+        "label": "Effort",
+        "description": "Controls Anthropic response thoroughness and token spend.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "high",
+        "values": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
+    ]
+  },
+  {
+    "provider": "anthropic",
+    "authType": "subscription",
+    "model": "claude-opus-5",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 4096,
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "thinking.type",
+        "label": "Thinking mode",
+        "description": "Controls the Anthropic thinking mode values supported by this model.",
+        "group": "reasoning",
+        "applicability": {
+          "except": {
+            "output_config.effort": [
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        "type": "enum",
+        "default": "adaptive",
+        "values": [
+          "disabled",
+          "adaptive"
+        ]
+      },
+      {
+        "path": "thinking.display",
+        "label": "Thinking display",
+        "description": "Controls whether Anthropic returns summarized or omitted thinking content.",
+        "group": "reasoning",
+        "applicability": {
+          "only": {
+            "thinking.type": [
+              "adaptive"
+            ]
+          }
+        },
+        "type": "enum",
+        "default": "omitted",
+        "values": [
+          "summarized",
+          "omitted"
+        ]
+      },
+      {
+        "path": "output_config.effort",
+        "label": "Effort",
+        "description": "Controls Anthropic response thoroughness and token spend.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "high",
+        "values": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
+    ]
+  },
+  {
+    "provider": "anthropic",
+    "authType": "api_key",
     "model": "claude-sonnet-4-20250514",
     "params": [
       {

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -264,6 +264,18 @@ export const DEFAULTS = {
     "thinking.type": "disabled",
     "thinking.budget_tokens": 4096,
   },
+  "anthropic/claude-opus-5": {
+    max_tokens: 4096,
+    "thinking.type": "adaptive",
+    "thinking.display": "omitted",
+    "output_config.effort": "high",
+  },
+  "anthropic/claude-opus-5-subscription": {
+    max_tokens: 4096,
+    "thinking.type": "adaptive",
+    "thinking.display": "omitted",
+    "output_config.effort": "high",
+  },
   "anthropic/claude-sonnet-4-20250514": {
     max_tokens: 4096,
     temperature: 1,

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -42,6 +42,8 @@ export const MODEL_IDS = [
   "anthropic/claude-opus-4-8",
   "anthropic/claude-opus-4-8-subscription",
   "anthropic/claude-opus-4-subscription",
+  "anthropic/claude-opus-5",
+  "anthropic/claude-opus-5-subscription",
   "anthropic/claude-sonnet-4-20250514",
   "anthropic/claude-sonnet-4-20250514-subscription",
   "anthropic/claude-sonnet-4-5",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -304,6 +304,18 @@ export type ParamsById = {
     "thinking.type": "disabled" | "adaptive" | "enabled";
     "thinking.budget_tokens": number;
   };
+  "anthropic/claude-opus-5": {
+    max_tokens: number;
+    "thinking.type": "disabled" | "adaptive";
+    "thinking.display": "summarized" | "omitted";
+    "output_config.effort": "low" | "medium" | "high" | "xhigh" | "max";
+  };
+  "anthropic/claude-opus-5-subscription": {
+    max_tokens: number;
+    "thinking.type": "disabled" | "adaptive";
+    "thinking.display": "summarized" | "omitted";
+    "output_config.effort": "low" | "medium" | "high" | "xhigh" | "max";
+  };
   "anthropic/claude-sonnet-4-20250514": {
     max_tokens: number;
     temperature: number;


### PR DESCRIPTION
### What changed
- Adds API-key and subscription rows for `claude-opus-5`.
- Models adaptive thinking and all five effort levels.

### Why
Claude Opus 5 has a distinct parameter surface and subscription route.

### Notes
Official docs: https://platform.claude.com/docs/en/build-with-claude/effort
Live smoke skipped because no Anthropic API key or Manifest API key is available.
Local validation, tests, build, typecheck, lint, and parameter guard pass.