### PR TITLE
Update deepseek-v4-flash.yaml

### DIFF
--- a/models/deepseek/deepseek-v4-flash.yaml
+++ b/models/deepseek/deepseek-v4-flash.yaml
@@ -55,7 +55,7 @@ params:
   - path: reasoning_effort
     type: enum
     label: Reasoning effort
-    description: Controls DeepSeek thinking effort when thinking mode is enabled.
+    description: Controls DeepSeek thinking effort when thinking mode is enabled. For compatibility, low, medium, and xhigh are also accepted, but low and medium are mapped to high, and xhigh is mapped to max.
     default: high
     values:
       - high


### PR DESCRIPTION
## What this changes

Added further details about reasoning effort options that are accepted by the API but get silently mapped to the actual supported options. source: https://api-docs.deepseek.com/guides/thinking_mode/

## Type of change

Tick whatever fits. This just helps reviewers triage; nothing is enforced.

- [ ] Add a model (new YAML file under `models/`)
- [ ] Add a provider (new folder under `models/`, plus a logo)
- [x] Add or update parameters on an existing model
- [ ] Fix incorrect data (default, range, values, applicability)
- [ ] Site or tooling (code under `src/`, docs, CI)

## Source

https://api-docs.deepseek.com/guides/thinking_mode/

## Before opening

- [ ] `npm run validate` and `npm test` pass locally
- [ ] Filenames follow the convention: `models/<provider>/<model>.yaml`, or `<model>-subscription.yaml` for the subscription route
- [ ] No existing parameter was removed (removals are blocked, see CONTRIBUTING)
