### PR TITLE
feat: add alibaba/qwen-vl-max

### DIFF
--- a/models/alibaba/qwen-vl-max.yaml
+++ b/models/alibaba/qwen-vl-max.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: alibaba
+authType: api_key
+model: qwen-vl-max
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    range:
+      min: 0
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: extra_body.top_k
+    type: integer
+    label: Top K
+    description: Limits generation to the selected number of highest-probability tokens.
+    default: 20
+    range:
+      min: 1
+    group: sampling
+  - path: extra_body.chat_template_kwargs.enable_thinking
+    type: boolean
+    label: Enable thinking
+    description: Controls Qwen3 thinking mode when using OpenAI-compatible clients that pass provider-specific extra body fields.
+    default: true
+    group: reasoning

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -127,6 +127,66 @@ export const CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "model": "qwen-vl-max",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "type": "number",
+        "range": {
+          "min": 0,
+          "max": 2,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.",
+        "group": "sampling",
+        "type": "number",
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "extra_body.top_k",
+        "label": "Top K",
+        "description": "Limits generation to the selected number of highest-probability tokens.",
+        "group": "sampling",
+        "type": "integer",
+        "default": 20,
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "extra_body.chat_template_kwargs.enable_thinking",
+        "label": "Enable thinking",
+        "description": "Controls Qwen3 thinking mode when using OpenAI-compatible clients that pass provider-specific extra body fields.",
+        "group": "reasoning",
+        "type": "boolean",
+        "default": true
+      }
+    ]
+  },
+  {
+    "provider": "alibaba",
+    "authType": "api_key",
     "model": "qwen3-coder-flash",
     "params": [
       {

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -13,6 +13,10 @@ export const DEFAULTS = {
     "extra_body.top_k": 20,
     "extra_body.chat_template_kwargs.enable_thinking": true,
   },
+  "alibaba/qwen-vl-max": {
+    "extra_body.top_k": 20,
+    "extra_body.chat_template_kwargs.enable_thinking": true,
+  },
   "alibaba/qwen3-coder-flash": {
     "extra_body.top_k": 20,
   },

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -4,6 +4,7 @@
 export const MODEL_IDS = [
   "alibaba/qwen-flash",
   "alibaba/qwen-plus",
+  "alibaba/qwen-vl-max",
   "alibaba/qwen3-coder-flash",
   "alibaba/qwen3-coder-plus",
   "alibaba/qwen3-max",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -21,6 +21,13 @@ export type ParamsById = {
     "extra_body.top_k": number;
     "extra_body.chat_template_kwargs.enable_thinking": boolean;
   };
+  "alibaba/qwen-vl-max": {
+    max_tokens: number;
+    temperature: number;
+    top_p: number;
+    "extra_body.top_k": number;
+    "extra_body.chat_template_kwargs.enable_thinking": boolean;
+  };
   "alibaba/qwen3-coder-flash": {
     max_tokens: number;
     temperature: number;


### PR DESCRIPTION
### ✨ What changed
- Adds `qwen-vl-max` (alibaba) to the catalog, params cloned from `alibaba/qwen-flash.yaml`.

### 💭 Why
The provider serves it but the catalog doesn't list it.

### 📝 Notes
- Liveness ✅ only: the model answers on its real endpoint, but params are sibling-cloned, not individually probed. Review the param surface.
- Draft PR, auto-proposed by the modelparams agent.