### PR TITLE
fix: compare the param guard against the merge base

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,8 +145,9 @@ that setting and breaks their setup.
 
 CI enforces this. The `Param guard` workflow (`npm run guard:params`) compares your
 PR against `main` and **fails if any parameter `path` that exists on a model is gone**
-— this includes renaming a `path` (the old name counts as removed). You can run the
-same check locally before opening a PR:
+— this includes renaming a `path` (the old name counts as removed). The comparison
+runs against the merge base, so parameters `main` gained after you branched are not
+counted against you. You can run the same check locally before opening a PR:
 
 ```bash
 npm run guard:params            # compares against origin/main

--- a/src/data/check-removals.ts
+++ b/src/data/check-removals.ts
@@ -1,5 +1,5 @@
 import { loadAllModels } from "./load.js";
-import { loadModelsAtRef, refExists } from "./git-baseline.js";
+import { loadModelsAtRef, mergeBase, refExists } from "./git-baseline.js";
 import { findRemovedParams, type ParamRemoval } from "./removals.js";
 
 const OVERRIDE_LABEL = "allow-param-removal";
@@ -12,14 +12,30 @@ function argBase(): string | undefined {
   return undefined;
 }
 
-/** Resolve the base ref to diff against, trying the most specific source first. */
-function resolveBaseRef(): string | null {
+interface Baseline {
+  /** Commit the current catalog is compared against. */
+  commit: string;
+  /** How to name that commit in output. */
+  label: string;
+}
+
+/**
+ * Resolve the baseline to diff against, trying the most specific source first.
+ *
+ * The catalog is compared against the merge base rather than the tip of the
+ * base branch: the tip may have moved on since this checkout was built, and
+ * anything it gained in the meantime is not something this change removed.
+ */
+function resolveBaseline(): Baseline | null {
   const githubBase = process.env.GITHUB_BASE_REF
     ? `origin/${process.env.GITHUB_BASE_REF}`
     : undefined;
   const candidates = [argBase(), process.env.BASE_REF, githubBase, "origin/main", "main"];
   for (const ref of candidates) {
-    if (ref && refExists(ref)) return ref;
+    if (!ref || !refExists(ref)) continue;
+    const base = mergeBase(ref);
+    if (!base) return { commit: ref, label: ref };
+    return { commit: base, label: `${ref} (merge base ${base.slice(0, 7)})` };
   }
   return null;
 }
@@ -46,24 +62,24 @@ function reportRemovals(removals: ParamRemoval[], baseRef: string): void {
 }
 
 async function main(): Promise<void> {
-  const baseRef = resolveBaseRef();
-  if (!baseRef) {
+  const baseline = resolveBaseline();
+  if (!baseline) {
     console.log("No base ref available to compare against — skipping removal guard.");
     return;
   }
 
   const [{ models: current }, base] = await Promise.all([
     loadAllModels(),
-    loadModelsAtRef(baseRef),
+    loadModelsAtRef(baseline.commit),
   ]);
 
   const removals = findRemovedParams(base, current);
   if (removals.length === 0) {
-    console.log(`OK — no parameters removed vs ${baseRef}.`);
+    console.log(`OK — no parameters removed vs ${baseline.label}.`);
     return;
   }
 
-  reportRemovals(removals, baseRef);
+  reportRemovals(removals, baseline.label);
   process.exit(1);
 }
 

--- a/src/data/git-baseline.ts
+++ b/src/data/git-baseline.ts
@@ -26,6 +26,25 @@ export function refExists(ref: string): boolean {
 }
 
 /**
+ * Return the commit `ref` and `HEAD` share, or null when git cannot find one
+ * (unrelated histories, or a clone shallow enough to hide it).
+ *
+ * On a pull request the checkout is GitHub's `refs/pull/N/merge` commit, which
+ * is only recomputed when the PR or its base is pushed to. A re-run — or a
+ * `labeled` event — therefore compares a merge built against an older base with
+ * a freshly fetched base tip, and every parameter the base gained in between
+ * reads as a removal. The merge base is the commit the tree in hand was
+ * actually built on, so both sides of the diff come from the same snapshot.
+ */
+export function mergeBase(ref: string): string | null {
+  try {
+    return git(["merge-base", ref, "HEAD"]).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Materialize the `models/` tree at `ref` into a temp dir and load it. Returns
  * an empty array when `ref` has no catalog (e.g. before the catalog existed).
  */

--- a/tests/git-baseline.test.ts
+++ b/tests/git-baseline.test.ts
@@ -7,11 +7,8 @@ describe("mergeBase", () => {
     expect(mergeBase("HEAD")).toBe(head);
   });
 
-  it("returns a commit both sides share", () => {
-    const parent = git(["rev-parse", "HEAD^"]).trim();
-    expect(mergeBase(parent)).toBe(parent);
-  });
-
+  // Nothing here may assume HEAD has a parent: CI clones shallow, and the
+  // guard falls back to the ref itself when git cannot find a merge base.
   it("returns null for a ref git cannot resolve", () => {
     expect(mergeBase("no-such-ref-for-tests")).toBeNull();
   });

--- a/tests/git-baseline.test.ts
+++ b/tests/git-baseline.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { git, mergeBase, refExists } from "../src/data/git-baseline.js";
+
+describe("mergeBase", () => {
+  it("resolves a ref that is already an ancestor of HEAD to that ref", () => {
+    const head = git(["rev-parse", "HEAD"]).trim();
+    expect(mergeBase("HEAD")).toBe(head);
+  });
+
+  it("returns a commit both sides share", () => {
+    const parent = git(["rev-parse", "HEAD^"]).trim();
+    expect(mergeBase(parent)).toBe(parent);
+  });
+
+  it("returns null for a ref git cannot resolve", () => {
+    expect(mergeBase("no-such-ref-for-tests")).toBeNull();
+  });
+});
+
+describe("refExists", () => {
+  it("is true for HEAD and false for a made-up ref", () => {
+    expect(refExists("HEAD")).toBe(true);
+    expect(refExists("no-such-ref-for-tests")).toBe(false);
+  });
+});


### PR DESCRIPTION
### 💭 Why

The param guard diffs the checked-out tree against the **tip** of the base branch. On a pull request that tree is GitHub's `refs/pull/N/merge` commit, which is only recomputed when the PR or its base is pushed to. A re-run — or a `labeled` event, which is exactly how the `allow-param-removal` override is applied — therefore compares a merge built on an older base against a base tip that has moved on. Every parameter the base gained in between reads as a removal.

That is how [run 26753498917](https://github.com/mnfst/modelparams.dev/actions/runs/26753498917) blocked #37. Re-run four days after it was queued, it reported `mistral/magistral-medium-latest` and `-small-latest` losing `prompt_mode` — a provider that PR never touched. `prompt_mode` had landed on `main` in #42 in the meantime.

### ✨ What changed

`resolveBaseline()` narrows the resolved base ref to `git merge-base <ref> HEAD`, so both sides of the comparison come from the same snapshot. Added `mergeBase()` to `git-baseline.ts`, plus tests. Output now names the commit it actually compared:

```
OK — no parameters removed vs origin/main (merge base 6e11d6f).
```

No workflow change: `BASE_REF` stays `origin/<base_ref>`.

### 🔧 For operators

Verified against the two runs that motivated this, replaying each PR's merge tree through `findRemovedParams`:

| PR | vs base tip (before) | vs merge base (after) |
|---|---|---|
| #37 add ollama/qwen3.5-9b | `mistral/magistral-*` → `prompt_mode` | clean |
| #132 add z-ai/glm-5.2 | `z-ai/glm-5.2` → `reasoning_effort` | `z-ai/glm-5.2` → `reasoning_effort` |

The false positive clears; the true positive stays caught. #132 really would drop `reasoning_effort`, because #136 landed the same model on `main` with a fuller param set — that PR needs a rebase, not a label.

### 📝 Notes

Local runs get the same treatment, which also makes `npm run guard:params` on a branch behind `main` stop reporting other people's additions.