### PR TITLE
fix: accept catalog defaults in Python validation

### DIFF
--- a/packages/modelparams-python/src/modelparams/validation.py
+++ b/packages/modelparams-python/src/modelparams/validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from functools import cache
 from typing import Any, cast
 
@@ -16,4 +17,6 @@ def params_adapter(model_id: ModelId) -> TypeAdapter[Any]:
 
 
 def validate_params(model_id: ModelId, params: object) -> dict[str, JsonPrimitive]:
+    if isinstance(params, Mapping):
+        params = dict(params)
     return cast(dict[str, JsonPrimitive], params_adapter(model_id).validate_python(params))

--- a/packages/modelparams-python/tests/test_validation.py
+++ b/packages/modelparams-python/tests/test_validation.py
@@ -21,6 +21,11 @@ def test_accepts_valid_and_empty_params() -> None:
     assert validate_params(GPT, {}) == {}
 
 
+def test_accepts_catalog_defaults_mapping() -> None:
+    defaults = get_defaults(GPT)
+    assert validate_params(GPT, defaults) == dict(defaults)
+
+
 def test_rejects_unknown_keys_and_collects_errors() -> None:
     with pytest.raises(ValidationError) as caught:
         validate_params(GPT, {"temperature": 5, "nope": 1})


### PR DESCRIPTION
### ✨ What changed
- Normalize Mapping inputs before Pydantic validation.
- Add regression coverage for passing get_defaults() directly.

### 💭 Why
get_defaults() returns an immutable mapping. Passing it to validate_params() previously failed at runtime.

### 👤 For users
Catalog defaults can now be validated without a manual dict conversion.

### 📝 Notes
Validated with 22 Python tests, Ruff, formatting, mypy, wheel/Twine checks, and installed-wheel smoke.