### PR TITLE
feat: add Python package install commands

### DIFF
--- a/src/build/render-api.ts
+++ b/src/build/render-api.ts
@@ -8,7 +8,7 @@ import { hubLinks, renderShell, viewHelpers } from "./render.js";
 
 const API_TITLE = `API documentation · ${SITE_NAME}`;
 const API_DESCRIPTION =
-  "How to use the modelparams.dev JSON API, npm package, and provider logos. Static, CORS-enabled, served from the edge.";
+  "How to use the modelparams.dev JSON API, npm and Python packages, and provider logos. Static, CORS-enabled, served from the edge.";
 
 export async function renderApiPage(allModels: Model[]): Promise<string> {
   const body = await ejs.renderFile(path.join(VIEWS_DIR, "api.ejs"), {

--- a/src/build/structured-data.ts
+++ b/src/build/structured-data.ts
@@ -18,6 +18,7 @@ import { type Model } from "../schema/model.js";
 
 const REPO_URL = "https://github.com/mnfst/modelparams.dev";
 const NPM_URL = "https://www.npmjs.com/package/modelparams";
+const PYPI_URL = "https://pypi.org/project/modelparams/";
 
 interface Crumb {
   name: string;
@@ -47,7 +48,7 @@ function organizationNode(siteUrl: string) {
     name: SITE_NAME,
     url: `${siteUrl}/`,
     description: SITE_DESCRIPTION,
-    sameAs: [REPO_URL, NPM_URL],
+    sameAs: [REPO_URL, NPM_URL, PYPI_URL],
   };
 }
 

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -99,21 +99,23 @@ function setupCopyHowToUse(): void {
   });
 }
 
-function setupCopyNpm(): void {
-  const btn = document.querySelector<HTMLButtonElement>("[data-copy-npm]");
-  if (!btn) return;
-  const idle = btn.querySelector<HTMLElement>("[data-copy-npm-idle]");
-  const done = btn.querySelector<HTMLElement>("[data-copy-npm-done]");
-  let timer = 0;
-  btn.addEventListener("click", async () => {
-    await copyText("npm i modelparams");
-    idle?.classList.add("hidden");
-    done?.classList.remove("hidden");
-    window.clearTimeout(timer);
-    timer = window.setTimeout(() => {
-      idle?.classList.remove("hidden");
-      done?.classList.add("hidden");
-    }, 2000);
+function setupCopyInstallCommands(): void {
+  document.querySelectorAll<HTMLButtonElement>("[data-copy-install]").forEach((btn) => {
+    const command = btn.dataset.copyInstall;
+    if (!command) return;
+    const idle = btn.querySelector<HTMLElement>("[data-copy-install-idle]");
+    const done = btn.querySelector<HTMLElement>("[data-copy-install-done]");
+    let timer = 0;
+    btn.addEventListener("click", async () => {
+      await copyText(command);
+      idle?.classList.add("hidden");
+      done?.classList.remove("hidden");
+      window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        idle?.classList.remove("hidden");
+        done?.classList.add("hidden");
+      }, 2000);
+    });
   });
 }
 
@@ -533,7 +535,7 @@ function setupMobileMenu(): void {
 
 document.addEventListener("DOMContentLoaded", () => {
   setupThemeToggle();
-  setupCopyNpm();
+  setupCopyInstallCommands();
   setupHowToUseModal();
   setupCopyHowToUse();
   setupProvidersMenu();

--- a/src/data/llms.ts
+++ b/src/data/llms.ts
@@ -89,6 +89,20 @@ function guideApi(siteUrl: string): string[] {
   ];
 }
 
+function guidePackages(): string[] {
+  return [
+    "## Packages",
+    "",
+    "Install the typed catalog package for your language:",
+    "",
+    "```bash",
+    "npm install modelparams",
+    "pip install modelparams",
+    "```",
+    "",
+  ];
+}
+
 function guideAgents(siteUrl: string): string[] {
   return [
     "## Contribute",
@@ -112,7 +126,12 @@ function guideAgents(siteUrl: string): string[] {
  * it backs the modal's Copy button and the body of /llms-full.txt.
  */
 export function usageGuideMarkdown(siteUrl: string): string {
-  return [...guideIntro(siteUrl), ...guideApi(siteUrl), ...guideAgents(siteUrl)].join("\n");
+  return [
+    ...guideIntro(siteUrl),
+    ...guidePackages(),
+    ...guideApi(siteUrl),
+    ...guideAgents(siteUrl),
+  ].join("\n");
 }
 
 function fmtValue(value: unknown): string {

--- a/src/views/api.ejs
+++ b/src/views/api.ejs
@@ -7,7 +7,7 @@
   <h1 class="tracking-tight">How to use the API</h1>
   <p class="mt-3 max-w-2xl text-pretty text-slate-600 dark:text-slate-300">
     The full catalog is available as static JSON, CORS-enabled, served from the edge.
-    You can also install the npm package or point your AI agent at <a href="/llms.txt" class="text-accent hover:text-accent-hover">/llms.txt</a>.
+    You can also install the npm or Python package, or point your AI agent at <a href="/llms.txt" class="text-accent hover:text-accent-hover">/llms.txt</a>.
   </p>
 
   <div class="mt-10 max-w-3xl space-y-12">
@@ -98,6 +98,17 @@
       </p>
       <div class="mt-4">
         <pre class="overflow-x-auto border border-slate-200 bg-slate-900 px-5 py-4 font-mono text-sm leading-relaxed text-slate-200 dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code>npm i modelparams</code></pre>
+      </div>
+    </section>
+
+    <!-- Python -->
+    <section>
+      <h2 class="text-slate-900 dark:text-slate-100">Python package</h2>
+      <p class="mt-2 text-slate-600 dark:text-slate-300">
+        Install the package to use typed model parameters and the bundled catalog in Python.
+      </p>
+      <div class="mt-4">
+        <pre class="overflow-x-auto border border-slate-200 bg-slate-900 px-5 py-4 font-mono text-sm leading-relaxed text-slate-200 dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code>pip install modelparams</code></pre>
       </div>
     </section>
 

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -5,24 +5,42 @@
     </h1>
     <p class="mt-4 max-w-2xl text-pretty text-base text-slate-600 dark:text-slate-400 sm:text-lg">
       An open, community-maintained catalog of model parameters.
-      Browse the UI below, query the API, or install the npm package.
+      Browse the UI below, query the API, or install the npm or Python package.
     </p>
 
     <div class="mt-8 flex flex-wrap items-center gap-4">
-      <!-- npm install — code snippet to copy -->
+      <!-- package install — code snippets to copy -->
       <div class="flex items-center border-2 border-slate-700 bg-slate-800 px-6 py-3 dark:border-slate-500 dark:bg-slate-900">
         <code class="font-mono text-sm text-slate-200"><span class="select-none text-slate-500">$ </span><span class="select-all">npm i modelparams</span></code>
         <button
           type="button"
-          data-copy-npm
-          aria-label="Copy to clipboard"
+          data-copy-install="npm i modelparams"
+          aria-label="Copy npm install command"
           class="group ml-6 shrink-0 text-slate-400 hover:text-white"
         >
-          <svg viewBox="0 0 16 16" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" data-copy-npm-idle>
+          <svg viewBox="0 0 16 16" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" data-copy-install-idle>
             <rect x="5" y="5" width="9" height="9" rx="1" />
             <path d="M5 11H3.5A1.5 1.5 0 012 9.5v-7A1.5 1.5 0 013.5 1h7A1.5 1.5 0 0112 2.5V5" />
           </svg>
-          <svg viewBox="0 0 16 16" class="hidden h-4 w-4 text-emerald-400" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" data-copy-npm-done>
+          <svg viewBox="0 0 16 16" class="hidden h-4 w-4 text-emerald-400" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" data-copy-install-done>
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.5 8.5l3 3 6-6" />
+          </svg>
+        </button>
+      </div>
+
+      <div class="flex items-center border-2 border-slate-700 bg-slate-800 px-6 py-3 dark:border-slate-500 dark:bg-slate-900">
+        <code class="font-mono text-sm text-slate-200"><span class="select-none text-slate-500">$ </span><span class="select-all">pip install modelparams</span></code>
+        <button
+          type="button"
+          data-copy-install="pip install modelparams"
+          aria-label="Copy Python install command"
+          class="group ml-6 shrink-0 text-slate-400 hover:text-white"
+        >
+          <svg viewBox="0 0 16 16" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" data-copy-install-idle>
+            <rect x="5" y="5" width="9" height="9" rx="1" />
+            <path d="M5 11H3.5A1.5 1.5 0 012 9.5v-7A1.5 1.5 0 013.5 1h7A1.5 1.5 0 0112 2.5V5" />
+          </svg>
+          <svg viewBox="0 0 16 16" class="hidden h-4 w-4 text-emerald-400" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" data-copy-install-done>
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.5 8.5l3 3 6-6" />
           </svg>
         </button>

--- a/src/views/partials/footer.ejs
+++ b/src/views/partials/footer.ejs
@@ -30,6 +30,7 @@
       <div class="flex flex-col gap-2 text-sm">
         <a href="/" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">Full catalog</a>
         <a href="https://www.npmjs.com/package/modelparams" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">npm package <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-3 w-3 shrink-0" aria-hidden="true"><path d="M17 16V7H8v2h5.59l-6.3 6.29 1.42 1.42 6.29-6.3V16z"></path></svg></a>
+        <a href="https://pypi.org/project/modelparams/" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">Python package <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-3 w-3 shrink-0" aria-hidden="true"><path d="M17 16V7H8v2h5.59l-6.3 6.29 1.42 1.42 6.29-6.3V16z"></path></svg></a>
         <a href="https://github.com/mnfst/modelparams.dev" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">GitHub <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-3 w-3 shrink-0" aria-hidden="true"><path d="M17 16V7H8v2h5.59l-6.3 6.29 1.42 1.42 6.29-6.3V16z"></path></svg></a>
       </div>
 


### PR DESCRIPTION
### ✨ What changed
- Add Python install commands to the homepage and API documentation.
- Link the Python package from the footer, agent guide, and JSON-LD metadata.
- Give each install command its own copy button.

### 💭 Why
The Python package is published on PyPI but was not discoverable from modelparams.dev.

### 👤 For users
Python users can copy `pip install modelparams` directly from the site.