### PR TITLE
feat: add mistral/zai-glm-5-2

### DIFF
--- a/models/mistral/zai-glm-5-2.yaml
+++ b/models/mistral/zai-glm-5-2.yaml
@@ -1,0 +1,85 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: mistral
+authType: api_key
+model: zai-glm-5-2
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the completion.
+    range:
+      min: 1
+    group: generation_length
+  - path: stop
+    type: string
+    label: Stop sequence
+    description: Stops generation when this string is detected.
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    range:
+      min: 0
+      max: 1.5
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: random_seed
+    type: integer
+    label: Random seed
+    description: Seed used for deterministic sampling when reproducible outputs are desired.
+    range:
+      min: 0
+    group: sampling
+  - path: presence_penalty
+    type: number
+    label: Presence penalty
+    description: Penalizes repeated words or phrases to encourage a wider variety of generated content.
+    default: 0
+    range:
+      min: -2
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: frequency_penalty
+    type: number
+    label: Frequency penalty
+    description: Penalizes words based on how often they already appear in the generated text.
+    default: 0
+    range:
+      min: -2
+      max: 2
+      step: 0.1
+    group: sampling
+  - path: prompt_mode
+    type: enum
+    label: Prompt mode
+    description: Enables Mistral's reasoning system prompt; leave unset to disable the default reasoning behavior.
+    values:
+      - reasoning
+    group: reasoning
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Controls whether the model returns normal text or JSON mode output.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format
+  - path: safe_prompt
+    type: boolean
+    label: Safe prompt
+    description: Controls whether Mistral injects its safety prompt before the conversation.
+    default: false
+    group: provider_metadata

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -11301,6 +11301,121 @@ export const CATALOG = [
     ]
   },
   {
+    "provider": "mistral",
+    "authType": "api_key",
+    "model": "zai-glm-5-2",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of tokens to generate in the completion.",
+        "group": "generation_length",
+        "type": "integer",
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "stop",
+        "label": "Stop sequence",
+        "description": "Stops generation when this string is detected.",
+        "group": "generation_length",
+        "type": "string"
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "type": "number",
+        "range": {
+          "min": 0,
+          "max": 1.5,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.",
+        "group": "sampling",
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "random_seed",
+        "label": "Random seed",
+        "description": "Seed used for deterministic sampling when reproducible outputs are desired.",
+        "group": "sampling",
+        "type": "integer",
+        "range": {
+          "min": 0
+        }
+      },
+      {
+        "path": "presence_penalty",
+        "label": "Presence penalty",
+        "description": "Penalizes repeated words or phrases to encourage a wider variety of generated content.",
+        "group": "sampling",
+        "type": "number",
+        "default": 0,
+        "range": {
+          "min": -2,
+          "max": 2,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "frequency_penalty",
+        "label": "Frequency penalty",
+        "description": "Penalizes words based on how often they already appear in the generated text.",
+        "group": "sampling",
+        "type": "number",
+        "default": 0,
+        "range": {
+          "min": -2,
+          "max": 2,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "prompt_mode",
+        "label": "Prompt mode",
+        "description": "Enables Mistral's reasoning system prompt; leave unset to disable the default reasoning behavior.",
+        "group": "reasoning",
+        "type": "enum",
+        "values": [
+          "reasoning"
+        ]
+      },
+      {
+        "path": "response_format.type",
+        "label": "Response format",
+        "description": "Controls whether the model returns normal text or JSON mode output.",
+        "group": "output_format",
+        "type": "enum",
+        "default": "text",
+        "values": [
+          "text",
+          "json_object"
+        ]
+      },
+      {
+        "path": "safe_prompt",
+        "label": "Safe prompt",
+        "description": "Controls whether Mistral injects its safety prompt before the conversation.",
+        "group": "provider_metadata",
+        "type": "boolean",
+        "default": false
+      }
+    ]
+  },
+  {
     "provider": "moonshot",
     "authType": "api_key",
     "model": "kimi-k2.5",

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -834,6 +834,13 @@ export const DEFAULTS = {
     "response_format.type": "text",
     safe_prompt: false,
   },
+  "mistral/zai-glm-5-2": {
+    top_p: 1,
+    presence_penalty: 0,
+    frequency_penalty: 0,
+    "response_format.type": "text",
+    safe_prompt: false,
+  },
   "moonshot/kimi-k2.5": {
     "response_format.type": "text",
   },

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -127,6 +127,7 @@ export const MODEL_IDS = [
   "mistral/mistral-medium-latest",
   "mistral/mistral-small-latest",
   "mistral/open-mistral-nemo",
+  "mistral/zai-glm-5-2",
   "moonshot/kimi-k2.5",
   "moonshot/kimi-k2.6",
   "moonshot/kimi-k2.6-subscription",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -1060,6 +1060,18 @@ export type ParamsById = {
     "response_format.type": "text" | "json_object";
     safe_prompt: boolean;
   };
+  "mistral/zai-glm-5-2": {
+    max_tokens: number;
+    stop: string;
+    temperature: number;
+    top_p: number;
+    random_seed: number;
+    presence_penalty: number;
+    frequency_penalty: number;
+    prompt_mode: "reasoning";
+    "response_format.type": "text" | "json_object";
+    safe_prompt: boolean;
+  };
   "moonshot/kimi-k2.5": {
     max_completion_tokens: number;
     "thinking.type": "enabled" | "disabled";


### PR DESCRIPTION
### ✨ What changed
- Adds `zai-glm-5-2` (mistral) to the catalog, params cloned from `mistral/magistral-medium-latest.yaml`.

### 💭 Why
The provider serves it but the catalog doesn't list it.

### 📝 Notes
- Liveness ✅ only: the model answers on its real endpoint, but params are sibling-cloned, not individually probed. Review the param surface.
- Draft PR, auto-proposed by the modelparams agent.