### PR TITLE
feat: add alibaba/qwen-max and alibaba/qwen-turbo

### DIFF
--- a/models/alibaba/qwen-max.yaml
+++ b/models/alibaba/qwen-max.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: alibaba
+authType: api_key
+model: qwen-max
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    range:
+      min: 0
+      max: 1.9
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: extra_body.top_k
+    type: integer
+    label: Top K
+    description: Limits generation to the selected number of highest-probability tokens.
+    default: 20
+    range:
+      min: 1
+    group: sampling
+  - path: extra_body.chat_template_kwargs.enable_thinking
+    type: boolean
+    label: Enable thinking
+    description: Controls Qwen3 thinking mode when using OpenAI-compatible clients that pass provider-specific extra body fields.
+    default: true
+    group: reasoning

--- a/models/alibaba/qwen-turbo.yaml
+++ b/models/alibaba/qwen-turbo.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: alibaba
+authType: api_key
+model: qwen-turbo
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    range:
+      min: 1
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    range:
+      min: 0
+      max: 1.9
+      step: 0.1
+    group: sampling
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+  - path: extra_body.top_k
+    type: integer
+    label: Top K
+    description: Limits generation to the selected number of highest-probability tokens.
+    default: 20
+    range:
+      min: 1
+    group: sampling
+  - path: extra_body.chat_template_kwargs.enable_thinking
+    type: boolean
+    label: Enable thinking
+    description: Controls Qwen3 thinking mode when using OpenAI-compatible clients that pass provider-specific extra body fields.
+    default: true
+    group: reasoning

--- a/packages/modelparams-python/src/modelparams/_generated/catalog.json
+++ b/packages/modelparams-python/src/modelparams/_generated/catalog.json
@@ -62,7 +62,127 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "model": "qwen-max",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "type": "number",
+        "range": {
+          "min": 0,
+          "max": 1.9,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.",
+        "group": "sampling",
+        "type": "number",
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "extra_body.top_k",
+        "label": "Top K",
+        "description": "Limits generation to the selected number of highest-probability tokens.",
+        "group": "sampling",
+        "type": "integer",
+        "default": 20,
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "extra_body.chat_template_kwargs.enable_thinking",
+        "label": "Enable thinking",
+        "description": "Controls Qwen3 thinking mode when using OpenAI-compatible clients that pass provider-specific extra body fields.",
+        "group": "reasoning",
+        "type": "boolean",
+        "default": true
+      }
+    ]
+  },
+  {
+    "provider": "alibaba",
+    "authType": "api_key",
     "model": "qwen-plus",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "type": "number",
+        "range": {
+          "min": 0,
+          "max": 1.9,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.",
+        "group": "sampling",
+        "type": "number",
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "extra_body.top_k",
+        "label": "Top K",
+        "description": "Limits generation to the selected number of highest-probability tokens.",
+        "group": "sampling",
+        "type": "integer",
+        "default": 20,
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "extra_body.chat_template_kwargs.enable_thinking",
+        "label": "Enable thinking",
+        "description": "Controls Qwen3 thinking mode when using OpenAI-compatible clients that pass provider-specific extra body fields.",
+        "group": "reasoning",
+        "type": "boolean",
+        "default": true
+      }
+    ]
+  },
+  {
+    "provider": "alibaba",
+    "authType": "api_key",
+    "model": "qwen-turbo",
     "params": [
       {
         "path": "max_tokens",

--- a/packages/modelparams-python/src/modelparams/_generated/model_ids.py
+++ b/packages/modelparams-python/src/modelparams/_generated/model_ids.py
@@ -5,7 +5,9 @@ from typing import Literal
 
 ModelId = Literal[
     "alibaba/qwen-flash",
+    "alibaba/qwen-max",
     "alibaba/qwen-plus",
+    "alibaba/qwen-turbo",
     "alibaba/qwen3-coder-flash",
     "alibaba/qwen3-coder-plus",
     "alibaba/qwen3-max",
@@ -264,7 +266,9 @@ ModelId = Literal[
 
 MODEL_IDS: tuple[ModelId, ...] = (
     "alibaba/qwen-flash",
+    "alibaba/qwen-max",
     "alibaba/qwen-plus",
+    "alibaba/qwen-turbo",
     "alibaba/qwen3-coder-flash",
     "alibaba/qwen3-coder-plus",
     "alibaba/qwen3-max",

--- a/packages/modelparams-python/src/modelparams/_generated/registry.py
+++ b/packages/modelparams-python/src/modelparams/_generated/registry.py
@@ -26,7 +26,9 @@ from .model_ids import ModelId
 
 PARAM_TYPES: dict[ModelId, Any] = {
     "alibaba/qwen-flash": alibaba.Qwen_FlashParams,
+    "alibaba/qwen-max": alibaba.Qwen_MaxParams,
     "alibaba/qwen-plus": alibaba.Qwen_PlusParams,
+    "alibaba/qwen-turbo": alibaba.Qwen_TurboParams,
     "alibaba/qwen3-coder-flash": alibaba.Qwen3_Coder_FlashParams,
     "alibaba/qwen3-coder-plus": alibaba.Qwen3_Coder_PlusParams,
     "alibaba/qwen3-max": alibaba.Qwen3_MaxParams,

--- a/packages/modelparams-python/src/modelparams/types/alibaba.py
+++ b/packages/modelparams-python/src/modelparams/types/alibaba.py
@@ -23,6 +23,19 @@ Qwen_FlashParams = TypedDict(
 )
 setattr(Qwen_FlashParams, "__pydantic_config__", _PARAMS_CONFIG)
 
+Qwen_MaxParams = TypedDict(
+    "Qwen_MaxParams",
+    {
+        "max_tokens": Annotated[int, Field(ge=1)],
+        "temperature": Annotated[float, Field(ge=0, le=1.9)],
+        "top_p": Annotated[float, Field(ge=0, le=1)],
+        "extra_body.top_k": Annotated[int, Field(ge=1)],
+        "extra_body.chat_template_kwargs.enable_thinking": bool,
+    },
+    total=False,
+)
+setattr(Qwen_MaxParams, "__pydantic_config__", _PARAMS_CONFIG)
+
 Qwen_PlusParams = TypedDict(
     "Qwen_PlusParams",
     {
@@ -35,6 +48,19 @@ Qwen_PlusParams = TypedDict(
     total=False,
 )
 setattr(Qwen_PlusParams, "__pydantic_config__", _PARAMS_CONFIG)
+
+Qwen_TurboParams = TypedDict(
+    "Qwen_TurboParams",
+    {
+        "max_tokens": Annotated[int, Field(ge=1)],
+        "temperature": Annotated[float, Field(ge=0, le=1.9)],
+        "top_p": Annotated[float, Field(ge=0, le=1)],
+        "extra_body.top_k": Annotated[int, Field(ge=1)],
+        "extra_body.chat_template_kwargs.enable_thinking": bool,
+    },
+    total=False,
+)
+setattr(Qwen_TurboParams, "__pydantic_config__", _PARAMS_CONFIG)
 
 Qwen3_Coder_FlashParams = TypedDict(
     "Qwen3_Coder_FlashParams",
@@ -183,7 +209,9 @@ setattr(Qwq_PlusParams, "__pydantic_config__", _PARAMS_CONFIG)
 
 __all__ = [
     "Qwen_FlashParams",
+    "Qwen_MaxParams",
     "Qwen_PlusParams",
+    "Qwen_TurboParams",
     "Qwen3_Coder_FlashParams",
     "Qwen3_Coder_PlusParams",
     "Qwen3_MaxParams",

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -67,7 +67,127 @@ export const CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "model": "qwen-max",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "type": "number",
+        "range": {
+          "min": 0,
+          "max": 1.9,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.",
+        "group": "sampling",
+        "type": "number",
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "extra_body.top_k",
+        "label": "Top K",
+        "description": "Limits generation to the selected number of highest-probability tokens.",
+        "group": "sampling",
+        "type": "integer",
+        "default": 20,
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "extra_body.chat_template_kwargs.enable_thinking",
+        "label": "Enable thinking",
+        "description": "Controls Qwen3 thinking mode when using OpenAI-compatible clients that pass provider-specific extra body fields.",
+        "group": "reasoning",
+        "type": "boolean",
+        "default": true
+      }
+    ]
+  },
+  {
+    "provider": "alibaba",
+    "authType": "api_key",
     "model": "qwen-plus",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of output tokens the model may generate.",
+        "group": "generation_length",
+        "type": "integer",
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "type": "number",
+        "range": {
+          "min": 0,
+          "max": 1.9,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.",
+        "group": "sampling",
+        "type": "number",
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "extra_body.top_k",
+        "label": "Top K",
+        "description": "Limits generation to the selected number of highest-probability tokens.",
+        "group": "sampling",
+        "type": "integer",
+        "default": 20,
+        "range": {
+          "min": 1
+        }
+      },
+      {
+        "path": "extra_body.chat_template_kwargs.enable_thinking",
+        "label": "Enable thinking",
+        "description": "Controls Qwen3 thinking mode when using OpenAI-compatible clients that pass provider-specific extra body fields.",
+        "group": "reasoning",
+        "type": "boolean",
+        "default": true
+      }
+    ]
+  },
+  {
+    "provider": "alibaba",
+    "authType": "api_key",
+    "model": "qwen-turbo",
     "params": [
       {
         "path": "max_tokens",

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -9,7 +9,15 @@ export const DEFAULTS = {
     "extra_body.top_k": 20,
     "extra_body.chat_template_kwargs.enable_thinking": true,
   },
+  "alibaba/qwen-max": {
+    "extra_body.top_k": 20,
+    "extra_body.chat_template_kwargs.enable_thinking": true,
+  },
   "alibaba/qwen-plus": {
+    "extra_body.top_k": 20,
+    "extra_body.chat_template_kwargs.enable_thinking": true,
+  },
+  "alibaba/qwen-turbo": {
     "extra_body.top_k": 20,
     "extra_body.chat_template_kwargs.enable_thinking": true,
   },

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -3,7 +3,9 @@
 
 export const MODEL_IDS = [
   "alibaba/qwen-flash",
+  "alibaba/qwen-max",
   "alibaba/qwen-plus",
+  "alibaba/qwen-turbo",
   "alibaba/qwen3-coder-flash",
   "alibaba/qwen3-coder-plus",
   "alibaba/qwen3-max",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -14,7 +14,21 @@ export type ParamsById = {
     "extra_body.top_k": number;
     "extra_body.chat_template_kwargs.enable_thinking": boolean;
   };
+  "alibaba/qwen-max": {
+    max_tokens: number;
+    temperature: number;
+    top_p: number;
+    "extra_body.top_k": number;
+    "extra_body.chat_template_kwargs.enable_thinking": boolean;
+  };
   "alibaba/qwen-plus": {
+    max_tokens: number;
+    temperature: number;
+    top_p: number;
+    "extra_body.top_k": number;
+    "extra_body.chat_template_kwargs.enable_thinking": boolean;
+  };
+  "alibaba/qwen-turbo": {
     max_tokens: number;
     temperature: number;
     top_p: number;


### PR DESCRIPTION
### ✨ What changed
- Adds `qwen-max` and `qwen-turbo` (alibaba) to the catalog in one PR.
- Supersedes #200 and #201 (params were sibling-cloned from `qwen-flash.yaml` there), bundled so the batch cuts **one** release.

### 💭 Why
DashScope serves both but the catalog doesn't list them.

### 📝 Notes
- **Probed live on 2026-08-17** against `dashscope-intl` compatible-mode, both models:
  - `temperature: 2.0` → 400 `InternalError.Algo.InvalidParameter: Temperature should be in [0.0, 2.0)`; `1.9`/`1.99`/`1.9999` → 200. The cloned files predated #232 and still said `max: 2`; corrected to `1.9` (largest steppable value at `step: 0.1`).
  - `top_p` `0`, `0.01`, `0.99`, `1` all 200 — declared `[0, 1]` holds.
  - `top_k` `1`/`100` 200; `chat_template_kwargs.enable_thinking` and top-level `enable_thinking` both accepted.
- Codegen committed; `validate`, `guard:params` and the full suite pass locally.