### PR TITLE
fix: gpt-5.6 variants serve xhigh reasoning effort

### DIFF
--- a/models/openai/gpt-5.6-luna.yaml
+++ b/models/openai/gpt-5.6-luna.yaml
@@ -9,7 +9,7 @@ params:
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 16
+      min: 1
     group: generation_length
   - path: reasoning_effort
     type: enum
@@ -21,4 +21,5 @@ params:
       - low
       - medium
       - high
+      - xhigh
     group: reasoning

--- a/models/openai/gpt-5.6-sol.yaml
+++ b/models/openai/gpt-5.6-sol.yaml
@@ -9,7 +9,7 @@ params:
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 16
+      min: 1
     group: generation_length
   - path: reasoning_effort
     type: enum
@@ -21,4 +21,5 @@ params:
       - low
       - medium
       - high
+      - xhigh
     group: reasoning

--- a/models/openai/gpt-5.6-terra.yaml
+++ b/models/openai/gpt-5.6-terra.yaml
@@ -9,7 +9,7 @@ params:
     description: Maximum number of output tokens the model may generate.
     default: 4096
     range:
-      min: 16
+      min: 1
     group: generation_length
   - path: reasoning_effort
     type: enum
@@ -21,4 +21,5 @@ params:
       - low
       - medium
       - high
+      - xhigh
     group: reasoning

--- a/packages/modelparams-python/src/modelparams/_generated/catalog.json
+++ b/packages/modelparams-python/src/modelparams/_generated/catalog.json
@@ -15599,7 +15599,7 @@
         "type": "integer",
         "default": 4096,
         "range": {
-          "min": 16
+          "min": 1
         }
       },
       {
@@ -15613,7 +15613,8 @@
           "none",
           "low",
           "medium",
-          "high"
+          "high",
+          "xhigh"
         ]
       }
     ]
@@ -15680,7 +15681,7 @@
         "type": "integer",
         "default": 4096,
         "range": {
-          "min": 16
+          "min": 1
         }
       },
       {
@@ -15694,7 +15695,8 @@
           "none",
           "low",
           "medium",
-          "high"
+          "high",
+          "xhigh"
         ]
       }
     ]
@@ -15761,7 +15763,7 @@
         "type": "integer",
         "default": 4096,
         "range": {
-          "min": 16
+          "min": 1
         }
       },
       {
@@ -15775,7 +15777,8 @@
           "none",
           "low",
           "medium",
-          "high"
+          "high",
+          "xhigh"
         ]
       }
     ]

--- a/packages/modelparams-python/src/modelparams/types/openai.py
+++ b/packages/modelparams-python/src/modelparams/types/openai.py
@@ -395,8 +395,8 @@ setattr(Gpt_5_5_SubscriptionParams, "__pydantic_config__", _PARAMS_CONFIG)
 Gpt_5_6_LunaParams = TypedDict(
     "Gpt_5_6_LunaParams",
     {
-        "max_completion_tokens": Annotated[int, Field(ge=16)],
-        "reasoning_effort": Literal["none", "low", "medium", "high"],
+        "max_completion_tokens": Annotated[int, Field(ge=1)],
+        "reasoning_effort": Literal["none", "low", "medium", "high", "xhigh"],
     },
     total=False,
 )
@@ -416,8 +416,8 @@ setattr(Gpt_5_6_Luna_SubscriptionParams, "__pydantic_config__", _PARAMS_CONFIG)
 Gpt_5_6_SolParams = TypedDict(
     "Gpt_5_6_SolParams",
     {
-        "max_completion_tokens": Annotated[int, Field(ge=16)],
-        "reasoning_effort": Literal["none", "low", "medium", "high"],
+        "max_completion_tokens": Annotated[int, Field(ge=1)],
+        "reasoning_effort": Literal["none", "low", "medium", "high", "xhigh"],
     },
     total=False,
 )
@@ -437,8 +437,8 @@ setattr(Gpt_5_6_Sol_SubscriptionParams, "__pydantic_config__", _PARAMS_CONFIG)
 Gpt_5_6_TerraParams = TypedDict(
     "Gpt_5_6_TerraParams",
     {
-        "max_completion_tokens": Annotated[int, Field(ge=16)],
-        "reasoning_effort": Literal["none", "low", "medium", "high"],
+        "max_completion_tokens": Annotated[int, Field(ge=1)],
+        "reasoning_effort": Literal["none", "low", "medium", "high", "xhigh"],
     },
     total=False,
 )

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -15604,7 +15604,7 @@ export const CATALOG = [
         "type": "integer",
         "default": 4096,
         "range": {
-          "min": 16
+          "min": 1
         }
       },
       {
@@ -15618,7 +15618,8 @@ export const CATALOG = [
           "none",
           "low",
           "medium",
-          "high"
+          "high",
+          "xhigh"
         ]
       }
     ]
@@ -15685,7 +15686,7 @@ export const CATALOG = [
         "type": "integer",
         "default": 4096,
         "range": {
-          "min": 16
+          "min": 1
         }
       },
       {
@@ -15699,7 +15700,8 @@ export const CATALOG = [
           "none",
           "low",
           "medium",
-          "high"
+          "high",
+          "xhigh"
         ]
       }
     ]
@@ -15766,7 +15768,7 @@ export const CATALOG = [
         "type": "integer",
         "default": 4096,
         "range": {
-          "min": 16
+          "min": 1
         }
       },
       {
@@ -15780,7 +15782,8 @@ export const CATALOG = [
           "none",
           "low",
           "medium",
-          "high"
+          "high",
+          "xhigh"
         ]
       }
     ]

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -1527,7 +1527,7 @@ export type ParamsById = {
   };
   "openai/gpt-5.6-luna": {
     max_completion_tokens: number;
-    reasoning_effort: "none" | "low" | "medium" | "high";
+    reasoning_effort: "none" | "low" | "medium" | "high" | "xhigh";
   };
   "openai/gpt-5.6-luna-subscription": {
     "reasoning.effort": "none" | "low" | "medium" | "high" | "xhigh" | "max";
@@ -1536,7 +1536,7 @@ export type ParamsById = {
   };
   "openai/gpt-5.6-sol": {
     max_completion_tokens: number;
-    reasoning_effort: "none" | "low" | "medium" | "high";
+    reasoning_effort: "none" | "low" | "medium" | "high" | "xhigh";
   };
   "openai/gpt-5.6-sol-subscription": {
     "reasoning.effort": "none" | "low" | "medium" | "high" | "xhigh" | "max";
@@ -1545,7 +1545,7 @@ export type ParamsById = {
   };
   "openai/gpt-5.6-terra": {
     max_completion_tokens: number;
-    reasoning_effort: "none" | "low" | "medium" | "high";
+    reasoning_effort: "none" | "low" | "medium" | "high" | "xhigh";
   };
   "openai/gpt-5.6-terra-subscription": {
     "reasoning.effort": "none" | "low" | "medium" | "high" | "xhigh" | "max";


### PR DESCRIPTION
### ✨ What changed
- `reasoning_effort` gains `xhigh` on `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra` (api_key files).
- `max_completion_tokens` range min 16 → 1 on the same three files.

### 💭 Why
Probed live on 2026-08-17: `reasoning_effort: xhigh` → 200 on all three, and the API's rejection of an unsupported value enumerates the real set — `Supported values are: 'none', 'low', 'medium', 'high', and 'xhigh'`. The `-subscription` variants already declared `xhigh` (and `max`); the api_key files had drifted.

The 16 floor isn't API-enforced: `max_completion_tokens: 0` → 400 `Expected a value >= 1`, and 1–15 pass validation.

### 📝 Notes
- Same drift class as #230's claude-sonnet-5 `xhigh` addition — the effort ladder grew after the files were authored.
- `gpt-5.6` itself (PR #207) gets the same two fixes on its branch before merge.
- Codegen committed; `validate`, `guard:params`, full suite pass locally.