### PR TITLE
fix: document opus-4-8 deprecated sampling params

### DIFF
--- a/models/anthropic/claude-opus-4-8.yaml
+++ b/models/anthropic/claude-opus-4-8.yaml
@@ -11,6 +11,43 @@ params:
     range:
       min: 1
     group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    deprecated:
+      behavior: default-only
+      note: The API rejects non-default values ("`temperature` is deprecated for this model") in every thinking mode; only the default value 1 is accepted. Probed 2026-08-17.
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.01
+    group: sampling
+    deprecated:
+      behavior: rejected
+      note: The API rejects every value including the default ("`top_p` is deprecated for this model"); the parameter must be unset. Probed 2026-08-17.
+  - path: top_k
+    type: integer
+    label: Top K
+    description: Limits sampling to the K most likely tokens.
+    default: 0
+    range:
+      min: 0
+    group: sampling
+    deprecated:
+      behavior: rejected
+      note: The API rejects every value including the default ("`top_k` is deprecated for this model"); the parameter must be unset. Probed 2026-08-17.
   - path: thinking.type
     type: enum
     label: Thinking mode

--- a/packages/modelparams-python/src/modelparams/_generated/catalog.json
+++ b/packages/modelparams-python/src/modelparams/_generated/catalog.json
@@ -3795,6 +3795,55 @@
         }
       },
       {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "deprecated": {
+          "behavior": "default-only",
+          "note": "The API rejects non-default values (\"`temperature` is deprecated for this model\") in every thinking mode; only the default value 1 is accepted. Probed 2026-08-17."
+        },
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.",
+        "group": "sampling",
+        "deprecated": {
+          "behavior": "rejected",
+          "note": "The API rejects every value including the default (\"`top_p` is deprecated for this model\"); the parameter must be unset. Probed 2026-08-17."
+        },
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "top_k",
+        "label": "Top K",
+        "description": "Limits sampling to the K most likely tokens.",
+        "group": "sampling",
+        "deprecated": {
+          "behavior": "rejected",
+          "note": "The API rejects every value including the default (\"`top_k` is deprecated for this model\"); the parameter must be unset. Probed 2026-08-17."
+        },
+        "type": "integer",
+        "default": 0,
+        "range": {
+          "min": 0
+        }
+      },
+      {
         "path": "thinking.type",
         "label": "Thinking mode",
         "description": "Controls the Anthropic thinking mode values supported by this model.",

--- a/packages/modelparams-python/src/modelparams/types/anthropic.py
+++ b/packages/modelparams-python/src/modelparams/types/anthropic.py
@@ -370,6 +370,9 @@ Claude_Opus_4_8Params = TypedDict(
     "Claude_Opus_4_8Params",
     {
         "max_tokens": Annotated[int, Field(ge=1)],
+        "temperature": Annotated[float, Field(ge=0, le=1)],
+        "top_p": Annotated[float, Field(ge=0, le=1)],
+        "top_k": Annotated[int, Field(ge=0)],
         "thinking.type": Literal["disabled", "adaptive"],
         "thinking.display": Literal["summarized", "omitted"],
         "output_config.effort": Literal["low", "medium", "high", "xhigh", "max"],

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -3800,6 +3800,55 @@ export const CATALOG = [
         }
       },
       {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "deprecated": {
+          "behavior": "default-only",
+          "note": "The API rejects non-default values (\"`temperature` is deprecated for this model\") in every thinking mode; only the default value 1 is accepted. Probed 2026-08-17."
+        },
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.",
+        "group": "sampling",
+        "deprecated": {
+          "behavior": "rejected",
+          "note": "The API rejects every value including the default (\"`top_p` is deprecated for this model\"); the parameter must be unset. Probed 2026-08-17."
+        },
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "top_k",
+        "label": "Top K",
+        "description": "Limits sampling to the K most likely tokens.",
+        "group": "sampling",
+        "deprecated": {
+          "behavior": "rejected",
+          "note": "The API rejects every value including the default (\"`top_k` is deprecated for this model\"); the parameter must be unset. Probed 2026-08-17."
+        },
+        "type": "integer",
+        "default": 0,
+        "range": {
+          "min": 0
+        }
+      },
+      {
         "path": "thinking.type",
         "label": "Thinking mode",
         "description": "Controls the Anthropic thinking mode values supported by this model.",

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -262,6 +262,9 @@ export const DEFAULTS = {
   },
   "anthropic/claude-opus-4-8": {
     max_tokens: 4096,
+    temperature: 1,
+    top_p: 1,
+    top_k: 0,
     "thinking.type": "disabled",
     "thinking.display": "omitted",
     "output_config.effort": "high",

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -316,6 +316,9 @@ export type ParamsById = {
   };
   "anthropic/claude-opus-4-8": {
     max_tokens: number;
+    temperature: number;
+    top_p: number;
+    top_k: number;
     "thinking.type": "disabled" | "adaptive";
     "thinking.display": "summarized" | "omitted";
     "output_config.effort": "low" | "medium" | "high" | "xhigh" | "max";


### PR DESCRIPTION
### ✨ What changed
- `claude-opus-4-8.yaml` gains `temperature`, `top_p`, `top_k` — all carrying the #230 `deprecated` flag: `temperature` as `default-only`, `top_p`/`top_k` as `rejected`.

### 💭 Why
Closes #214. The issue asks to make `temperature` manually configurable on opus-4-8; the API doesn't allow it, and the catalog silently omitting the params reads as "unknown" rather than "not settable". Now the entry documents the real behavior.

### 📝 Notes
- Probed live on 2026-08-17 against `/v1/messages`:
  - `temperature` 0 / 0.5 → 400 `` `temperature` is deprecated for this model ``; `1` → 200. With adaptive thinking: 0.5 → 400 (the error the issue reports), 1 → 200. → **default-only**.
  - `top_p` 0.5 / 0.97 / **1** → 400 deprecated, in both modes — even the default is rejected → **rejected**.
  - `top_k` 5 / **0** → 400 deprecated → **rejected**.
  - `temperature: 1.01` → 400 `range: 0..1` (declared range mirrors the validator).
- The `>= 0.95` thinking-mode hint in the issue's error text is unreachable: the deprecation gate fires first at every value.
- Same drift class as claude-sonnet-5 (#230): the deprecation gate arrived after the entry was authored.
- Codegen committed; `validate`, `guard:params`, full suite pass locally.