### PR TITLE
fix: skip ambiguous bare slugs in providerless params lookup

### DIFF
--- a/src/data/model-params.ts
+++ b/src/data/model-params.ts
@@ -19,6 +19,7 @@ export function modelParamsResponse(model: Model): ModelParamsResponse {
 export function listModelParamsResponses(models: Model[]): ModelParamsResponse[] {
   const bySlug = new Map<string, ModelParamsResponse>();
   const signatures = new Map<string, string>();
+  const ambiguous = new Set<string>();
 
   for (const model of models) {
     const response = modelParamsResponse(model);
@@ -27,12 +28,16 @@ export function listModelParamsResponses(models: Model[]): ModelParamsResponse[]
     );
     const existing = signatures.get(response.model);
     if (existing !== undefined && existing !== signature) {
-      throw new Error(`Conflicting params for providerless model slug "${response.model}"`);
+      // Several providers serve this model id with different param surfaces, so
+      // a bare slug has no single truthful answer — use provider/model instead.
+      ambiguous.add(response.model);
+      continue;
     }
     signatures.set(response.model, signature);
     bySlug.set(response.model, response);
   }
 
+  for (const slug of ambiguous) bySlug.delete(slug);
   return [...bySlug.values()].sort((a, b) => a.model.localeCompare(b.model));
 }
 

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -126,7 +126,7 @@ describe("providerless model params", () => {
     expect(listModelParamsResponses([one, two])).toEqual([modelParamsResponse(one)]);
   });
 
-  it("rejects conflicting providerless model param sets", () => {
+  it("omits providerless slugs whose serving providers disagree on params", () => {
     const one = makeModel({ provider: "anthropic" });
     const two = makeModel({
       provider: "openrouter",
@@ -141,9 +141,7 @@ describe("providerless model params", () => {
       ],
     });
 
-    expect(() => listModelParamsResponses([one, two])).toThrow(
-      'Conflicting params for providerless model slug "claude-opus-4-7"',
-    );
+    expect(listModelParamsResponses([one, two])).toEqual([]);
   });
 });
 


### PR DESCRIPTION
When two providers serve the same bare model slug with different param surfaces (e.g. zai/glm-5.2 vs alibaba/glm-5.2), the build failed with 'Conflicting params for providerless model slug', blocking the DashScope-hosted entries #244–#248.

Now the providerless index simply omits an ambiguous bare slug — there is no single truthful answer for it, so callers use the provider-prefixed slug instead. Provider-prefixed lookups are unchanged; slugs served by one provider (or identically by several) behave exactly as before. Any single answer for an ambiguous slug would be wrong for callers on the other provider's endpoint (DashScope caps glm-5.2 temperature at 1.9; z-ai does not) — omitting beats guessing.

Verification: full vitest suite passes (the test asserting the old throw now asserts omission); catalog validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)