### PR TITLE
ci: fix release-prepare workflow rejected at parse time

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -40,8 +40,8 @@ on:
         description: "Force bump level (overrides auto-detect)"
         required: false
         type: choice
-        options: ["", "patch", "major"]
-        default: ""
+        options: ["auto", "patch", "major"]
+        default: "auto"
 
 concurrency:
   group: release-prepare
@@ -57,6 +57,10 @@ jobs:
   prepare:
     name: Prepare release PR
     runs-on: ubuntu-latest
+    env:
+      # The `secrets` context is not allowed in a step-level `if`, so the
+      # App-vs-PAT choice is materialized here where it is allowed.
+      HAS_APP: ${{ secrets.APP_ID != '' }}
     steps:
       - name: Require release credentials
         env:
@@ -70,7 +74,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        if: ${{ secrets.APP_ID != '' }}
+        if: env.HAS_APP == 'true'
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         with:
           app-id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
## What this changes

The first `Prepare release` run on main ([32155274244](https://github.com/mnfst/modelparams.dev/actions/runs/32155274244)) failed with zero jobs: GitHub refused the workflow file at parse time because the `secrets` context is not allowed in a step-level `if`. Verified with actionlint, which pinpoints the line.

- Materialize the App-vs-PAT choice as job-level `env.HAS_APP` (where `secrets` **is** allowed) and gate the app-token step on that.
- Give `force_level` a non-empty `auto` default while here (actionlint flags empty choice strings; the prepare script already treats anything except `major`/`patch` as auto).

All three release workflows now pass actionlint clean.

## Type of change

- [x] Site or tooling (code under `src/`, docs, CI)