### PR TITLE
ci: bump uv.lock alongside pyproject.toml in release PRs

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -129,6 +129,7 @@ jobs:
           git add packages/modelparams/package.json \
                   packages/modelparams/CHANGELOG.md \
                   packages/modelparams-python/pyproject.toml \
+                  packages/modelparams-python/uv.lock \
                   packages/modelparams-python/CHANGELOG.md
           git commit -m "$TITLE"
           # The branch is a rolling proposal rebuilt from main on every merge,

--- a/scripts/lib/uv-lock.ts
+++ b/scripts/lib/uv-lock.ts
@@ -1,0 +1,15 @@
+/**
+ * Rewrite the version uv.lock records for the root `modelparams` package.
+ *
+ * The lockfile pins the project's own version, so bumping pyproject.toml alone
+ * makes every `uv sync --locked` in CI refuse with "the lockfile needs to be
+ * updated". This mirrors the one line `uv version` would change; the editable
+ * root package carries no hash, so nothing else in the lock depends on it.
+ */
+export function bumpUvLockVersion(source: string, next: string): string {
+  const pattern = /(\[\[package]]\nname = "modelparams"\nversion = ")\d+\.\d+\.\d+(")/;
+  if (!pattern.test(source)) {
+    throw new Error("could not find the modelparams package entry in uv.lock");
+  }
+  return source.replace(pattern, `$1${next}$2`);
+}

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -20,6 +20,7 @@ import { loadAllModels } from "../src/data/load.js";
 import { loadModelsAtRef, refExists } from "../src/data/git-baseline.js";
 import { diffCatalogs, renderCatalogChangelog } from "../src/data/catalog-diff.js";
 import { insertChangelogEntry } from "./lib/changelog.js";
+import { bumpUvLockVersion } from "./lib/uv-lock.js";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -33,6 +34,8 @@ interface PackageSpec {
   changelogFile: string;
   readVersion(source: string): string;
   writeVersion(source: string, next: string): string;
+  /** Extra files that also record the version and must move with it. */
+  syncFiles?: { file: string; write(source: string, next: string): string }[];
 }
 
 const PACKAGES: PackageSpec[] = [
@@ -63,6 +66,11 @@ const PACKAGES: PackageSpec[] = [
     },
     writeVersion: (source, next) =>
       source.replace(/^(version\s*=\s*")\d+\.\d+\.\d+(")\s*$/m, `$1${next}$2`),
+    syncFiles: [
+      // uv.lock pins the project's own version; without this, every
+      // `uv sync --locked` in CI fails on the release PR.
+      { file: "packages/modelparams-python/uv.lock", write: bumpUvLockVersion },
+    ],
   },
 ];
 
@@ -165,6 +173,10 @@ async function main(): Promise<void> {
       throw new Error(`failed to write version ${next} into ${spec.manifestFile}`);
     }
     fs.writeFileSync(manifestPath, updated, "utf8");
+    for (const sync of spec.syncFiles ?? []) {
+      const syncPath = path.join(REPO_ROOT, sync.file);
+      fs.writeFileSync(syncPath, sync.write(fs.readFileSync(syncPath, "utf8"), next), "utf8");
+    }
     const changelogPath = path.join(REPO_ROOT, spec.changelogFile);
     const existingChangelog = fs.existsSync(changelogPath)
       ? fs.readFileSync(changelogPath, "utf8")

--- a/tests/uv-lock.test.ts
+++ b/tests/uv-lock.test.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { bumpUvLockVersion } from "../scripts/lib/uv-lock.js";
+
+describe("bumpUvLockVersion", () => {
+  it("rewrites only the root package's version in the real lockfile", () => {
+    const lock = fs.readFileSync(
+      path.join(__dirname, "../packages/modelparams-python/uv.lock"),
+      "utf8",
+    );
+    const bumped = bumpUvLockVersion(lock, "9.9.9");
+    expect(bumped).toContain('name = "modelparams"\nversion = "9.9.9"');
+    // Exactly one line differs: no other package's version moves.
+    const diff = bumped.split("\n").filter((line, i) => line !== lock.split("\n")[i]);
+    expect(diff).toEqual(['version = "9.9.9"']);
+  });
+
+  it("throws when the package entry is missing", () => {
+    expect(() =>
+      bumpUvLockVersion('[[package]]\nname = "other"\nversion = "1.0.0"', "2.0.0"),
+    ).toThrow(/could not find/);
+  });
+});


### PR DESCRIPTION
## What this changes

All seven Python jobs on release PR #255 fail with `error: The lockfile at uv.lock needs to be updated, but --locked was provided`. The lockfile records the project's own version, and `prepare-release.ts` bumped only `pyproject.toml` — in the old flow the bump happened at publish time via `uv version`, which keeps the lock in sync.

- `prepare-release.ts` now also rewrites the `modelparams` entry in `uv.lock` (the one line `uv version` would change; the editable root package carries no hash, so nothing else depends on it), via a new `syncFiles` hook on the package spec.
- `release-prepare.yml` stages `uv.lock` in the release commit.
- Test asserts the rewrite touches exactly one line of the real lockfile, and `uv lock --check` passes locally against the prepared pair.

Merging this re-runs `Prepare release`, which force-rebuilds `chore/release` with the lock included — #255 should go green on its own.

## Type of change

- [x] Site or tooling (code under `src/`, docs, CI)