### PR TITLE
ci: use the REST API to open and update the release PR

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -144,15 +144,23 @@ jobs:
           TITLE: ${{ steps.prepare.outputs.title }}
           BODY_FILE: ${{ runner.temp }}/release-pr-body.md
         run: |
-          existing=$(gh pr list --head "$RELEASE_BRANCH" --base main --state open --json number --jq '.[0].number')
+          # REST only — no gh pr subcommands. Those go through GraphQL, which
+          # rejects classic tokens without read:org on org repos ("the 'login'
+          # field requires ['read:org']"); the REST pulls API needs just repo,
+          # so this works with RELEASE_PAT and App tokens alike.
+          existing=$(gh api "repos/${GITHUB_REPOSITORY}/pulls?state=open&base=main&head=${GITHUB_REPOSITORY_OWNER}:${RELEASE_BRANCH}" \
+            --jq '.[0].number')
           if [ -n "$existing" ]; then
-            gh pr edit "$existing" --title "$TITLE" --body-file "$BODY_FILE"
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/pulls/${existing}" \
+              -f title="$TITLE" -f body="$(cat "$BODY_FILE")" --silent
             echo "::notice::Updated release PR #${existing}: ${TITLE}"
           else
-            gh pr create --head "$RELEASE_BRANCH" --base main \
-              --title "$TITLE" --body-file "$BODY_FILE"
+            number=$(gh api -X POST "repos/${GITHUB_REPOSITORY}/pulls" \
+              -f title="$TITLE" -f head="$RELEASE_BRANCH" -f base=main \
+              -f body="$(cat "$BODY_FILE")" --jq '.number')
             # Best-effort: the label is created by label-sync.yml, which may not
             # have run yet the very first time this workflow fires.
-            gh pr edit "$RELEASE_BRANCH" --add-label release || true
-            echo "::notice::Opened release PR: ${TITLE}"
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${number}/labels" \
+              -f "labels[]=release" --silent || true
+            echo "::notice::Opened release PR #${number}: ${TITLE}"
           fi


### PR DESCRIPTION
## What this changes

The `Prepare release` run after #256 force-pushed `chore/release` fine but failed at the PR-update step: `gh pr list` goes through GraphQL, which rejects classic tokens without `read:org` on org repos. Same root cause silently ate the `release` label on #255 earlier.

Switch the step to the REST pulls/issues API (`gh api`), which needs only the `repo` scope and works with both `RELEASE_PAT` and App tokens.

## Type of change

- [x] Site or tooling (code under `src/`, docs, CI)