### PR TITLE
fix: accept requestModel in the Python package's CatalogEntry

### DIFF
--- a/packages/modelparams-python/src/modelparams/models.py
+++ b/packages/modelparams-python/src/modelparams/models.py
@@ -68,4 +68,7 @@ class CatalogEntry(FrozenModel):
     provider: str
     auth_type: AuthType = Field(alias="authType")
     model: str
+    # Exact wire string when the host's native id differs from the catalog
+    # slug (pathed ids: accounts/fireworks/models/kimi-k3, openai/gpt-oss-20b).
+    request_model: str | None = Field(alias="requestModel", default=None)
     params: tuple[Parameter, ...]


### PR DESCRIPTION
The Python package's strict `CatalogEntry` pydantic model rejected the `requestModel` field added in #253, so every Python CI job (compat matrix + package tests) has failed on every PR since fireworks/kimi-k3 (#258) landed on main. Adds `request_model` (alias `requestModel`, default None), mirroring the TS schema. Full Python test suite passes.

My miss in #253 — I claimed the field flowed through the packages automatically and merged past the red non-required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)