### PR TITLE
docs: explain multi-provider entries and in-place parameter deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,44 @@ npx skills add mnfst/modelparams.dev # the companion agent skill
 
 The MCP server exposes `validate_model_params`, `get_model_params`, `list_models`, and `find_models_supporting`. Details in the [package README](packages/modelparams-mcp/README.md). There's also [llms.txt](https://modelparams.dev/llms.txt) if you'd rather just point an agent at a URL.
 
+## One model, many providers
+
+A model appears in the catalog under **every provider that serves it**, not just the vendor that made it — because each host accepts a different set of parameters for the same weights. That difference is exactly what this catalog exists to record, and it is real. Probed live on 2026-08-18:
+
+|                    | `moonshot/kimi-k3`                                                | `fireworks/kimi-k3`                 |
+| ------------------ | ----------------------------------------------------------------- | ----------------------------------- |
+| Wire id to send    | `kimi-k3`                                                         | `accounts/fireworks/models/kimi-k3` |
+| `temperature: 1.8` | ✗ 400 — `invalid temperature: only 0.6 is allowed for this model` | ✓ accepted (range 0–2)              |
+| `top_k: 40`        | not declared                                                      | ✓ accepted                          |
+| Thinking control   | `thinking.type`, `reasoning_effort`                               | not exposed                         |
+
+Three consequences of this convention:
+
+- **`requestModel`** — when a host's native id can't serve as the catalog slug (Fireworks' pathed ids, Groq's `openai/gpt-oss-20b`), the entry keeps a clean slug and carries the exact wire string in `requestModel`. Every API response and MCP tool returns it; send that string, not the slug.
+- **Bare slugs can be ambiguous.** Ask for `kimi-k3` without a provider and the API answers `ambiguous_model` with the qualified ids instead of guessing — any single answer would be wrong for callers on the other host. Providerless `/api/v1/params/<slug>.json` files exist only for unambiguous slugs.
+- **Each entry is probed against its own host.** `fireworks/kimi-k3` was verified against Fireworks' endpoint, not Moonshot's docs.
+
+## Parameters that stop working
+
+Providers change gateway validation **in place, on live model ids, without a version bump**. The catalog records this with a per-parameter `deprecated` flag instead of deleting the parameter — deleting would erase the answer to "why did my working code break?".
+
+The proving case: `anthropic/claude-sonnet-5` accepted `temperature` on 2026-07-11 (verified live). By 2026-08-17 the same request had become a hard error:
+
+```bash
+# temperature 0.5 — worked in July, now:
+# 400 {"error": {"message": "`temperature` is deprecated for this model."}}
+# temperature 1 (the default) — still 200 OK
+```
+
+That's `behavior: default-only` — only the default survives. The other behaviors are `rejected` (any use fails) and `ignored` (accepted, no effect — the worst one, because nothing tells you). A nightly drift sweep re-probes the catalog so these flips get caught and dated:
+
+```yaml
+deprecated:
+  behavior: default-only
+  since: "2026-08-17"
+  note: The API now rejects non-default values; only the default value 1 is accepted.
+```
+
 ## Adding a model
 
 Drop a YAML file in `models/<provider>/`, open a PR, and CI validates it against the schema. Details in [CONTRIBUTING.md](CONTRIBUTING.md). Can't open a PR? [File an issue](https://github.com/mnfst/modelparams.dev/issues/new/choose) with a link to the docs.


### PR DESCRIPTION
Requested by Guillaume: the README now explains the two catalog conventions that most surprise newcomers, each backed by a live probe rather than an assertion.

**One model, many providers** — why kimi-k3 has an entry under both moonshot and fireworks, with the probed proof (Moonshot locks temperature to 0.6 and 400s anything else; Fireworks accepts 0–2), plus the three consequences: `requestModel` wire ids, ambiguous bare slugs answered with qualified ids instead of a guess, and per-host verification.

**Parameters that stop working** — the `deprecated` flag, with the claude-sonnet-5 temperature case as the proving breaking change: verified working 2026-07-11, hard 400 (`temperature is deprecated for this model`) by 2026-08-17, default value still accepted → `default-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)