### PR TITLE
fix: regenerate package catalogs after sonnet-5 note corrections

### DIFF
--- a/packages/modelparams-python/src/modelparams/_generated/catalog.json
+++ b/packages/modelparams-python/src/modelparams/_generated/catalog.json
@@ -7011,7 +7011,7 @@
         "deprecated": {
           "behavior": "default-only",
           "since": "2026-08-17",
-          "note": "The API now rejects non-default values (\"`temperature` is deprecated for this model\"); only the default value 1 is accepted. Verified working 2026-07-11."
+          "note": "The API rejects non-default values (\"`temperature` is deprecated for this model\"); only the default value 1 is accepted. Documented at the model's 2026-06-30 launch; this entry wrongly declared it usable until 2026-08-17 because the original probe tested only the default value."
         },
         "type": "number",
         "default": 1,
@@ -7043,7 +7043,7 @@
         "deprecated": {
           "behavior": "default-only",
           "since": "2026-08-17",
-          "note": "The API now rejects non-default values (\"`top_p` is deprecated for this model\"); only the default value 1 is accepted. Verified working 2026-07-11."
+          "note": "The API rejects non-default values (\"`top_p` is deprecated for this model\"); only the default value 1 is accepted. Documented at the model's 2026-06-30 launch; this entry wrongly declared it usable until 2026-08-17 because the original probe tested only the default value."
         },
         "type": "number",
         "default": 1,
@@ -7068,7 +7068,7 @@
         "deprecated": {
           "behavior": "default-only",
           "since": "2026-08-17",
-          "note": "The API now rejects non-default values (\"`top_k` is deprecated for this model\"); only the default value 0 is accepted. Verified working 2026-07-11."
+          "note": "The API rejects non-default values (\"`top_k` is deprecated for this model\"); only the default value 0 is accepted. Documented at the model's 2026-06-30 launch; this entry wrongly declared it usable until 2026-08-17 because the original probe tested only the default value."
         },
         "type": "integer",
         "default": 0,

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -7016,7 +7016,7 @@ export const CATALOG = [
         "deprecated": {
           "behavior": "default-only",
           "since": "2026-08-17",
-          "note": "The API now rejects non-default values (\"`temperature` is deprecated for this model\"); only the default value 1 is accepted. Verified working 2026-07-11."
+          "note": "The API rejects non-default values (\"`temperature` is deprecated for this model\"); only the default value 1 is accepted. Documented at the model's 2026-06-30 launch; this entry wrongly declared it usable until 2026-08-17 because the original probe tested only the default value."
         },
         "type": "number",
         "default": 1,
@@ -7048,7 +7048,7 @@ export const CATALOG = [
         "deprecated": {
           "behavior": "default-only",
           "since": "2026-08-17",
-          "note": "The API now rejects non-default values (\"`top_p` is deprecated for this model\"); only the default value 1 is accepted. Verified working 2026-07-11."
+          "note": "The API rejects non-default values (\"`top_p` is deprecated for this model\"); only the default value 1 is accepted. Documented at the model's 2026-06-30 launch; this entry wrongly declared it usable until 2026-08-17 because the original probe tested only the default value."
         },
         "type": "number",
         "default": 1,
@@ -7073,7 +7073,7 @@ export const CATALOG = [
         "deprecated": {
           "behavior": "default-only",
           "since": "2026-08-17",
-          "note": "The API now rejects non-default values (\"`top_k` is deprecated for this model\"); only the default value 0 is accepted. Verified working 2026-07-11."
+          "note": "The API rejects non-default values (\"`top_k` is deprecated for this model\"); only the default value 0 is accepted. Documented at the model's 2026-06-30 launch; this entry wrongly declared it usable until 2026-08-17 because the original probe tested only the default value."
         },
         "type": "integer",
         "default": 0,


### PR DESCRIPTION
#282 edited three deprecation notes in claude-sonnet-5.yaml without regenerating the packages that embed them, leaving the two package sync checks red on main. This is the regeneration, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)