### PR TITLE
fix: restore the providerless params endpoint and bare-slug lookups

### DIFF
--- a/api/v1/validate.ts
+++ b/api/v1/validate.ts
@@ -6,7 +6,6 @@
 import {
   dropUnsupported,
   getModel,
-  MODEL_IDS,
   resolveByBaseUrl,
   resolveModelId,
   type DroppedParam,
@@ -45,7 +44,8 @@ const USAGE = {
     "Validate a params object against a model. Reports unknown parameters, out-of-range values, " +
     "and combinations the provider rejects, and returns a corrected payload.",
   request: {
-    model: "provider/model id, e.g. anthropic/claude-opus-5",
+    model:
+      "provider/model id (e.g. anthropic/claude-opus-5), or a bare model slug when it is unambiguous",
     baseUrl:
       "optional — the base URL your SDK is configured with; with it, `model` is the exact wire string you send",
     params: "object of provider-native parameter paths to values",
@@ -149,31 +149,26 @@ export default {
       resolvedId = byUrl.id;
     }
 
-    if (resolvedId === null && !model.includes("/")) {
-      const matches = MODEL_IDS.filter((id) => id.slice(id.indexOf("/") + 1) === model.trim());
-      return fail(
-        "provider_required",
-        {
-          message: `\`model\` must be \`provider/model\`${matches.length ? "; did you mean one of the ids below?" : ""}`,
-          ...(matches.length ? { matches } : {}),
-        },
-        400,
-      );
-    }
-
     const resolved = resolveModelId(resolvedId ?? model);
     if (!resolved.ok) {
-      // With a provider prefix required above, resolution can only miss.
-      const suggestions = resolved.reason === "not_found" ? resolved.suggestions : resolved.matches;
-      return fail(
-        "unknown_model",
-        {
-          message: `"${model}" is not in the catalog`,
-          suggestions,
-          catalog: "https://modelparams.dev/api/v1/models.json",
-        },
-        404,
-      );
+      return resolved.reason === "ambiguous"
+        ? fail(
+            "ambiguous_model",
+            {
+              message: `"${model}" is published by more than one provider; qualify it with a provider prefix`,
+              matches: resolved.matches,
+            },
+            400,
+          )
+        : fail(
+            "unknown_model",
+            {
+              message: `"${model}" is not in the catalog`,
+              suggestions: resolved.suggestions,
+              catalog: "https://modelparams.dev/api/v1/models.json",
+            },
+            404,
+          );
     }
 
     if (

--- a/packages/modelparams-mcp/src/server.ts
+++ b/packages/modelparams-mcp/src/server.ts
@@ -56,7 +56,7 @@ export function createServer(): McpServer {
         model: z
           .string()
           .describe(
-            'Catalog id ("anthropic/claude-opus-4-7") — or, with baseUrl, the exact wire string your SDK sends.',
+            'Catalog id ("anthropic/claude-opus-4-7") or bare model slug when unambiguous — or, with baseUrl, the exact wire string your SDK sends.',
           ),
         baseUrl: z
           .string()
@@ -88,7 +88,7 @@ export function createServer(): McpServer {
         model: z
           .string()
           .describe(
-            'Catalog id ("openai/gpt-5.5") — or, with baseUrl, the exact wire string your SDK sends.',
+            'Catalog id ("openai/gpt-5.5") or bare model slug when unambiguous — or, with baseUrl, the exact wire string your SDK sends.',
           ),
         baseUrl: z.string().optional().describe("The base URL your SDK is configured with."),
       },

--- a/packages/modelparams-mcp/src/tools.ts
+++ b/packages/modelparams-mcp/src/tools.ts
@@ -20,19 +20,7 @@ function modelIdOf(entry: (typeof CATALOG)[number]): ModelId {
   return `${entry.provider}/${entry.model}${suffix}` as ModelId;
 }
 
-/** Provider is mandatory: a bare slug gets the qualified ids, never a guess. */
-function providerRequired(input: string): ToolPayload | null {
-  if (input.includes("/")) return null;
-  const slug = input.trim();
-  const matches = CATALOG.filter((e) => e.model === slug).map(modelIdOf);
-  return {
-    error: "provider_required",
-    message: `Model ids are \`provider/model\`.${matches.length ? " Retry with one of the ids below." : " Call list_models to find the id."}`,
-    ...(matches.length ? { matches } : {}),
-  };
-}
-
-/** Resolve via base URL when given, else require provider/model. */
+/** Resolve via base URL when given, else pass through for catalog resolution. */
 function resolveInput(input: { model: string; baseUrl?: string }): {
   id?: string;
   error?: ToolPayload;
@@ -56,8 +44,8 @@ function resolveInput(input: { model: string; baseUrl?: string }): {
             },
     };
   }
-  const needsProvider = providerRequired(input.model);
-  if (needsProvider) return { error: needsProvider };
+  // A bare slug is resolved by the catalog: unique → that model, shared by
+  // several providers → an ambiguous_model payload with the qualified ids.
   return { id: input.model };
 }
 

--- a/packages/modelparams-mcp/tests/server.test.ts
+++ b/packages/modelparams-mcp/tests/server.test.ts
@@ -123,12 +123,21 @@ describe("validate_model_params", () => {
     expect(out.valid).toBe(true);
   });
 
-  it("requires a provider prefix and lists the qualified ids", async () => {
+  it("resolves a bare model slug when it is unambiguous", async () => {
+    const out = await call<ValidateResult>("validate_model_params", {
+      model: "gpt-5.5",
+      params: {},
+    });
+    expect(out.model).toBe("openai/gpt-5.5");
+    expect(out.valid).toBe(true);
+  });
+
+  it("reports an ambiguous bare slug with the qualified ids", async () => {
     const out = await call<ValidateResult>("validate_model_params", {
       model: "kimi-k3",
       params: {},
     });
-    expect(out.error).toBe("provider_required");
+    expect(out.error).toBe("ambiguous_model");
     expect(out.matches).toContain("fireworks/kimi-k3");
     expect(out.matches).toContain("moonshot/kimi-k3");
   });

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -8,6 +8,7 @@ import {
 } from "../data/catalog.js";
 import { loadAllModels } from "../data/load.js";
 import { buildLlmsFullTxt, buildLlmsTxt } from "../data/llms.js";
+import { listModelParamsResponses } from "../data/model-params.js";
 import { buildParameterIndex } from "../data/parameters.js";
 import {
   DIST_API_DIR,
@@ -45,6 +46,7 @@ async function cleanDist(): Promise<void> {
   await fs.rm(DIST_DIR, { recursive: true, force: true });
   await fs.mkdir(DIST_ASSETS_DIR, { recursive: true });
   await fs.mkdir(path.join(DIST_API_DIR, "models"), { recursive: true });
+  await fs.mkdir(path.join(DIST_API_DIR, "params"), { recursive: true });
 }
 
 async function writeJson(file: string, payload: unknown): Promise<void> {
@@ -161,6 +163,10 @@ async function writeApiIndex(modelCount: number): Promise<void> {
       schema: "/api/v1/schema.json",
       modelByIdApiKey: "/api/v1/models/{provider}/{model}.json",
       modelByIdSubscription: "/api/v1/models/{provider}/{model}-subscription.json",
+      // Legacy providerless lookups, kept for compatibility — prefer the
+      // provider-qualified modelById paths above.
+      paramsByModelApiKey: "/api/v1/params/{model}.json",
+      paramsByModelSubscription: "/api/v1/params/{model}-subscription.json",
       validate: "POST /api/v1/validate",
     },
     modelCount,
@@ -207,6 +213,9 @@ export async function build(): Promise<{ models: number }> {
     });
   }
 
+  for (const params of listModelParamsResponses(models)) {
+    await writeJson(path.join(DIST_API_DIR, "params", `${params.model}.json`), params);
+  }
 
   console.log("Bundling client + styles...");
   await Promise.all([bundleClientScript(), compileStyles(), copyStaticAssets()]);

--- a/src/data/model-params.ts
+++ b/src/data/model-params.ts
@@ -1,0 +1,46 @@
+import { authSuffix, type Model, type Parameter } from "../schema/model.js";
+
+export interface ModelParamsResponse {
+  model: string;
+  params: Parameter[];
+}
+
+export function modelParamSlug(model: Pick<Model, "model" | "authType">): string {
+  return `${model.model}${authSuffix(model.authType)}`;
+}
+
+export function modelParamsResponse(model: Model): ModelParamsResponse {
+  return {
+    model: modelParamSlug(model),
+    params: model.params,
+  };
+}
+
+export function listModelParamsResponses(models: Model[]): ModelParamsResponse[] {
+  const bySlug = new Map<string, ModelParamsResponse>();
+  const signatures = new Map<string, string>();
+  const ambiguous = new Set<string>();
+
+  for (const model of models) {
+    const response = modelParamsResponse(model);
+    const signature = JSON.stringify(
+      [...response.params].sort((a, b) => a.path.localeCompare(b.path)),
+    );
+    const existing = signatures.get(response.model);
+    if (existing !== undefined && existing !== signature) {
+      // Several providers serve this model id with different param surfaces, so
+      // a bare slug has no single truthful answer — use provider/model instead.
+      ambiguous.add(response.model);
+      continue;
+    }
+    signatures.set(response.model, signature);
+    bySlug.set(response.model, response);
+  }
+
+  for (const slug of ambiguous) bySlug.delete(slug);
+  return [...bySlug.values()].sort((a, b) => a.model.localeCompare(b.model));
+}
+
+export function findModelParams(models: Model[], slug: string): ModelParamsResponse | null {
+  return listModelParamsResponses(models).find((model) => model.model === slug) ?? null;
+}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { buildCapabilityFacets, buildCatalog, buildProviderFacets } from "../data/catalog.js";
 import { buildLlmsFullTxt, buildLlmsTxt } from "../data/llms.js";
+import { findModelParams } from "../data/model-params.js";
 import { buildParameterIndex } from "../data/parameters.js";
 import { DIST_ASSETS_DIR } from "../data/paths.js";
 import { buildModelJsonSchema } from "../schema/generate.js";
@@ -139,6 +140,21 @@ export function makeApp(loadModels: LoadModels): express.Express {
 
   app.get("/api/v1/schema.json", (_req, res) => {
     res.json(buildModelJsonSchema());
+  });
+
+  // Legacy providerless lookup, kept for compatibility with pre-existing
+  // consumers — prefer /api/v1/models/{provider}/{model}.json.
+  app.get("/api/v1/params/:slug.json", async (req, res, next) => {
+    try {
+      const params = findModelParams(await loadModels(), req.params.slug);
+      if (!params) {
+        res.status(404).json({ error: "not_found", model: req.params.slug });
+        return;
+      }
+      res.json(params);
+    } catch (err) {
+      next(err);
+    }
   });
 
   app.get("/llms.txt", async (_req, res, next) => {

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect } from "vitest";
 import { buildCapabilityFacets, buildCatalog, uniqueProviders } from "../src/data/catalog.js";
 import { describeApplicability } from "../src/data/applicability.js";
 import { modelFullLabel, modelLabel, paramLabel, providerLabel } from "../src/data/display.js";
+import {
+  findModelParams,
+  listModelParamsResponses,
+  modelParamSlug,
+  modelParamsResponse,
+} from "../src/data/model-params.js";
 import { loadAllModels } from "../src/data/load.js";
 import { modelId } from "../src/schema/model.js";
 import type { Model } from "../src/schema/model.js";
@@ -69,6 +75,73 @@ describe("uniqueProviders", () => {
       makeModel({ provider: "openai", model: "gpt-4o" }),
     ]);
     expect(result).toEqual(["anthropic", "openai"]);
+  });
+});
+
+describe("providerless model params", () => {
+  it("uses -subscription as the model slug variant", () => {
+    expect(modelParamSlug(makeModel())).toBe("claude-opus-4-7");
+    expect(modelParamSlug(makeModel({ authType: "subscription" }))).toBe(
+      "claude-opus-4-7-subscription",
+    );
+  });
+
+  it("returns only model slug and params", () => {
+    const response = modelParamsResponse(makeModel());
+    expect(response).toEqual({
+      model: "claude-opus-4-7",
+      params: makeModel().params,
+    });
+  });
+
+  it("finds api-key and subscription params by providerless slug", () => {
+    const apiKey = makeModel();
+    const subscription = makeModel({
+      authType: "subscription",
+      params: [
+        {
+          path: "thinking.type",
+          type: "enum",
+          label: "Thinking",
+          description: "Thinking mode.",
+          values: ["disabled", "enabled"],
+          group: "reasoning",
+        },
+      ],
+    });
+
+    expect(findModelParams([apiKey, subscription], "claude-opus-4-7")).toEqual(
+      modelParamsResponse(apiKey),
+    );
+    expect(findModelParams([apiKey, subscription], "claude-opus-4-7-subscription")).toEqual(
+      modelParamsResponse(subscription),
+    );
+    expect(findModelParams([apiKey, subscription], "unknown")).toBeNull();
+  });
+
+  it("deduplicates identical providerless model param sets", () => {
+    const one = makeModel({ provider: "anthropic" });
+    const two = makeModel({ provider: "openrouter" });
+
+    expect(listModelParamsResponses([one, two])).toEqual([modelParamsResponse(one)]);
+  });
+
+  it("omits providerless slugs whose serving providers disagree on params", () => {
+    const one = makeModel({ provider: "anthropic" });
+    const two = makeModel({
+      provider: "openrouter",
+      params: [
+        {
+          path: "top_p",
+          type: "number",
+          label: "Top P",
+          description: "Nucleus sampling.",
+          group: "sampling",
+        },
+      ],
+    });
+
+    expect(listModelParamsResponses([one, two])).toEqual([]);
   });
 });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -100,6 +100,32 @@ describe("GET /api/v1/schema.json", () => {
   });
 });
 
+describe("GET /api/v1/params/:model.json", () => {
+  it("returns params for an api-key model slug without provider metadata", async () => {
+    const res = await get("/api/v1/params/claude-opus-4-7.json");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      model: "claude-opus-4-7",
+      params: MODELS[0]!.params,
+    });
+  });
+
+  it("returns params for the -subscription model variant", async () => {
+    const res = await get("/api/v1/params/claude-opus-4-7-subscription.json");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.model).toBe("claude-opus-4-7-subscription");
+    expect(body.params).toEqual(MODELS[1]!.params);
+  });
+
+  it("404s with a model-scoped JSON error for an unknown slug", async () => {
+    const res = await get("/api/v1/params/does-not-exist.json");
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "not_found", model: "does-not-exist" });
+  });
+});
+
 describe("GET /api/v1/models/:provider/:slug.json", () => {
   it("returns the full model for a known id", async () => {
     const res = await get("/api/v1/models/anthropic/claude-opus-4-7.json");

--- a/tests/validate-endpoint.test.ts
+++ b/tests/validate-endpoint.test.ts
@@ -102,10 +102,17 @@ describe("POST /api/v1/validate", () => {
     expect(body.error).toBe("unknown_base_url");
   });
 
-  it("requires a provider prefix and lists the qualified ids", async () => {
+  it("resolves a bare model slug", async () => {
+    const { status, body } = await post({ model: "gpt-5.5", params: {} });
+    expect(status).toBe(200);
+    expect(body.model).toBe("openai/gpt-5.5");
+    expect(body.provider).toBe("openai");
+  });
+
+  it("400s an ambiguous bare slug with the qualified ids", async () => {
     const { status, body } = await post({ model: "kimi-k3", params: {} });
     expect(status).toBe(400);
-    expect(body.error).toBe("provider_required");
+    expect(body.error).toBe("ambiguous_model");
     expect(body.matches).toContain("fireworks/kimi-k3");
     expect(body.matches).toContain("moonshot/kimi-k3");
   });


### PR DESCRIPTION
#294 deleted three public lookup surfaces in one go, and the deploy is live: `GET /api/v1/params/{slug}.json` (public since #46) now 404s, `POST /api/v1/validate` rejects bare model slugs with `provider_required`, and the MCP validate/get tools apply the same rule. Any pre-existing consumer of those surfaces broke the moment main deployed.

This restores the old compatibility without giving up the new design — provider-qualified ids (and #295's `baseUrl` resolution) stay the documented, preferred path:

- `/api/v1/params/{slug}.json` is generated and served again via the restored `model-params.ts`, with the exact pre-#294 semantics: identical param sets dedupe to one providerless slug, and slugs whose providers disagree are omitted. The build writes 276 of them for the 306-model catalog. `index.json` re-advertises the two legacy keys, marked as legacy in the source.
- `validate` accepts a bare slug again when exactly one provider publishes it, and answers an ambiguous one with `ambiguous_model` plus the qualified ids — the pre-#294 contract. The `baseUrl` path from #295 is untouched.
- The MCP `validate_model_params` / `get_model_params` tools resolve bare slugs through the catalog again, with the same ambiguity payload.
- The tests deleted or flipped in #294 are restored, plus new coverage for the ambiguous-slug answers (`kimi-k3` → `fireworks/kimi-k3` | `moonshot/kimi-k3`).

Verified locally: root suite 206 tests, modelparams package 74, MCP package 20, typecheck, lint, and a full site build all green. Prod checked before this PR: the legacy endpoint 404s and bare-slug validate 400s today, so this wants a prompt merge.