### PR TITLE
feat: add z-ai/glm-5.3

### DIFF
--- a/models/z-ai/glm-5.3.yaml
+++ b/models/z-ai/glm-5.3.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: z-ai
+authType: api_key
+model: glm-5.3
+params:
+  - path: max_tokens
+    type: integer
+    label: Max tokens
+    description: Maximum number of tokens to generate in the response.
+    default: 65536
+    range:
+      min: 1
+      max: 131072
+    group: generation_length
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness. Lower values make outputs more focused; higher values make them more varied.
+    default: 1
+    range:
+      min: 0
+      max: 1
+      step: 0.1
+    group: sampling
+    applicability:
+      except:
+        do_sample: false
+  - path: top_p
+    type: number
+    label: Top P
+    description: Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.
+    default: 0.95
+    range:
+      min: 0.01
+      max: 1
+      step: 0.01
+    group: sampling
+    applicability:
+      except:
+        do_sample: false
+  - path: do_sample
+    type: boolean
+    label: Do sample
+    description: When false, the model uses greedy decoding and ignores temperature and top_p.
+    default: true
+    group: sampling
+  - path: thinking.type
+    type: enum
+    label: Thinking mode
+    description: Toggles the model's extended reasoning before it produces the final answer.
+    default: enabled
+    values:
+      - enabled
+      - disabled
+    group: reasoning
+  - path: reasoning_effort
+    type: enum
+    label: Reasoning effort
+    description: Controls how much reasoning effort GLM-5.2 spends when thinking is enabled.
+    default: max
+    values:
+      - none
+      - minimal
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    group: reasoning
+    applicability:
+      only:
+        thinking.type: enabled
+  - path: response_format.type
+    type: enum
+    label: Response format
+    description: Forces the response into plain text or a JSON object.
+    default: text
+    values:
+      - text
+      - json_object
+    group: output_format

--- a/packages/modelparams-python/src/modelparams/_generated/catalog.json
+++ b/packages/modelparams-python/src/modelparams/_generated/catalog.json
@@ -24530,5 +24530,114 @@
         ]
       }
     ]
+  },
+  {
+    "provider": "z-ai",
+    "authType": "api_key",
+    "model": "glm-5.3",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of tokens to generate in the response.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 65536,
+        "range": {
+          "min": 1,
+          "max": 131072
+        }
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "applicability": {
+          "except": {
+            "do_sample": false
+          }
+        },
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.",
+        "group": "sampling",
+        "applicability": {
+          "except": {
+            "do_sample": false
+          }
+        },
+        "type": "number",
+        "default": 0.95,
+        "range": {
+          "min": 0.01,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "do_sample",
+        "label": "Do sample",
+        "description": "When false, the model uses greedy decoding and ignores temperature and top_p.",
+        "group": "sampling",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "path": "thinking.type",
+        "label": "Thinking mode",
+        "description": "Toggles the model's extended reasoning before it produces the final answer.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "enabled",
+        "values": [
+          "enabled",
+          "disabled"
+        ]
+      },
+      {
+        "path": "reasoning_effort",
+        "label": "Reasoning effort",
+        "description": "Controls how much reasoning effort GLM-5.2 spends when thinking is enabled.",
+        "group": "reasoning",
+        "applicability": {
+          "only": {
+            "thinking.type": "enabled"
+          }
+        },
+        "type": "enum",
+        "default": "max",
+        "values": [
+          "none",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      },
+      {
+        "path": "response_format.type",
+        "label": "Response format",
+        "description": "Forces the response into plain text or a JSON object.",
+        "group": "output_format",
+        "type": "enum",
+        "default": "text",
+        "values": [
+          "text",
+          "json_object"
+        ]
+      }
+    ]
   }
 ]

--- a/packages/modelparams-python/src/modelparams/_generated/model_ids.py
+++ b/packages/modelparams-python/src/modelparams/_generated/model_ids.py
@@ -317,6 +317,7 @@ ModelId = Literal[
     "z-ai/glm-5.1-subscription",
     "z-ai/glm-5.2",
     "z-ai/glm-5.2-subscription",
+    "z-ai/glm-5.3",
 ]
 
 MODEL_IDS: tuple[ModelId, ...] = (
@@ -633,6 +634,7 @@ MODEL_IDS: tuple[ModelId, ...] = (
     "z-ai/glm-5.1-subscription",
     "z-ai/glm-5.2",
     "z-ai/glm-5.2-subscription",
+    "z-ai/glm-5.3",
 )
 
 Provider = Literal[

--- a/packages/modelparams-python/src/modelparams/_generated/registry.py
+++ b/packages/modelparams-python/src/modelparams/_generated/registry.py
@@ -339,4 +339,5 @@ PARAM_TYPES: dict[ModelId, Any] = {
     "z-ai/glm-5.1-subscription": z_ai.Glm_5_1_SubscriptionParams,
     "z-ai/glm-5.2": z_ai.Glm_5_2Params,
     "z-ai/glm-5.2-subscription": z_ai.Glm_5_2_SubscriptionParams,
+    "z-ai/glm-5.3": z_ai.Glm_5_3Params,
 }

--- a/packages/modelparams-python/src/modelparams/types/z_ai.py
+++ b/packages/modelparams-python/src/modelparams/types/z_ai.py
@@ -306,6 +306,21 @@ Glm_5_2_SubscriptionParams = TypedDict(
 )
 setattr(Glm_5_2_SubscriptionParams, "__pydantic_config__", _PARAMS_CONFIG)
 
+Glm_5_3Params = TypedDict(
+    "Glm_5_3Params",
+    {
+        "max_tokens": Annotated[int, Field(ge=1, le=131072)],
+        "temperature": Annotated[float, Field(ge=0, le=1)],
+        "top_p": Annotated[float, Field(ge=0.01, le=1)],
+        "do_sample": bool,
+        "thinking.type": Literal["enabled", "disabled"],
+        "reasoning_effort": Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+        "response_format.type": Literal["text", "json_object"],
+    },
+    total=False,
+)
+setattr(Glm_5_3Params, "__pydantic_config__", _PARAMS_CONFIG)
+
 __all__ = [
     "Glm_4_5Params",
     "Glm_4_5_AirParams",
@@ -328,4 +343,5 @@ __all__ = [
     "Glm_5_1_SubscriptionParams",
     "Glm_5_2Params",
     "Glm_5_2_SubscriptionParams",
+    "Glm_5_3Params",
 ]

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -24535,6 +24535,115 @@ export const CATALOG = [
         ]
       }
     ]
+  },
+  {
+    "provider": "z-ai",
+    "authType": "api_key",
+    "model": "glm-5.3",
+    "params": [
+      {
+        "path": "max_tokens",
+        "label": "Max tokens",
+        "description": "Maximum number of tokens to generate in the response.",
+        "group": "generation_length",
+        "type": "integer",
+        "default": 65536,
+        "range": {
+          "min": 1,
+          "max": 131072
+        }
+      },
+      {
+        "path": "temperature",
+        "label": "Temperature",
+        "description": "Controls randomness. Lower values make outputs more focused; higher values make them more varied.",
+        "group": "sampling",
+        "applicability": {
+          "except": {
+            "do_sample": false
+          }
+        },
+        "type": "number",
+        "default": 1,
+        "range": {
+          "min": 0,
+          "max": 1,
+          "step": 0.1
+        }
+      },
+      {
+        "path": "top_p",
+        "label": "Top P",
+        "description": "Controls nucleus sampling by limiting generation to tokens within the selected cumulative probability.",
+        "group": "sampling",
+        "applicability": {
+          "except": {
+            "do_sample": false
+          }
+        },
+        "type": "number",
+        "default": 0.95,
+        "range": {
+          "min": 0.01,
+          "max": 1,
+          "step": 0.01
+        }
+      },
+      {
+        "path": "do_sample",
+        "label": "Do sample",
+        "description": "When false, the model uses greedy decoding and ignores temperature and top_p.",
+        "group": "sampling",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "path": "thinking.type",
+        "label": "Thinking mode",
+        "description": "Toggles the model's extended reasoning before it produces the final answer.",
+        "group": "reasoning",
+        "type": "enum",
+        "default": "enabled",
+        "values": [
+          "enabled",
+          "disabled"
+        ]
+      },
+      {
+        "path": "reasoning_effort",
+        "label": "Reasoning effort",
+        "description": "Controls how much reasoning effort GLM-5.2 spends when thinking is enabled.",
+        "group": "reasoning",
+        "applicability": {
+          "only": {
+            "thinking.type": "enabled"
+          }
+        },
+        "type": "enum",
+        "default": "max",
+        "values": [
+          "none",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      },
+      {
+        "path": "response_format.type",
+        "label": "Response format",
+        "description": "Forces the response into plain text or a JSON object.",
+        "group": "output_format",
+        "type": "enum",
+        "default": "text",
+        "values": [
+          "text",
+          "json_object"
+        ]
+      }
+    ]
   }
 ] as const;
 

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -1804,4 +1804,13 @@ export const DEFAULTS = {
     reasoning_effort: "max",
     "response_format.type": "text",
   },
+  "z-ai/glm-5.3": {
+    max_tokens: 65536,
+    temperature: 1,
+    top_p: 0.95,
+    do_sample: true,
+    "thinking.type": "enabled",
+    reasoning_effort: "max",
+    "response_format.type": "text",
+  },
 } as const satisfies { [K in ModelId]: Partial<ParamsById[K]> };

--- a/packages/modelparams/src/generated/model-ids.ts
+++ b/packages/modelparams/src/generated/model-ids.ts
@@ -314,7 +314,8 @@ export const MODEL_IDS = [
   "z-ai/glm-5.1",
   "z-ai/glm-5.1-subscription",
   "z-ai/glm-5.2",
-  "z-ai/glm-5.2-subscription"
+  "z-ai/glm-5.2-subscription",
+  "z-ai/glm-5.3"
 ] as const;
 
 export type ModelId = (typeof MODEL_IDS)[number];

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -2455,4 +2455,13 @@ export type ParamsById = {
     reasoning_effort: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
     "response_format.type": "text" | "json_object";
   };
+  "z-ai/glm-5.3": {
+    max_tokens: number;
+    temperature: number;
+    top_p: number;
+    do_sample: boolean;
+    "thinking.type": "enabled" | "disabled";
+    reasoning_effort: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+    "response_format.type": "text" | "json_object";
+  };
 };


### PR DESCRIPTION
### ✨ What changed
- Adds `glm-5.3` (z-ai) to the catalog, params cloned from `z-ai/glm-5.2.yaml`.

### 💭 Why
The provider serves it but the catalog doesn't list it.

### 📝 Notes
- Liveness ✅ only: the model answers on its real endpoint; unverified params are listed in the evidence table below.
- Draft PR, auto-proposed by the modelparams agent.

<details><summary>Param verification evidence</summary>

| param | check | ok | detail |
|---|---|---|---|
| `(baseline)` | accepted | ✅ | 1-shot answers 200 |
| `max_tokens` | min=1 | ✅ |  |
| `max_tokens` | max=131072 | ➖ | too large for a non-streaming probe — upper bound from docs |
| `max_tokens` | range policed | ✅ | vendor max 131072 |
| `temperature` | min=0 | ✅ |  |
| `temperature` | max=1 | ✅ |  |
| `temperature` | range policed | ✅ | temperature=2 rejected |
| `top_p` | min=0.01 | ✅ |  |
| `top_p` | max=1 | ✅ |  |
| `top_p` | range policed | ✅ | top_p=2 rejected |
| `do_sample` | =true | ✅ | accepted (no effect oracle) |
| `thinking.type` | =enabled | ✅ | accepted + effect confirmed in response |
| `thinking.type` | =disabled | ❌ | rejected: 400 This model always engages in thinking and cannot be disabled; please use low, high, or max |
| `thinking.type` | enum policed | ✅ | bogus value rejected |
| `reasoning_effort` | =none | ❌ | rejected: 400 This model always engages in thinking and cannot be disabled; please use low, high, or max |
| `reasoning_effort` | =minimal | ❌ | rejected: 400 This model always engages in thinking and cannot be disabled; please use low, high, or max |
| `reasoning_effort` | =low | ✅ | accepted (no effect oracle for this value) |
| `reasoning_effort` | =medium | ❌ | rejected: 400 This model always engages in thinking and cannot be disabled; please use low, high, or max |
| `reasoning_effort` | =high | ✅ | accepted + effect confirmed in response |
| `reasoning_effort` | =xhigh | ❌ | rejected: 400 This model always engages in thinking and cannot be disabled; please use low, high, or max |
| `reasoning_effort` | =max | ✅ | accepted + effect confirmed in response |
| `reasoning_effort` | enum policed | ✅ | bogus value rejected |
| `response_format.type` | =text | ✅ | accepted (no effect oracle for this value) |
| `response_format.type` | =json_object | ✅ | accepted + effect confirmed in response |
| `response_format.type` | enum policed | ➖ | bogus value accepted — vendor doesn't police this enum; declared values are docs-sourced |

</details>