### PR TITLE
fix: keep the release PR installable so it can actually merge

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -126,8 +126,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "$RELEASE_BRANCH"
-          git add packages/modelparams/package.json \
+          # Every file prepare-release.ts writes has to be listed here: an
+          # unstaged version bump is silently dropped, and a lockfile left
+          # behind its manifest fails `npm ci` on this very PR.
+          git add package-lock.json \
+                  packages/modelparams/package.json \
                   packages/modelparams/CHANGELOG.md \
+                  packages/modelparams-mcp/package.json \
+                  packages/modelparams-mcp/CHANGELOG.md \
                   packages/modelparams-python/pyproject.toml \
                   packages/modelparams-python/uv.lock \
                   packages/modelparams-python/CHANGELOG.md

--- a/scripts/lib/package-lock.ts
+++ b/scripts/lib/package-lock.ts
@@ -1,0 +1,59 @@
+/**
+ * Rewrite the versions package-lock.json records for a workspace package.
+ *
+ * npm's lockfile mirrors every workspace's own `version` (and the exact pins
+ * one workspace puts on another) under a `packages/<dir>` entry. Bumping the
+ * workspace package.json alone leaves the lock behind, and `npm ci` then
+ * refuses the whole install with "Missing: modelparams@<old> from lock file"
+ * — which fails every CI job on the release PR, the required param guard
+ * included, so the PR can never merge and nothing ever publishes.
+ *
+ * This mirrors the handful of lines `npm install --package-lock-only` would
+ * change, edited in place so the release commit carries no incidental
+ * dependency-tree churn. Same job as `bumpUvLockVersion` does for uv.lock.
+ */
+export function bumpPackageLockVersion(
+  source: string,
+  next: string,
+  workspaceDir: string,
+  /** Workspace siblings this package pins exactly, whose pins move too. */
+  repinnedDependencies: string[] = [],
+): string {
+  const key = `packages/${workspaceDir}`;
+  const opening = `\n    ${JSON.stringify(key)}: {`;
+  const start = source.indexOf(opening);
+  if (start === -1) {
+    throw new Error(`could not find the "${key}" entry in package-lock.json`);
+  }
+  // Entries live two levels deep, so the first four-space-indented closing
+  // brace after the opening one ends this entry and no nested object.
+  const end = source.indexOf("\n    }", start + opening.length);
+  if (end === -1) {
+    throw new Error(`could not find the end of the "${key}" entry in package-lock.json`);
+  }
+
+  const entry = source.slice(start, end);
+  let updated = replaceOnce(
+    entry,
+    /("version"\s*:\s*")\d+\.\d+\.\d+(")/,
+    next,
+    `version in the "${key}" entry of package-lock.json`,
+  );
+  for (const dependency of repinnedDependencies) {
+    updated = replaceOnce(
+      updated,
+      new RegExp(`(${JSON.stringify(dependency)}\\s*:\\s*")\\d+\\.\\d+\\.\\d+(")`),
+      next,
+      `"${dependency}" pin in the "${key}" entry of package-lock.json`,
+    );
+  }
+
+  return source.slice(0, start) + updated + source.slice(end);
+}
+
+function replaceOnce(source: string, pattern: RegExp, next: string, what: string): string {
+  if (!pattern.test(source)) {
+    throw new Error(`could not find the ${what}`);
+  }
+  return source.replace(pattern, `$1${next}$2`);
+}

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -20,6 +20,7 @@ import { loadAllModels } from "../src/data/load.js";
 import { loadModelsAtRef, refExists } from "../src/data/git-baseline.js";
 import { diffCatalogs, renderCatalogChangelog } from "../src/data/catalog-diff.js";
 import { insertChangelogEntry } from "./lib/changelog.js";
+import { bumpPackageLockVersion } from "./lib/package-lock.js";
 import { bumpUvLockVersion } from "./lib/uv-lock.js";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -58,6 +59,14 @@ const PACKAGES: PackageSpec[] = [
       // Rewrite the single line rather than re-serializing, so the release
       // commit carries no incidental key-order or formatting churn.
       source.replace(/("version"\s*:\s*")\d+\.\d+\.\d+(")/, `$1${next}$2`),
+    syncFiles: [
+      // package-lock.json records each workspace's own version; without this,
+      // every `npm ci` in CI fails on the release PR.
+      {
+        file: "package-lock.json",
+        write: (source, next) => bumpPackageLockVersion(source, next, "modelparams"),
+      },
+    ],
   },
   {
     key: "mcp",
@@ -73,6 +82,15 @@ const PACKAGES: PackageSpec[] = [
         .replace(/("version"\s*:\s*")\d+\.\d+\.\d+(")/, `$1${next}$2`)
         // The exact dependency pin moves with the version (see lockstepWith).
         .replace(/("modelparams"\s*:\s*")[^"]+(")/, `$1${next}$2`),
+    syncFiles: [
+      // Both the workspace version and the exact `modelparams` pin are
+      // mirrored in the lockfile, and `npm ci` checks both.
+      {
+        file: "package-lock.json",
+        write: (source, next) =>
+          bumpPackageLockVersion(source, next, "modelparams-mcp", ["modelparams"]),
+      },
+    ],
   },
   {
     key: "python",

--- a/tests/release-lockfiles.test.ts
+++ b/tests/release-lockfiles.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { bumpPackageLockVersion } from "../scripts/lib/package-lock.js";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const lock = fs.readFileSync(path.join(REPO_ROOT, "package-lock.json"), "utf8");
+
+function entry(source: string, key: string): string {
+  const start = source.indexOf(`\n    ${JSON.stringify(`packages/${key}`)}: {`);
+  return source.slice(start, source.indexOf("\n    }", start + 1));
+}
+
+describe("bumpPackageLockVersion", () => {
+  it("moves the workspace version npm ci compares against package.json", () => {
+    const updated = bumpPackageLockVersion(lock, "9.9.9", "modelparams");
+    expect(entry(updated, "modelparams")).toContain('"version": "9.9.9"');
+  });
+
+  it("moves the exact sibling pin the MCP package ships in lockstep", () => {
+    const updated = bumpPackageLockVersion(lock, "9.9.9", "modelparams-mcp", ["modelparams"]);
+    const mcp = entry(updated, "modelparams-mcp");
+    expect(mcp).toContain('"version": "9.9.9"');
+    expect(mcp).toContain('"modelparams": "9.9.9"');
+  });
+
+  it("leaves every other entry untouched", () => {
+    const updated = bumpPackageLockVersion(lock, "9.9.9", "modelparams");
+    expect(entry(updated, "modelparams-mcp")).toBe(entry(lock, "modelparams-mcp"));
+    expect(updated.length).toBe(lock.length);
+  });
+
+  it("fails loudly rather than silently skipping an unknown workspace", () => {
+    expect(() => bumpPackageLockVersion(lock, "9.9.9", "not-a-workspace")).toThrow(
+      /packages\/not-a-workspace/,
+    );
+    expect(() => bumpPackageLockVersion(lock, "9.9.9", "modelparams", ["not-a-dep"])).toThrow(
+      /not-a-dep/,
+    );
+  });
+});


### PR DESCRIPTION
## What's broken

Every CI job on `chore/release` has failed at `npm ci` since the batched release flow landed — [PR #255](https://github.com/mnfst/modelparams.dev/pull/255) has not had a green run since 2026-08-18, so no npm or PyPI release has shipped in that window despite ~15 model merges:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: modelparams@0.0.1 from lock file
```

Because `param-guard.yml` also starts with `npm ci`, the **required** "No parameter removals" check can never report success — the release PR is structurally unmergeable. That is the same wedge `release-prepare.yml`'s header comment warns about for `GITHUB_TOKEN`-authored PRs, reached from a different direction.

## Why

Two omissions in the "Push release branch" step, which stages an explicit path list:

1. **`packages/modelparams-mcp/package.json` was never staged.** `prepare-release.ts` writes it — the lockstep version bump *and* the exact `modelparams` dependency pin that has to move with it — but the file was not in `git add`, so the edit was dropped every run. The branch ended up with `modelparams` at `0.0.55` while `modelparams-mcp` still pinned `modelparams@0.0.1`, a version no longer present in the tree. Hence npm's "Missing: modelparams@0.0.1".
2. **`package-lock.json` was never updated.** The lockfile mirrors both workspace versions and that pin, and `npm ci` refuses any tree it cannot reconcile with the manifests.

The Python side already solved the identical problem: `uv.lock` pins the project's own version, so it rides along as a `syncFiles` entry on the Python spec.

## The fix

- `scripts/lib/package-lock.ts` — `bumpPackageLockVersion`, the npm counterpart to `bumpUvLockVersion`. Surgical in-place edits of the `packages/<dir>` entry (version, plus any exact sibling pin), so the release commit carries no incidental dependency-tree churn, and a loud throw rather than a silent no-op if an entry moves.
- `scripts/prepare-release.ts` — `package-lock.json` added as a `syncFiles` entry on both the `modelparams` and `modelparams-mcp` specs.
- `.github/workflows/release-prepare.yml` — staged-path list now covers every file the script writes, MCP manifest and changelog included, with a comment on why an unstaged path is a silent failure.

## Verification

Reproduced and fixed against a clean checkout of `chore/release` (not just locally, where npm 10 and a warm `node_modules` mask it):

| tree | `npm ci` |
|---|---|
| `chore/release` as it stands | `EUSAGE — Missing: modelparams@0.0.1 from lock file` |
| same branch + the lockfile and MCP manifest this change commits | `added 584 packages` |

Also ran `prepare-release.ts` end to end on current `main`: it produces `modelparams@0.0.55 + modelparams-mcp@0.0.55 + modelparams-py@0.0.36` with a 4-line `package-lock.json` diff and nothing else. Four unit tests cover the helper; full suite is 210 passing.

## After merge

`chore/release` is rebuilt on push to `main`, so merging this regenerates it correctly. If no model PR lands first, kick it with a `workflow_dispatch` on **Prepare release**. Note that #255 will then also carry the MCP bump it has been silently missing — `modelparams-mcp@0.0.55` publishes in lockstep on merge.