### PR TITLE
fix: stop the lockfile test from assuming the version it bumps from

### DIFF
--- a/tests/release-lockfiles.test.ts
+++ b/tests/release-lockfiles.test.ts
@@ -7,28 +7,37 @@ import { bumpPackageLockVersion } from "../scripts/lib/package-lock.js";
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const lock = fs.readFileSync(path.join(REPO_ROOT, "package-lock.json"), "utf8");
 
-function entry(source: string, key: string): string {
+/** The `packages/<key>` entry, and everything in the lockfile that is not it. */
+function split(source: string, key: string): { entry: string; rest: string } {
   const start = source.indexOf(`\n    ${JSON.stringify(`packages/${key}`)}: {`);
-  return source.slice(start, source.indexOf("\n    }", start + 1));
+  const end = source.indexOf("\n    }", start + 1);
+  return { entry: source.slice(start, end), rest: source.slice(0, start) + source.slice(end) };
 }
 
 describe("bumpPackageLockVersion", () => {
   it("moves the workspace version npm ci compares against package.json", () => {
     const updated = bumpPackageLockVersion(lock, "9.9.9", "modelparams");
-    expect(entry(updated, "modelparams")).toContain('"version": "9.9.9"');
+    expect(split(updated, "modelparams").entry).toContain('"version": "9.9.9"');
   });
 
   it("moves the exact sibling pin the MCP package ships in lockstep", () => {
     const updated = bumpPackageLockVersion(lock, "9.9.9", "modelparams-mcp", ["modelparams"]);
-    const mcp = entry(updated, "modelparams-mcp");
-    expect(mcp).toContain('"version": "9.9.9"');
-    expect(mcp).toContain('"modelparams": "9.9.9"');
+    const { entry } = split(updated, "modelparams-mcp");
+    expect(entry).toContain('"version": "9.9.9"');
+    expect(entry).toContain('"modelparams": "9.9.9"');
   });
 
   it("leaves every other entry untouched", () => {
+    // Deliberately not a length comparison: the release branch runs this
+    // against a lockfile already carrying a longer version than the one under
+    // test, so byte counts legitimately differ.
     const updated = bumpPackageLockVersion(lock, "9.9.9", "modelparams");
-    expect(entry(updated, "modelparams-mcp")).toBe(entry(lock, "modelparams-mcp"));
-    expect(updated.length).toBe(lock.length);
+    expect(split(updated, "modelparams").rest).toBe(split(lock, "modelparams").rest);
+  });
+
+  it("is idempotent, so a re-prepared release branch converges", () => {
+    const once = bumpPackageLockVersion(lock, "9.9.9", "modelparams-mcp", ["modelparams"]);
+    expect(bumpPackageLockVersion(once, "9.9.9", "modelparams-mcp", ["modelparams"])).toBe(once);
   });
 
   it("fails loudly rather than silently skipping an unknown workspace", () => {


### PR DESCRIPTION
Follow-up to #303, which left one wrong assertion behind.

`tests/release-lockfiles.test.ts` checked "leaves every other entry untouched" by comparing the length of the rewritten lockfile against the original. That holds on `main`, where the lock says `0.0.1` and the fixture bumps it to `9.9.9` — same width. It does not hold on `chore/release`, where the lock already carries `0.0.55`, so the bump shortens the file by one byte:

```
FAIL tests/release-lockfiles.test.ts > bumpPackageLockVersion > leaves every other entry untouched
  → expected 277350 to be 277351
```

That was the single remaining red check on [#255](https://github.com/mnfst/modelparams.dev/pull/255) after #303 fixed the `npm ci` failure — a test failing on the exact branch it exists to protect.

The case now compares the untouched remainder of the lockfile, which is what it was claiming all along. Also adds an idempotence case, for the same underlying reason: `chore/release` is force-rebuilt from `main` on every merge, so the helper regularly runs against a lock it already rewrote.

Verified both ways — the suite passes against `main`'s lockfile and against `chore/release`'s.