### PR TITLE
feat: serve the MCP server over HTTP at /mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npx -y modelparams-mcp              # MCP server: 4 tools, stdio, no network nee
 npx skills add mnfst/modelparams.dev # the companion agent skill
 ```
 
-The MCP server exposes `validate_model_params`, `get_model_params`, `list_models`, and `find_models_supporting`. Details in the [package README](packages/modelparams-mcp/README.md). There's also [llms.txt](https://modelparams.dev/llms.txt) if you'd rather just point an agent at a URL.
+The MCP server is also hosted at `https://modelparams.dev/mcp` over Streamable HTTP, which needs no install and always answers from the catalog the site is serving — `claude mcp add --transport http modelparams https://modelparams.dev/mcp`, or `codex mcp add modelparams --url https://modelparams.dev/mcp`. Either way it exposes `validate_model_params`, `get_model_params`, `list_models`, and `find_models_supporting`. Details in the [package README](packages/modelparams-mcp/README.md). There's also [llms.txt](https://modelparams.dev/llms.txt) if you'd rather just point an agent at a URL.
 
 ## One model, many providers
 

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -1,0 +1,164 @@
+// POST /mcp — the modelparams catalog as an MCP server over Streamable HTTP.
+//
+// Same four tools as the `modelparams-mcp` npm package, built by the same
+// `createServer()` factory; only the transport differs. The stdio package pins
+// an exact catalog version at publish time, so a model added today reaches
+// those users only after they upgrade. This endpoint is rebuilt with the site
+// on every merge to main, so it answers from the catalog the site is serving.
+//
+// Stateless by design: no session ids, no server-initiated streams, one server
+// instance per request. All four tools are read-only request/response, so
+// nothing needs to survive between calls, and every request can land on a
+// different serverless instance without coordination.
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { createServer } from "../packages/modelparams-mcp/src/server.js";
+
+const MAX_BODY_BYTES = 256 * 1024;
+
+// Vercel exposes the deployment sha; the catalog is whatever that build carried,
+// so it is the honest answer to "which version am I talking to?".
+const VERSION = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ?? "dev";
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Accept, Mcp-Protocol-Version, Mcp-Session-Id",
+  "Access-Control-Max-Age": "86400",
+} as const;
+
+const USAGE = {
+  endpoint: "POST /mcp",
+  description:
+    "MCP server for the modelparams.dev catalog, over Streamable HTTP. Answers what " +
+    "parameters a model accepts, and validates a params object before you send it.",
+  transport: "streamable-http",
+  stateless: true,
+  tools: ["validate_model_params", "get_model_params", "list_models", "find_models_supporting"],
+  install: {
+    "claude-code": "claude mcp add --transport http modelparams https://modelparams.dev/mcp",
+    codex: "codex mcp add modelparams --url https://modelparams.dev/mcp",
+  },
+  docs: "https://modelparams.dev/api",
+} as const;
+
+function json(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body, null, 2) + "\n", {
+    status,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      // Every response is specific to one JSON-RPC call, so no shared cache may
+      // hold it — unlike the static catalog endpoints under /api/v1.
+      "Cache-Control": "no-store",
+      ...CORS,
+      ...headers,
+    },
+  });
+}
+
+function rpcError(id: string | number | null, code: number, message: string, status: number) {
+  return json({ jsonrpc: "2.0", id, error: { code, message } }, status);
+}
+
+/**
+ * Carries exactly one JSON-RPC message into an McpServer and hands back what
+ * the server replies. The SDK's own HTTP transport wants Node's `req`/`res`
+ * objects, which this function never sees — Vercel hands it a web `Request`.
+ */
+class SingleMessageTransport implements Transport {
+  onmessage?: (message: JSONRPCMessage) => void;
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+
+  private resolve?: (message: JSONRPCMessage) => void;
+
+  async start(): Promise<void> {}
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    this.resolve?.(message);
+  }
+
+  async close(): Promise<void> {
+    this.onclose?.();
+  }
+
+  /** Resolves with the server's reply, or null when the input was a notification. */
+  async exchange(message: JSONRPCMessage): Promise<JSONRPCMessage | null> {
+    const isRequest = "id" in message && message.id !== null && message.id !== undefined;
+    if (!isRequest) {
+      this.onmessage?.(message);
+      return null;
+    }
+    const reply = new Promise<JSONRPCMessage>((resolve) => {
+      this.resolve = resolve;
+    });
+    this.onmessage?.(message);
+    return await reply;
+  }
+}
+
+async function readMessage(request: Request): Promise<JSONRPCMessage> {
+  const raw = await request.text();
+  if (raw.length > MAX_BODY_BYTES) {
+    throw new RangeError(`request body exceeds ${MAX_BODY_BYTES} bytes`);
+  }
+  if (raw.trim() === "") throw new SyntaxError("request body is empty");
+  const parsed: unknown = JSON.parse(raw);
+  if (Array.isArray(parsed)) {
+    // Batching left the protocol in the 2025-06-18 revision; say so rather than
+    // silently answering the first message in the array.
+    throw new SyntaxError("JSON-RPC batches are not supported");
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new SyntaxError("request body must be a JSON-RPC message object");
+  }
+  return parsed as JSONRPCMessage;
+}
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: CORS });
+    }
+
+    // A GET is either an MCP client opening the optional server-to-client
+    // stream, which a stateless server has nothing to put on, or a person
+    // opening the URL. Answer each in its own terms.
+    if (request.method === "GET") {
+      if ((request.headers.get("accept") ?? "").includes("text/event-stream")) {
+        return json({ error: "streaming_not_supported", usage: USAGE }, 405, { Allow: "POST" });
+      }
+      return json(USAGE);
+    }
+
+    if (request.method !== "POST") {
+      return json({ error: "method_not_allowed", usage: USAGE }, 405, {
+        Allow: "POST, GET, OPTIONS",
+      });
+    }
+
+    let message: JSONRPCMessage;
+    try {
+      message = await readMessage(request);
+    } catch (err) {
+      const status = err instanceof RangeError ? 413 : 400;
+      return rpcError(null, -32700, (err as Error).message, status);
+    }
+
+    const server = createServer(VERSION);
+    const transport = new SingleMessageTransport();
+    try {
+      await server.connect(transport);
+      const reply = await transport.exchange(message);
+      // A notification gets no body: the client is telling us something
+      // (`notifications/initialized`), not asking.
+      if (reply === null) return new Response(null, { status: 202, headers: CORS });
+      return json(reply);
+    } catch (err) {
+      const id = "id" in message ? ((message.id as string | number | null) ?? null) : null;
+      return rpcError(id, -32603, (err as Error).message, 500);
+    } finally {
+      await server.close();
+    }
+  },
+};

--- a/packages/modelparams-mcp/README.md
+++ b/packages/modelparams-mcp/README.md
@@ -12,6 +12,19 @@ This server gives the agent a way to look it up instead.
 
 ## Install
 
+**Hosted (no install)** — the same four tools over Streamable HTTP, always serving the current catalog:
+
+```bash
+claude mcp add --transport http modelparams https://modelparams.dev/mcp
+codex mcp add modelparams --url https://modelparams.dev/mcp
+```
+
+Use the hosted endpoint unless you need to work offline, or your client speaks stdio only. This package pins an exact
+catalog version at publish time, so it answers from the catalog as of its release; the hosted endpoint rebuilds with the
+site on every catalog change.
+
+## Install locally (stdio)
+
 The server speaks MCP over stdio and bundles the catalog, so it needs no network access and no API key.
 
 **Claude Code**

--- a/packages/modelparams-mcp/src/index.ts
+++ b/packages/modelparams-mcp/src/index.ts
@@ -1,12 +1,19 @@
 #!/usr/bin/env node
+import { createRequire } from "node:module";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./server.js";
+
+// The release workflow rewrites package.json's version; read it there so the
+// MCP handshake always reports the shipped version.
+const PKG_VERSION: string = (
+  createRequire(import.meta.url)("../package.json") as { version: string }
+).version;
 
 export { createServer } from "./server.js";
 export * from "./tools.js";
 
 async function main(): Promise<void> {
-  const server = createServer();
+  const server = createServer(PKG_VERSION);
   // stdout is the transport — anything written there that isn't a protocol
   // message corrupts the session, so diagnostics go to stderr.
   await server.connect(new StdioServerTransport());

--- a/packages/modelparams-mcp/src/server.ts
+++ b/packages/modelparams-mcp/src/server.ts
@@ -1,4 +1,3 @@
-import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CATALOG } from "modelparams";
 import { z } from "zod";
@@ -10,12 +9,6 @@ import {
   type ToolPayload,
 } from "./tools.js";
 
-// The release workflow rewrites package.json's version; read it there so the
-// MCP handshake always reports the shipped version.
-const PKG_VERSION: string = (
-  createRequire(import.meta.url)("../package.json") as { version: string }
-).version;
-
 /** Every tool here is a pure read over data compiled into the package. */
 const READ_ONLY = { readOnlyHint: true, idempotentHint: true, openWorldHint: false } as const;
 
@@ -24,12 +17,16 @@ function reply(payload: ToolPayload) {
 }
 
 /**
- * Build the server. Kept separate from the stdio entry point so tests can drive
- * it over an in-memory transport.
+ * Build the server. Kept separate from any transport so the stdio entry point,
+ * the site's HTTP endpoint, and the tests can each drive the same tools.
+ *
+ * `version` is passed in rather than read from package.json: the HTTP endpoint
+ * is bundled by Vercel, where a relative read of the package manifest does not
+ * survive bundling, and the two transports report different versions anyway.
  */
-export function createServer(): McpServer {
+export function createServer(version = "0.0.0"): McpServer {
   const server = new McpServer(
-    { name: "modelparams", version: PKG_VERSION },
+    { name: "modelparams", version },
     {
       instructions:
         "Answers what parameters an LLM accepts, using the modelparams.dev catalog of " +

--- a/packages/modelparams/package.json
+++ b/packages/modelparams/package.json
@@ -60,6 +60,7 @@
   },
   "scripts": {
     "codegen": "tsx scripts/codegen.ts",
+    "prepare": "npm run build",
     "prebuild": "npm run codegen",
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",

--- a/src/views/api.ejs
+++ b/src/views/api.ejs
@@ -113,12 +113,18 @@
     <section>
       <h2 class="text-slate-900 dark:text-slate-100">MCP server</h2>
       <p class="mt-2 text-slate-600 dark:text-slate-300">
-        Let a coding agent check the catalog itself. The server speaks the Model Context Protocol over stdio and bundles
-        the catalog, so it works with no network access.
+        Let a coding agent check the catalog itself. Hosted at
+        <code class="font-mono text-xs">https://modelparams.dev/mcp</code>, over Streamable HTTP — nothing to install,
+        and it always answers from the catalog this site is serving.
       </p>
       <div class="mt-4">
-        <pre class="overflow-x-auto border border-slate-200 bg-slate-900 px-5 py-4 font-mono text-sm leading-relaxed text-slate-200 dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code>npx -y modelparams-mcp</code></pre>
+        <pre class="overflow-x-auto border border-slate-200 bg-slate-900 px-5 py-4 font-mono text-sm leading-relaxed text-slate-200 dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code>claude mcp add --transport http modelparams https://modelparams.dev/mcp
+codex mcp add modelparams --url https://modelparams.dev/mcp</code></pre>
       </div>
+      <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">
+        Need it offline, or a client that only speaks stdio? Run the same four tools locally with
+        <code class="font-mono text-xs">npx -y modelparams-mcp</code>, which carries its own copy of the catalog.
+      </p>
       <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">
         Tools:
         <code class="font-mono text-xs">validate_model_params</code>,

--- a/tests/mcp-endpoint-protocol.test.ts
+++ b/tests/mcp-endpoint-protocol.test.ts
@@ -1,0 +1,72 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import handler from "../api/mcp.js";
+
+// The unit tests above drive the handler with hand-written JSON-RPC. This one
+// puts the real SDK client in front of it over real HTTP, which is what Claude
+// Code and Codex do — protocol details we get wrong show up here, not there.
+let server: http.Server;
+let client: Client;
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      void (async () => {
+        const body = Buffer.concat(chunks);
+        const response = await handler.fetch(
+          new Request(`http://localhost${req.url ?? "/"}`, {
+            method: req.method,
+            headers: req.headers as Record<string, string>,
+            body: req.method === "GET" || req.method === "HEAD" ? undefined : body,
+          }),
+        );
+        res.writeHead(response.status, Object.fromEntries(response.headers));
+        res.end(Buffer.from(await response.arrayBuffer()));
+      })();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+
+  client = new Client({ name: "protocol-test", version: "1" });
+  await client.connect(new StreamableHTTPClientTransport(new URL(`http://localhost:${port}/mcp`)));
+});
+
+afterAll(async () => {
+  await client.close();
+  server.close();
+});
+
+describe("the MCP endpoint over real HTTP", () => {
+  it("completes the handshake a standard client performs", () => {
+    expect(client.getServerVersion()?.name).toBe("modelparams");
+  });
+
+  it("advertises the four tools", async () => {
+    const { tools } = await client.listTools();
+    expect(tools.map((tool) => tool.name).sort()).toEqual([
+      "find_models_supporting",
+      "get_model_params",
+      "list_models",
+      "validate_model_params",
+    ]);
+  });
+
+  it("answers a tool call", async () => {
+    const result = await client.callTool({
+      name: "validate_model_params",
+      arguments: { model: "anthropic/claude-opus-5", params: { temperature: 0.7 } },
+    });
+    const payload = JSON.parse((result.content as { text: string }[])[0]!.text) as {
+      model: string;
+      issues: unknown[];
+    };
+    expect(payload.model).toBe("anthropic/claude-opus-5");
+    expect(Array.isArray(payload.issues)).toBe(true);
+  });
+});

--- a/tests/mcp-endpoint.test.ts
+++ b/tests/mcp-endpoint.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import handler from "../api/mcp.js";
+
+const URL = "https://modelparams.dev/mcp";
+
+async function rpc(body: unknown, init: RequestInit = {}): Promise<Response> {
+  return await handler.fetch(
+    new Request(URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+      ...init,
+    }),
+  );
+}
+
+interface RpcReply {
+  jsonrpc: string;
+  id?: number | string | null;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+}
+
+async function call(name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const res = await rpc({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: { name, arguments: args },
+  });
+  const body = (await res.json()) as RpcReply;
+  const content = (body.result as { content: { type: string; text: string }[] }).content;
+  return JSON.parse(content[0]!.text) as Record<string, unknown>;
+}
+
+describe("POST /mcp", () => {
+  it("completes the initialize handshake", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test", version: "0" },
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as RpcReply;
+    const result = body.result as {
+      serverInfo: { name: string };
+      capabilities: Record<string, unknown>;
+    };
+    expect(result.serverInfo.name).toBe("modelparams");
+    expect(result.capabilities.tools).toBeDefined();
+  });
+
+  it("lists the four catalog tools", async () => {
+    const res = await rpc({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+    const body = (await res.json()) as RpcReply;
+    const names = (body.result as { tools: { name: string }[] }).tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      "find_models_supporting",
+      "get_model_params",
+      "list_models",
+      "validate_model_params",
+    ]);
+  });
+
+  it("answers a real catalog question", async () => {
+    const result = await call("get_model_params", { model: "openai/gpt-4" });
+    expect(result.model).toBe("openai/gpt-4");
+    expect(result.parameterCount as number).toBeGreaterThan(0);
+  });
+
+  it("validates params, which is the tool agents should call first", async () => {
+    const result = await call("validate_model_params", {
+      model: "openai/gpt-4",
+      params: { temperature: 0.5, nonsense_param: 1 },
+    });
+    expect(result.valid).toBe(false);
+    expect(JSON.stringify(result.issues)).toContain("nonsense_param");
+    expect(result.safeParams).toEqual({ temperature: 0.5 });
+  });
+
+  it("serves the catalog the site was built from, not a pinned npm version", async () => {
+    // The stdio package answers from `modelparams@<exact pin>`; this endpoint
+    // answers from the build. A model merged today must be present here.
+    const result = await call("list_models", { provider: "bedrock" });
+    expect((result.models as string[]).length).toBeGreaterThan(0);
+  });
+
+  it("accepts a notification with no body", async () => {
+    const res = await rpc({ jsonrpc: "2.0", method: "notifications/initialized" });
+    expect(res.status).toBe(202);
+    expect(await res.text()).toBe("");
+  });
+
+  it("rejects a JSON-RPC batch instead of answering only its first message", async () => {
+    const res = await rpc([{ jsonrpc: "2.0", id: 1, method: "tools/list" }]);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as RpcReply;
+    expect(body.error?.message).toContain("batch");
+  });
+
+  it("rejects a malformed body", async () => {
+    const res = await rpc("{not json");
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as RpcReply).error?.code).toBe(-32700);
+  });
+
+  it("answers a browser GET with usage, and an SSE GET with 405", async () => {
+    const usage = await handler.fetch(new Request(URL));
+    expect(usage.status).toBe(200);
+    expect(((await usage.json()) as { transport: string }).transport).toBe("streamable-http");
+
+    const stream = await handler.fetch(
+      new Request(URL, { headers: { Accept: "text/event-stream" } }),
+    );
+    expect(stream.status).toBe(405);
+    expect(stream.headers.get("Allow")).toBe("POST");
+  });
+
+  it("never lets a shared cache hold a response", async () => {
+    const res = await rpc({ jsonrpc: "2.0", id: 3, method: "tools/list" });
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -4,5 +4,9 @@
     "rootDir": ".",
     "noEmit": true
   },
-  "include": ["api/**/*.ts", "packages/modelparams/src/**/*.ts"]
+  "include": [
+    "api/**/*.ts",
+    "packages/modelparams/src/**/*.ts",
+    "packages/modelparams-mcp/src/**/*.ts"
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,7 @@
   "framework": null,
   "cleanUrls": true,
   "trailingSlash": false,
+  "rewrites": [{ "source": "/mcp", "destination": "/api/mcp" }],
   "headers": [
     {
       "source": "/api/(.*)",
@@ -17,6 +18,17 @@
     {
       "source": "/api/v1/(.*)",
       "headers": [{ "key": "X-Robots-Tag", "value": "noindex" }]
+    },
+    {
+      "source": "/api/mcp",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" },
+        { "key": "Access-Control-Allow-Methods", "value": "POST, GET, OPTIONS" },
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "Content-Type, Accept, Mcp-Protocol-Version, Mcp-Session-Id"
+        }
+      ]
     },
     {
       "source": "/api/v1/validate",


### PR DESCRIPTION
## Why

The catalog changes several times a day. `modelparams-mcp` answers from an exact `modelparams` pin fixed at publish time, so a model merged today reaches those users only when they upgrade — and every catalog change has to drag an npm release of the MCP server behind it. That lockstep is what makes the release train a three-package affair.

A hosted endpoint has neither problem. It rebuilds with the site on every merge to `main`, so it answers from the catalog the site is serving, and it needs no publish at all.

```bash
claude mcp add --transport http modelparams https://modelparams.dev/mcp
codex mcp add modelparams --url https://modelparams.dev/mcp
```

## What

`api/mcp.ts` — the same four tools, built by the same `createServer()` factory. Only the transport differs.

Stateless by design: no session ids, no server-initiated streams, one server instance per request. Every tool is a read-only request/response, so nothing needs to survive between calls and any request may land on any serverless instance. A `GET` with `Accept: text/event-stream` gets a `405` with `Allow: POST`; a plain `GET` gets the usage document, matching how `/api/v1/validate` treats browsers.

The SDK's own HTTP transport wants Node's `req`/`res`, which a Vercel fetch handler never sees, so the endpoint carries one JSON-RPC message into the server through a small `Transport` implementation and returns the reply as JSON.

## Two supporting changes

**`createServer()` takes the version as an argument** instead of reading `../package.json` through `createRequire`. A relative manifest read does not survive Vercel's function bundling, and the two transports report different versions anyway — the endpoint reports the deployment sha, which is where its catalog actually came from. The stdio entry point still reads the manifest and passes it in, so the published package reports its release version exactly as before.

**`packages/modelparams` gains a `prepare` script.** The endpoint reaches the catalog through the bare `modelparams` specifier the MCP sources already use, which resolves to the workspace's `dist`. Building it on install (~2s) means the function bundle finds it on Vercel the same way it does locally.

## Verification

- `tests/mcp-endpoint.test.ts` — 10 cases over the handler: handshake, `tools/list`, two real catalog answers, notification → `202`, batch rejected, malformed body, browser `GET` vs SSE `GET`, `no-store` and CORS headers.
- `tests/mcp-endpoint-protocol.test.ts` — the **real SDK client over real HTTP**, not hand-written JSON-RPC: it connects, completes the handshake, lists the tools and calls one. That is exactly what Claude Code and Codex do, so protocol mistakes fail here rather than in a user's client.
- Full suite: 224 passing. Lint, typecheck and site build clean.

## What this does not change

The npm package keeps working, unchanged in behaviour, for offline use and for clients that speak stdio only. Both READMEs and the `/api` page now point at the hosted endpoint first and describe the stdio package as the offline path.

Follow-up worth considering separately: if the hosted endpoint carries the traffic, the stdio package no longer needs an exact pin, and the release train drops back to two packages.