### PR TITLE
fix: take the unpublishable MCP package out of the release path

### DIFF
--- a/.github/workflows/release-modelparams.yml
+++ b/.github/workflows/release-modelparams.yml
@@ -1,7 +1,6 @@
 name: Release modelparams
 
-# Publishes the `modelparams` and `modelparams-mcp` npm packages when a release
-# lands on main (lockstep — see the MCP steps below).
+# Publishes the `modelparams` npm package when a release lands on main.
 #
 # Releases are batched: `release-prepare.yml` accumulates every catalog change
 # since the last tag into one `chore: release …` PR that bumps
@@ -136,34 +135,17 @@ jobs:
       - name: Publish to npm
         run: npm publish --workspace=modelparams --provenance --access public
 
-      # modelparams-mcp ships in LOCKSTEP: release-prepare bumps it to the same
-      # version and rewrites its exact `modelparams` dependency pin, so "which
-      # catalog does modelparams-mcp@x.y.z carry?" has one answer. It needs its
-      # OWN npm trusted publisher bound to THIS workflow file (npmjs.com →
-      # Settings → Trusted Publishers → GitHub Actions → org=mnfst,
-      # repo=modelparams.dev, workflow=release-modelparams.yml).
-      - name: Build MCP server
-        run: npm run build --workspace=modelparams-mcp
-
-      - name: MCP server tests
-        run: npm test --workspace=modelparams-mcp
-
-      - name: Wait for modelparams on the registry
-        env:
-          VERSION: ${{ needs.detect.outputs.version }}
-        run: |
-          # The MCP package's exact pin must resolve for consumers the moment
-          # it publishes; registry propagation can lag the publish call.
-          for i in $(seq 1 30); do
-            npm view "modelparams@${VERSION}" version >/dev/null 2>&1 && exit 0
-            sleep 10
-          done
-          echo "::error::modelparams@${VERSION} never appeared on the registry"
-          exit 1
-
-      - name: Publish MCP server to npm
-        run: npm publish --workspace=modelparams-mcp --provenance --access public
-
+      # modelparams-mcp is NOT published here. The package has never existed on
+      # npm, and npm cannot bootstrap a trusted publisher for a name that does
+      # not exist yet — the first publish has to come from a logged-in account
+      # (npm/cli#8544). Every attempt therefore failed with a misleading 404,
+      # and because the publish step ran before the tagging steps below, each
+      # failure also cost `modelparams` its release tag, which the version
+      # classifier reads as the baseline for the next release. Agents reach the
+      # same four tools at https://modelparams.dev/mcp, which ships with the
+      # site. To restore this: publish the package once by hand, configure its
+      # trusted publisher against THIS workflow file, then re-add the publish
+      # step AFTER the tag steps.
       - name: Create GitHub release + tag
         uses: softprops/action-gh-release@v2
         with:
@@ -172,11 +154,3 @@ jobs:
           target_commitish: ${{ github.sha }}
           body: ${{ steps.notes.outputs.body }}
           generate_release_notes: true
-
-      - name: Tag modelparams-mcp release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: "modelparams-mcp@${{ needs.detect.outputs.version }}"
-          name: "modelparams-mcp@${{ needs.detect.outputs.version }}"
-          target_commitish: ${{ github.sha }}
-          body: "Ships the modelparams@${{ needs.detect.outputs.version }} catalog over MCP (stdio). `npx -y modelparams-mcp`"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -132,8 +132,6 @@ jobs:
           git add package-lock.json \
                   packages/modelparams/package.json \
                   packages/modelparams/CHANGELOG.md \
-                  packages/modelparams-mcp/package.json \
-                  packages/modelparams-mcp/CHANGELOG.md \
                   packages/modelparams-python/pyproject.toml \
                   packages/modelparams-python/uv.lock \
                   packages/modelparams-python/CHANGELOG.md

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -26,7 +26,7 @@ import { bumpUvLockVersion } from "./lib/uv-lock.js";
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 interface PackageSpec {
-  key: "npm" | "python" | "mcp";
+  key: "npm" | "python";
   name: string;
   tagPrefix: string;
   /** Version-classifier CLI; emits `next=<version>` (empty when nothing to release). */
@@ -37,13 +37,6 @@ interface PackageSpec {
   writeVersion(source: string, next: string): string;
   /** Extra files that also record the version and must move with it. */
   syncFiles?: { file: string; write(source: string, next: string): string }[];
-  /**
-   * Ship at the same version as another package instead of running an own
-   * classifier. modelparams-mcp answers from the catalog compiled into its
-   * exact-pinned `modelparams` dependency, so "which catalog does version
-   * x.y.z carry?" must have one answer.
-   */
-  lockstepWith?: "npm";
 }
 
 const PACKAGES: PackageSpec[] = [
@@ -65,30 +58,6 @@ const PACKAGES: PackageSpec[] = [
       {
         file: "package-lock.json",
         write: (source, next) => bumpPackageLockVersion(source, next, "modelparams"),
-      },
-    ],
-  },
-  {
-    key: "mcp",
-    name: "modelparams-mcp (npm)",
-    tagPrefix: "modelparams-mcp@",
-    computeScript: "", // lockstepWith drives the version
-    manifestFile: "packages/modelparams-mcp/package.json",
-    changelogFile: "packages/modelparams-mcp/CHANGELOG.md",
-    lockstepWith: "npm",
-    readVersion: (source) => (JSON.parse(source) as { version: string }).version,
-    writeVersion: (source, next) =>
-      source
-        .replace(/("version"\s*:\s*")\d+\.\d+\.\d+(")/, `$1${next}$2`)
-        // The exact dependency pin moves with the version (see lockstepWith).
-        .replace(/("modelparams"\s*:\s*")[^"]+(")/, `$1${next}$2`),
-    syncFiles: [
-      // Both the workspace version and the exact `modelparams` pin are
-      // mirrored in the lockfile, and `npm ci` checks both.
-      {
-        file: "package-lock.json",
-        write: (source, next) =>
-          bumpPackageLockVersion(source, next, "modelparams-mcp", ["modelparams"]),
       },
     ],
   },
@@ -138,21 +107,12 @@ function latestTag(prefix: string): string | null {
   return versions[0] === undefined ? null : `${prefix}${versions[0]}`;
 }
 
-/** Has the MCP server's own source moved since its last published tag? */
-function mcpSourceChanged(): boolean {
-  const tag = latestTag("modelparams-mcp@");
-  if (!tag || !refExists(tag)) return true; // never published -> needs a first release
-  return (
-    git(["diff", "--name-only", `${tag}..HEAD`, "--", "packages/modelparams-mcp"]).trim() !== ""
-  );
-}
-
 /** Run a version classifier and read the `next=` line it emits. */
-function computeNext(spec: PackageSpec, forceLevel?: string): string {
+function computeNext(spec: PackageSpec): string {
   const stdout = execFileSync("npx", ["tsx", spec.computeScript], {
     cwd: REPO_ROOT,
     encoding: "utf8",
-    env: { ...process.env, FORCE_LEVEL: forceLevel ?? process.env.FORCE_LEVEL ?? "" },
+    env: { ...process.env, FORCE_LEVEL: process.env.FORCE_LEVEL ?? "" },
     stdio: ["ignore", "pipe", "inherit"],
   });
   const line = stdout
@@ -188,15 +148,8 @@ async function main(): Promise<void> {
 
   const prepared: Prepared[] = [];
 
-  // The catalog classifier only sees model changes. An MCP-only change is
-  // still real work that needs shipping, so it forces at least a patch on the
-  // npm pair (never on the Python package).
-  const mcpForce = mcpSourceChanged() ? "patch" : undefined;
-
   for (const spec of PACKAGES) {
-    const next = spec.lockstepWith
-      ? (prepared.find((p) => p.spec.key === spec.lockstepWith)?.next ?? "")
-      : computeNext(spec, spec.key === "npm" ? mcpForce : undefined);
+    const next = computeNext(spec);
     if (next === "") {
       console.error(`${spec.name}: nothing to release.`);
       continue;


### PR DESCRIPTION
Two failures, one cause, both visible in today's releases.

## 1. The publish could never succeed, and it took the tags with it

`modelparams-mcp` has never existed on npm. npm cannot bootstrap a trusted publisher for a name that does not exist yet, so the first publish has to come from a logged-in account ([npm/cli#8544](https://github.com/npm/cli/issues/8544)). Every release attempted it and got:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/modelparams-mcp
```

That step ran **before** the tagging steps. So each failure also cost `modelparams` its release tag: `0.0.55` and `0.0.56` both published to npm untagged, and I recreated both tags by hand today.

## 2. The missing tag then forced empty releases

`mcpSourceChanged()` returns `true` whenever the MCP tag is absent — "never published → needs a first release". That forced a patch bump on the catalog package. The tag can never appear, so the force was permanent.

Demonstrated on current `main`, with no catalog change since 0.0.56:

```
$ npx tsx scripts/prepare-release.ts
modelparams (npm): 0.0.56 -> 0.0.57 (last published: modelparams@0.0.56).
modelparams-mcp (npm): 0.0.56 -> 0.0.57 (last published: none).
has_changes=true
```

The same run on this branch:

```
modelparams (npm): nothing to release.
modelparams (PyPI): nothing to release.
has_changes=false
```

That is a loop of empty catalog versions, each one a real npm publish, for a package nobody can install.

## The change

- `release-modelparams.yml` — drops the MCP build, tests, registry wait, publish, and tag steps. The comment in their place records why, and what to do to bring them back.
- `prepare-release.ts` — drops the MCP package spec, the `lockstepWith` mechanism it was the only user of, and `mcpSourceChanged()`.
- `release-prepare.yml` — stops staging the two MCP files nothing writes any more.

Net: 90 lines removed, 16 added.

## What stays

The server source, its tests, and the stdio smoke test in CI. `api/mcp.ts` imports its `createServer()`, so the code is live — it is served over HTTP at https://modelparams.dev/mcp, which is where agents now reach the same four tools.

## To restore publishing

1. Publish the package once by hand from a logged-in npm account.
2. Configure its trusted publisher against `release-modelparams.yml`.
3. Re-add the publish step **after** the tag steps, so a failure there cannot cost the catalog its tag again.

## Verification

Ran `prepare-release.ts` end to end on both branches, output above. 224 tests, lint and typecheck clean.