### PR TITLE
fix: unpin modelparams in the unpublished MCP package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8013,7 +8013,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "modelparams": "0.0.56",
+        "modelparams": "*",
         "zod": "^3.25.0"
       },
       "bin": {

--- a/packages/modelparams-mcp/README.md
+++ b/packages/modelparams-mcp/README.md
@@ -109,7 +109,7 @@ One entry documents one wire format, so `validate_model_params` answers for the 
 
 The catalog is compiled in at publish time from the YAML source of truth at [github.com/mnfst/modelparams.dev](https://github.com/mnfst/modelparams.dev/tree/main/models). No runtime fetch, no cache to invalidate — update the package to get new models.
 
-The hosted endpoint is rebuilt with the site on every catalog change, so it always answers from the current catalog. A local build of this package pins an exact [`modelparams`](https://www.npmjs.com/package/modelparams) dependency instead, and answers from whichever catalog version that pin resolves.
+The hosted endpoint is rebuilt with the site on every catalog change, so it always answers from the current catalog. A local build of this package takes [`modelparams`](https://www.npmjs.com/package/modelparams) straight from this workspace — the dependency is deliberately unpinned, because the package is not published and an exact pin only froze it at a version the workspace had already moved past.
 
 ## License
 

--- a/packages/modelparams-mcp/package.json
+++ b/packages/modelparams-mcp/package.json
@@ -54,6 +54,6 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
     "zod": "^3.25.0",
-    "modelparams": "0.0.56"
+    "modelparams": "*"
   }
 }

--- a/tests/release-lockfiles.test.ts
+++ b/tests/release-lockfiles.test.ts
@@ -20,11 +20,27 @@ describe("bumpPackageLockVersion", () => {
     expect(split(updated, "modelparams").entry).toContain('"version": "9.9.9"');
   });
 
-  it("moves the exact sibling pin the MCP package ships in lockstep", () => {
-    const updated = bumpPackageLockVersion(lock, "9.9.9", "modelparams-mcp", ["modelparams"]);
-    const { entry } = split(updated, "modelparams-mcp");
-    expect(entry).toContain('"version": "9.9.9"');
-    expect(entry).toContain('"modelparams": "9.9.9"');
+  // No workspace pins a sibling exactly today — modelparams-mcp did until it
+  // stopped being published — so this exercises the repinning against a
+  // fixture. Keep it: the day another package pins a sibling, a release that
+  // moves one and not the other breaks `npm ci` for every job on the PR.
+  it("moves an exact sibling pin alongside the version", () => {
+    const fixture = [
+      "{",
+      '  "packages": {',
+      '    "packages/pinning-workspace": {',
+      '      "version": "0.0.1",',
+      '      "dependencies": {',
+      '        "modelparams": "0.0.1"',
+      "      }",
+      "    }",
+      "  }",
+      "}",
+    ].join("\n");
+
+    const updated = bumpPackageLockVersion(fixture, "9.9.9", "pinning-workspace", ["modelparams"]);
+    expect(updated).toContain('"version": "9.9.9"');
+    expect(updated).toContain('"modelparams": "9.9.9"');
   });
 
   it("leaves every other entry untouched", () => {
@@ -36,8 +52,8 @@ describe("bumpPackageLockVersion", () => {
   });
 
   it("is idempotent, so a re-prepared release branch converges", () => {
-    const once = bumpPackageLockVersion(lock, "9.9.9", "modelparams-mcp", ["modelparams"]);
-    expect(bumpPackageLockVersion(once, "9.9.9", "modelparams-mcp", ["modelparams"])).toBe(once);
+    const once = bumpPackageLockVersion(lock, "9.9.9", "modelparams");
+    expect(bumpPackageLockVersion(once, "9.9.9", "modelparams")).toBe(once);
   });
 
   it("fails loudly rather than silently skipping an unknown workspace", () => {


### PR DESCRIPTION
### ✨ What changed
- `packages/modelparams-mcp` now depends on `modelparams: "*"` instead of an exact version, in both its package.json and the lockfile
- README corrected to match

### 💭 Why
Every check on release PR #313 fails with `npm ci` refusing the install:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: modelparams@0.0.56 from lock file
```

The exact pin existed to keep the two published packages in lockstep. #311 stopped publishing `modelparams-mcp`, so nothing bumps that pin any more — `prepare-release` only rewrites the `modelparams` workspace. The pin froze at 0.0.56 while the workspace moved to 0.0.57, and since the release commit is what changes the version, **every future release PR would have failed the same way**, including the required param guard, so nothing could ever publish again.

Unpinning is the fix rather than teaching the release script to bump a package it no longer ships: the package is built only from this checkout, so it should track whatever the workspace holds.

### 📝 Notes
Reproduced and verified locally: with the pin at 0.0.56, simulating the release bump (`modelparams` → 0.0.57 in package.json + lockfile, exactly what prepare-release writes) makes `npm ci` fail with the error above; with the pin unpinned, the same simulated bump installs cleanly. Catalog validates and the full test suite passes.
Once this lands, the release-prepare workflow regenerates `chore/release` from main and #313 should go green.