### PR TITLE
feat: import model lifecycle metadata

### DIFF
--- a/models/anthropic/claude-3-5-haiku-20241022.yaml
+++ b/models/anthropic/claude-3-5-haiku-20241022.yaml
@@ -2,6 +2,9 @@
 provider: anthropic
 authType: api_key
 model: claude-3-5-haiku-20241022
+status: retired
+replacement: anthropic/claude-haiku-4-5-20251001
+shutdownOn: 2026-02-19
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-3-5-haiku-latest.yaml
+++ b/models/anthropic/claude-3-5-haiku-latest.yaml
@@ -2,6 +2,9 @@
 provider: anthropic
 authType: api_key
 model: claude-3-5-haiku-latest
+status: retired
+replacement: anthropic/claude-haiku-4-5-20251001
+shutdownOn: 2026-02-19
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-3-5-sonnet-20241022.yaml
+++ b/models/anthropic/claude-3-5-sonnet-20241022.yaml
@@ -2,6 +2,9 @@
 provider: anthropic
 authType: api_key
 model: claude-3-5-sonnet-20241022
+status: retired
+replacement: anthropic/claude-sonnet-4-6
+shutdownOn: 2025-10-28
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-3-5-sonnet-latest.yaml
+++ b/models/anthropic/claude-3-5-sonnet-latest.yaml
@@ -2,6 +2,9 @@
 provider: anthropic
 authType: api_key
 model: claude-3-5-sonnet-latest
+status: retired
+replacement: anthropic/claude-sonnet-4-6
+shutdownOn: 2025-10-28
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-3-7-sonnet-20250219.yaml
+++ b/models/anthropic/claude-3-7-sonnet-20250219.yaml
@@ -2,6 +2,9 @@
 provider: anthropic
 authType: api_key
 model: claude-3-7-sonnet-20250219
+status: retired
+replacement: anthropic/claude-sonnet-4-6
+shutdownOn: 2026-02-19
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-3-7-sonnet-latest.yaml
+++ b/models/anthropic/claude-3-7-sonnet-latest.yaml
@@ -2,6 +2,9 @@
 provider: anthropic
 authType: api_key
 model: claude-3-7-sonnet-latest
+status: retired
+replacement: anthropic/claude-sonnet-4-6
+shutdownOn: 2026-02-19
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-3-opus-20240229.yaml
+++ b/models/anthropic/claude-3-opus-20240229.yaml
@@ -2,6 +2,9 @@
 provider: anthropic
 authType: api_key
 model: claude-3-opus-20240229
+status: retired
+replacement: anthropic/claude-opus-4-8
+shutdownOn: 2026-01-05
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-fable-5-subscription.yaml
+++ b/models/anthropic/claude-fable-5-subscription.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: subscription
 model: claude-fable-5
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-fable-5.yaml
+++ b/models/anthropic/claude-fable-5.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: api_key
 model: claude-fable-5
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-haiku-4-5-20251001-subscription.yaml
+++ b/models/anthropic/claude-haiku-4-5-20251001-subscription.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: subscription
 model: claude-haiku-4-5-20251001
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-haiku-4-5-20251001.yaml
+++ b/models/anthropic/claude-haiku-4-5-20251001.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: api_key
 model: claude-haiku-4-5-20251001
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-haiku-4-5-subscription.yaml
+++ b/models/anthropic/claude-haiku-4-5-subscription.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: subscription
 model: claude-haiku-4-5
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-haiku-4-5.yaml
+++ b/models/anthropic/claude-haiku-4-5.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: api_key
 model: claude-haiku-4-5
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-4-1-20250805-subscription.yaml
+++ b/models/anthropic/claude-opus-4-1-20250805-subscription.yaml
@@ -2,6 +2,9 @@
 provider: anthropic
 authType: subscription
 model: claude-opus-4-1-20250805
+status: retired
+replacement: anthropic/claude-opus-4-8
+shutdownOn: 2026-08-05
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-4-1-20250805.yaml
+++ b/models/anthropic/claude-opus-4-1-20250805.yaml
@@ -2,6 +2,9 @@
 provider: anthropic
 authType: api_key
 model: claude-opus-4-1-20250805
+status: retired
+replacement: anthropic/claude-opus-4-8
+shutdownOn: 2026-08-05
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-4-20250514-subscription.yaml
+++ b/models/anthropic/claude-opus-4-20250514-subscription.yaml
@@ -2,6 +2,9 @@
 provider: anthropic
 authType: subscription
 model: claude-opus-4-20250514
+status: retired
+replacement: anthropic/claude-opus-4-8
+shutdownOn: 2026-06-15
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-4-20250514.yaml
+++ b/models/anthropic/claude-opus-4-20250514.yaml
@@ -2,6 +2,9 @@
 provider: anthropic
 authType: api_key
 model: claude-opus-4-20250514
+status: retired
+replacement: anthropic/claude-opus-4-8
+shutdownOn: 2026-06-15
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-4-5-20251101-subscription.yaml
+++ b/models/anthropic/claude-opus-4-5-20251101-subscription.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: subscription
 model: claude-opus-4-5-20251101
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-4-5-20251101.yaml
+++ b/models/anthropic/claude-opus-4-5-20251101.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: api_key
 model: claude-opus-4-5-20251101
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-4-6-subscription.yaml
+++ b/models/anthropic/claude-opus-4-6-subscription.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: subscription
 model: claude-opus-4-6
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-4-6.yaml
+++ b/models/anthropic/claude-opus-4-6.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: api_key
 model: claude-opus-4-6
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-4-7-subscription.yaml
+++ b/models/anthropic/claude-opus-4-7-subscription.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: subscription
 model: claude-opus-4-7
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-4-7.yaml
+++ b/models/anthropic/claude-opus-4-7.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: api_key
 model: claude-opus-4-7
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-4-8-subscription.yaml
+++ b/models/anthropic/claude-opus-4-8-subscription.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: subscription
 model: claude-opus-4-8
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-4-8.yaml
+++ b/models/anthropic/claude-opus-4-8.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: api_key
 model: claude-opus-4-8
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-5-subscription.yaml
+++ b/models/anthropic/claude-opus-5-subscription.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: subscription
 model: claude-opus-5
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-opus-5.yaml
+++ b/models/anthropic/claude-opus-5.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: api_key
 model: claude-opus-5
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-sonnet-4-20250514-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-20250514-subscription.yaml
@@ -2,6 +2,9 @@
 provider: anthropic
 authType: subscription
 model: claude-sonnet-4-20250514
+status: retired
+replacement: anthropic/claude-sonnet-4-6
+shutdownOn: 2026-06-15
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-sonnet-4-20250514.yaml
+++ b/models/anthropic/claude-sonnet-4-20250514.yaml
@@ -2,6 +2,9 @@
 provider: anthropic
 authType: api_key
 model: claude-sonnet-4-20250514
+status: retired
+replacement: anthropic/claude-sonnet-4-6
+shutdownOn: 2026-06-15
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-sonnet-4-5-20250929-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-5-20250929-subscription.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: subscription
 model: claude-sonnet-4-5-20250929
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-sonnet-4-5-20250929.yaml
+++ b/models/anthropic/claude-sonnet-4-5-20250929.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: api_key
 model: claude-sonnet-4-5-20250929
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-sonnet-4-5-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-5-subscription.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: subscription
 model: claude-sonnet-4-5
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-sonnet-4-5.yaml
+++ b/models/anthropic/claude-sonnet-4-5.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: api_key
 model: claude-sonnet-4-5
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-sonnet-4-6-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-6-subscription.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: subscription
 model: claude-sonnet-4-6
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-sonnet-4-6.yaml
+++ b/models/anthropic/claude-sonnet-4-6.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: api_key
 model: claude-sonnet-4-6
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-sonnet-5-subscription.yaml
+++ b/models/anthropic/claude-sonnet-5-subscription.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: subscription
 model: claude-sonnet-5
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/anthropic/claude-sonnet-5.yaml
+++ b/models/anthropic/claude-sonnet-5.yaml
@@ -2,6 +2,7 @@
 provider: anthropic
 authType: api_key
 model: claude-sonnet-5
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/cohere/command-a-03-2025.yaml
+++ b/models/cohere/command-a-03-2025.yaml
@@ -2,6 +2,7 @@
 provider: cohere
 authType: api_key
 model: command-a-03-2025
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/cohere/command-a-plus-05-2026.yaml
+++ b/models/cohere/command-a-plus-05-2026.yaml
@@ -2,6 +2,7 @@
 provider: cohere
 authType: api_key
 model: command-a-plus-05-2026
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/cohere/command-a-reasoning-08-2025.yaml
+++ b/models/cohere/command-a-reasoning-08-2025.yaml
@@ -2,6 +2,7 @@
 provider: cohere
 authType: api_key
 model: command-a-reasoning-08-2025
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/cohere/command-a-translate-08-2025.yaml
+++ b/models/cohere/command-a-translate-08-2025.yaml
@@ -2,6 +2,7 @@
 provider: cohere
 authType: api_key
 model: command-a-translate-08-2025
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/cohere/command-a-vision-07-2025.yaml
+++ b/models/cohere/command-a-vision-07-2025.yaml
@@ -2,6 +2,7 @@
 provider: cohere
 authType: api_key
 model: command-a-vision-07-2025
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/cohere/command-r-08-2024.yaml
+++ b/models/cohere/command-r-08-2024.yaml
@@ -2,6 +2,7 @@
 provider: cohere
 authType: api_key
 model: command-r-08-2024
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/cohere/command-r-plus-08-2024.yaml
+++ b/models/cohere/command-r-plus-08-2024.yaml
@@ -2,6 +2,7 @@
 provider: cohere
 authType: api_key
 model: command-r-plus-08-2024
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/cohere/command-r7b-12-2024.yaml
+++ b/models/cohere/command-r7b-12-2024.yaml
@@ -2,6 +2,7 @@
 provider: cohere
 authType: api_key
 model: command-r7b-12-2024
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/deepseek/deepseek-chat.yaml
+++ b/models/deepseek/deepseek-chat.yaml
@@ -2,6 +2,9 @@
 provider: deepseek
 authType: api_key
 model: deepseek-chat
+status: retired
+replacement: deepseek/deepseek-v4-flash
+shutdownOn: 2026-07-24
 params:
   - path: max_tokens
     type: integer

--- a/models/deepseek/deepseek-reasoner.yaml
+++ b/models/deepseek/deepseek-reasoner.yaml
@@ -2,6 +2,9 @@
 provider: deepseek
 authType: api_key
 model: deepseek-reasoner
+status: retired
+replacement: deepseek/deepseek-v4-flash
+shutdownOn: 2026-07-24
 params:
   - path: max_tokens
     type: integer

--- a/models/deepseek/deepseek-v4-flash.yaml
+++ b/models/deepseek/deepseek-v4-flash.yaml
@@ -2,6 +2,7 @@
 provider: deepseek
 authType: api_key
 model: deepseek-v4-flash
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/deepseek/deepseek-v4-pro.yaml
+++ b/models/deepseek/deepseek-v4-pro.yaml
@@ -2,6 +2,7 @@
 provider: deepseek
 authType: api_key
 model: deepseek-v4-pro
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/google/gemini-2.5-flash-lite-subscription.yaml
+++ b/models/google/gemini-2.5-flash-lite-subscription.yaml
@@ -3,7 +3,6 @@ provider: google
 authType: subscription
 model: gemini-2.5-flash-lite
 status: active
-replacement: google/gemini-3.1-flash-lite
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-flash-lite-subscription.yaml
+++ b/models/google/gemini-2.5-flash-lite-subscription.yaml
@@ -2,6 +2,8 @@
 provider: google
 authType: subscription
 model: gemini-2.5-flash-lite
+status: active
+replacement: google/gemini-3.1-flash-lite
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-flash-lite.yaml
+++ b/models/google/gemini-2.5-flash-lite.yaml
@@ -3,7 +3,6 @@ provider: google
 authType: api_key
 model: gemini-2.5-flash-lite
 status: active
-replacement: google/gemini-3.1-flash-lite
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-flash-lite.yaml
+++ b/models/google/gemini-2.5-flash-lite.yaml
@@ -2,6 +2,8 @@
 provider: google
 authType: api_key
 model: gemini-2.5-flash-lite
+status: active
+replacement: google/gemini-3.1-flash-lite
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-flash-subscription.yaml
+++ b/models/google/gemini-2.5-flash-subscription.yaml
@@ -2,6 +2,8 @@
 provider: google
 authType: subscription
 model: gemini-2.5-flash
+status: active
+replacement: google/gemini-3.6-flash
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-flash-subscription.yaml
+++ b/models/google/gemini-2.5-flash-subscription.yaml
@@ -3,7 +3,6 @@ provider: google
 authType: subscription
 model: gemini-2.5-flash
 status: active
-replacement: google/gemini-3.6-flash
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-flash.yaml
+++ b/models/google/gemini-2.5-flash.yaml
@@ -3,7 +3,6 @@ provider: google
 authType: api_key
 model: gemini-2.5-flash
 status: active
-replacement: google/gemini-3.6-flash
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-flash.yaml
+++ b/models/google/gemini-2.5-flash.yaml
@@ -2,6 +2,8 @@
 provider: google
 authType: api_key
 model: gemini-2.5-flash
+status: active
+replacement: google/gemini-3.6-flash
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-pro-subscription.yaml
+++ b/models/google/gemini-2.5-pro-subscription.yaml
@@ -2,6 +2,8 @@
 provider: google
 authType: subscription
 model: gemini-2.5-pro
+status: active
+replacement: google/gemini-3.1-pro-preview
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-pro-subscription.yaml
+++ b/models/google/gemini-2.5-pro-subscription.yaml
@@ -3,7 +3,6 @@ provider: google
 authType: subscription
 model: gemini-2.5-pro
 status: active
-replacement: google/gemini-3.1-pro-preview
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-pro.yaml
+++ b/models/google/gemini-2.5-pro.yaml
@@ -3,7 +3,6 @@ provider: google
 authType: api_key
 model: gemini-2.5-pro
 status: active
-replacement: google/gemini-3.1-pro-preview
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-pro.yaml
+++ b/models/google/gemini-2.5-pro.yaml
@@ -2,6 +2,8 @@
 provider: google
 authType: api_key
 model: gemini-2.5-pro
+status: active
+replacement: google/gemini-3.1-pro-preview
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-3-flash-preview-subscription.yaml
+++ b/models/google/gemini-3-flash-preview-subscription.yaml
@@ -2,6 +2,8 @@
 provider: google
 authType: subscription
 model: gemini-3-flash-preview
+status: active
+replacement: google/gemini-3.6-flash
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-3-flash-preview.yaml
+++ b/models/google/gemini-3-flash-preview.yaml
@@ -2,6 +2,8 @@
 provider: google
 authType: api_key
 model: gemini-3-flash-preview
+status: active
+replacement: google/gemini-3.6-flash
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-3.1-flash-lite-preview-subscription.yaml
+++ b/models/google/gemini-3.1-flash-lite-preview-subscription.yaml
@@ -2,6 +2,9 @@
 provider: google
 authType: subscription
 model: gemini-3.1-flash-lite-preview
+status: retired
+replacement: google/gemini-3.1-flash-lite
+shutdownOn: 2026-05-25
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-3.1-flash-lite-preview.yaml
+++ b/models/google/gemini-3.1-flash-lite-preview.yaml
@@ -2,6 +2,9 @@
 provider: google
 authType: api_key
 model: gemini-3.1-flash-lite-preview
+status: retired
+replacement: google/gemini-3.1-flash-lite
+shutdownOn: 2026-05-25
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-3.1-flash-lite-subscription.yaml
+++ b/models/google/gemini-3.1-flash-lite-subscription.yaml
@@ -2,6 +2,8 @@
 provider: google
 authType: subscription
 model: gemini-3.1-flash-lite
+status: active
+replacement: google/gemini-3.5-flash-lite
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-3.1-flash-lite.yaml
+++ b/models/google/gemini-3.1-flash-lite.yaml
@@ -2,6 +2,8 @@
 provider: google
 authType: api_key
 model: gemini-3.1-flash-lite
+status: active
+replacement: google/gemini-3.5-flash-lite
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-3.1-pro-preview-subscription.yaml
+++ b/models/google/gemini-3.1-pro-preview-subscription.yaml
@@ -2,6 +2,7 @@
 provider: google
 authType: subscription
 model: gemini-3.1-pro-preview
+status: active
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-3.1-pro-preview.yaml
+++ b/models/google/gemini-3.1-pro-preview.yaml
@@ -2,6 +2,7 @@
 provider: google
 authType: api_key
 model: gemini-3.1-pro-preview
+status: active
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-3.5-flash-lite.yaml
+++ b/models/google/gemini-3.5-flash-lite.yaml
@@ -2,6 +2,7 @@
 provider: google
 authType: api_key
 model: gemini-3.5-flash-lite
+status: active
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-3.5-flash.yaml
+++ b/models/google/gemini-3.5-flash.yaml
@@ -2,6 +2,7 @@
 provider: google
 authType: api_key
 model: gemini-3.5-flash
+status: active
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-3.6-flash.yaml
+++ b/models/google/gemini-3.6-flash.yaml
@@ -2,6 +2,7 @@
 provider: google
 authType: api_key
 model: gemini-3.6-flash
+status: active
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/minimax/MiniMax-M2-subscription.yaml
+++ b/models/minimax/MiniMax-M2-subscription.yaml
@@ -2,6 +2,7 @@
 provider: minimax
 authType: subscription
 model: MiniMax-M2
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/minimax/MiniMax-M2.1-highspeed-subscription.yaml
+++ b/models/minimax/MiniMax-M2.1-highspeed-subscription.yaml
@@ -2,6 +2,7 @@
 provider: minimax
 authType: subscription
 model: MiniMax-M2.1-highspeed
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/minimax/MiniMax-M2.1-subscription.yaml
+++ b/models/minimax/MiniMax-M2.1-subscription.yaml
@@ -2,6 +2,7 @@
 provider: minimax
 authType: subscription
 model: MiniMax-M2.1
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/minimax/MiniMax-M2.5-highspeed-subscription.yaml
+++ b/models/minimax/MiniMax-M2.5-highspeed-subscription.yaml
@@ -2,6 +2,7 @@
 provider: minimax
 authType: subscription
 model: MiniMax-M2.5-highspeed
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/minimax/MiniMax-M2.5-subscription.yaml
+++ b/models/minimax/MiniMax-M2.5-subscription.yaml
@@ -2,6 +2,7 @@
 provider: minimax
 authType: subscription
 model: MiniMax-M2.5
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/minimax/MiniMax-M2.7-highspeed-subscription.yaml
+++ b/models/minimax/MiniMax-M2.7-highspeed-subscription.yaml
@@ -2,6 +2,7 @@
 provider: minimax
 authType: subscription
 model: MiniMax-M2.7-highspeed
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/minimax/MiniMax-M2.7-subscription.yaml
+++ b/models/minimax/MiniMax-M2.7-subscription.yaml
@@ -2,6 +2,7 @@
 provider: minimax
 authType: subscription
 model: MiniMax-M2.7
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/minimax/MiniMax-M3-subscription.yaml
+++ b/models/minimax/MiniMax-M3-subscription.yaml
@@ -2,6 +2,7 @@
 provider: minimax
 authType: subscription
 model: MiniMax-M3
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/mistral/devstral-2512.yaml
+++ b/models/mistral/devstral-2512.yaml
@@ -2,8 +2,7 @@
 provider: mistral
 authType: api_key
 model: devstral-2512
-status: retired
-shutdownOn: 2026-07-31
+status: deprecated
 params:
   - path: max_tokens
     type: integer

--- a/models/mistral/devstral-2512.yaml
+++ b/models/mistral/devstral-2512.yaml
@@ -2,6 +2,8 @@
 provider: mistral
 authType: api_key
 model: devstral-2512
+status: retired
+shutdownOn: 2026-07-31
 params:
   - path: max_tokens
     type: integer

--- a/models/mistral/open-mistral-nemo.yaml
+++ b/models/mistral/open-mistral-nemo.yaml
@@ -2,8 +2,7 @@
 provider: mistral
 authType: api_key
 model: open-mistral-nemo
-status: retired
-shutdownOn: 2026-07-31
+status: deprecated
 params:
   - path: max_tokens
     type: integer

--- a/models/mistral/open-mistral-nemo.yaml
+++ b/models/mistral/open-mistral-nemo.yaml
@@ -2,6 +2,8 @@
 provider: mistral
 authType: api_key
 model: open-mistral-nemo
+status: retired
+shutdownOn: 2026-07-31
 params:
   - path: max_tokens
     type: integer

--- a/models/moonshot/kimi-k2.5.yaml
+++ b/models/moonshot/kimi-k2.5.yaml
@@ -3,7 +3,7 @@ provider: moonshot
 authType: api_key
 model: kimi-k2.5
 status: deprecated
-replacement: moonshot/kimi-k2.6
+replacement: moonshot/kimi-k3
 shutdownOn: 2026-08-31
 params:
   - path: max_completion_tokens

--- a/models/moonshot/kimi-k2.5.yaml
+++ b/models/moonshot/kimi-k2.5.yaml
@@ -2,6 +2,9 @@
 provider: moonshot
 authType: api_key
 model: kimi-k2.5
+status: deprecated
+replacement: moonshot/kimi-k2.6
+shutdownOn: 2026-08-31
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/moonshot/kimi-k2.6-subscription.yaml
+++ b/models/moonshot/kimi-k2.6-subscription.yaml
@@ -2,6 +2,7 @@
 provider: moonshot
 authType: subscription
 model: kimi-k2.6
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/moonshot/kimi-k2.6.yaml
+++ b/models/moonshot/kimi-k2.6.yaml
@@ -2,6 +2,7 @@
 provider: moonshot
 authType: api_key
 model: kimi-k2.6
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/moonshot/kimi-k2.7-code-highspeed-subscription.yaml
+++ b/models/moonshot/kimi-k2.7-code-highspeed-subscription.yaml
@@ -2,6 +2,7 @@
 provider: moonshot
 authType: subscription
 model: kimi-k2.7-code-highspeed
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/moonshot/kimi-k2.7-code-highspeed.yaml
+++ b/models/moonshot/kimi-k2.7-code-highspeed.yaml
@@ -2,6 +2,7 @@
 provider: moonshot
 authType: api_key
 model: kimi-k2.7-code-highspeed
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/moonshot/kimi-k2.7-code-subscription.yaml
+++ b/models/moonshot/kimi-k2.7-code-subscription.yaml
@@ -2,6 +2,7 @@
 provider: moonshot
 authType: subscription
 model: kimi-k2.7-code
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/moonshot/kimi-k2.7-code.yaml
+++ b/models/moonshot/kimi-k2.7-code.yaml
@@ -2,6 +2,7 @@
 provider: moonshot
 authType: api_key
 model: kimi-k2.7-code
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/moonshot/kimi-k3.yaml
+++ b/models/moonshot/kimi-k3.yaml
@@ -2,6 +2,7 @@
 provider: moonshot
 authType: api_key
 model: kimi-k3
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/moonshot/moonshot-v1-128k.yaml
+++ b/models/moonshot/moonshot-v1-128k.yaml
@@ -3,7 +3,7 @@ provider: moonshot
 authType: api_key
 model: moonshot-v1-128k
 status: deprecated
-replacement: moonshot/kimi-k2.6
+replacement: moonshot/kimi-k3
 shutdownOn: 2026-08-31
 params:
   - path: max_completion_tokens

--- a/models/moonshot/moonshot-v1-128k.yaml
+++ b/models/moonshot/moonshot-v1-128k.yaml
@@ -2,6 +2,9 @@
 provider: moonshot
 authType: api_key
 model: moonshot-v1-128k
+status: deprecated
+replacement: moonshot/kimi-k2.6
+shutdownOn: 2026-08-31
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/moonshot/moonshot-v1-32k.yaml
+++ b/models/moonshot/moonshot-v1-32k.yaml
@@ -2,6 +2,9 @@
 provider: moonshot
 authType: api_key
 model: moonshot-v1-32k
+status: deprecated
+replacement: moonshot/kimi-k2.6
+shutdownOn: 2026-08-31
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/moonshot/moonshot-v1-32k.yaml
+++ b/models/moonshot/moonshot-v1-32k.yaml
@@ -3,7 +3,7 @@ provider: moonshot
 authType: api_key
 model: moonshot-v1-32k
 status: deprecated
-replacement: moonshot/kimi-k2.6
+replacement: moonshot/kimi-k3
 shutdownOn: 2026-08-31
 params:
   - path: max_completion_tokens

--- a/models/moonshot/moonshot-v1-8k.yaml
+++ b/models/moonshot/moonshot-v1-8k.yaml
@@ -2,6 +2,9 @@
 provider: moonshot
 authType: api_key
 model: moonshot-v1-8k
+status: deprecated
+replacement: moonshot/kimi-k2.6
+shutdownOn: 2026-08-31
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/moonshot/moonshot-v1-8k.yaml
+++ b/models/moonshot/moonshot-v1-8k.yaml
@@ -3,7 +3,7 @@ provider: moonshot
 authType: api_key
 model: moonshot-v1-8k
 status: deprecated
-replacement: moonshot/kimi-k2.6
+replacement: moonshot/kimi-k3
 shutdownOn: 2026-08-31
 params:
   - path: max_completion_tokens

--- a/models/openai/chatgpt-4o-latest.yaml
+++ b/models/openai/chatgpt-4o-latest.yaml
@@ -2,6 +2,8 @@
 provider: openai
 authType: api_key
 model: chatgpt-4o-latest
+status: retired
+shutdownOn: 2026-02-17
 params:
   - path: max_tokens
     type: integer

--- a/models/openai/gpt-3.5-turbo.yaml
+++ b/models/openai/gpt-3.5-turbo.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: gpt-3.5-turbo
+status: deprecated
+replacement: openai/gpt-5.6-terra
+shutdownOn: 2026-10-23
 params:
   - path: max_tokens
     type: integer

--- a/models/openai/gpt-4-0613.yaml
+++ b/models/openai/gpt-4-0613.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: gpt-4-0613
+status: deprecated
+replacement: openai/gpt-5.6-sol
+shutdownOn: 2026-10-23
 params:
   - path: max_tokens
     type: integer

--- a/models/openai/gpt-4-turbo-2024-04-09.yaml
+++ b/models/openai/gpt-4-turbo-2024-04-09.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: gpt-4-turbo-2024-04-09
+status: deprecated
+replacement: openai/gpt-5.6-sol
+shutdownOn: 2026-10-23
 params:
   - path: max_tokens
     type: integer

--- a/models/openai/gpt-4-turbo.yaml
+++ b/models/openai/gpt-4-turbo.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: gpt-4-turbo
+status: deprecated
+replacement: openai/gpt-5.6-sol
+shutdownOn: 2026-10-23
 params:
   - path: max_tokens
     type: integer

--- a/models/openai/gpt-4.1-mini.yaml
+++ b/models/openai/gpt-4.1-mini.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-4.1-mini
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/openai/gpt-4.1-nano.yaml
+++ b/models/openai/gpt-4.1-nano.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: gpt-4.1-nano
+status: deprecated
+replacement: openai/gpt-5.6-luna
+shutdownOn: 2026-10-23
 params:
   - path: max_tokens
     type: integer

--- a/models/openai/gpt-4.1.yaml
+++ b/models/openai/gpt-4.1.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-4.1
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/openai/gpt-4.yaml
+++ b/models/openai/gpt-4.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: gpt-4
+status: deprecated
+replacement: openai/gpt-5.6-sol
+shutdownOn: 2026-10-23
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-4o-mini.yaml
+++ b/models/openai/gpt-4o-mini.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-4o-mini
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/openai/gpt-4o.yaml
+++ b/models/openai/gpt-4o.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-4o
+status: active
 params:
   - path: max_tokens
     type: integer

--- a/models/openai/gpt-5-chat-latest.yaml
+++ b/models/openai/gpt-5-chat-latest.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: gpt-5-chat-latest
+status: retired
+replacement: openai/gpt-5.6-sol
+shutdownOn: 2026-07-23
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-5-mini.yaml
+++ b/models/openai/gpt-5-mini.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: gpt-5-mini
+status: deprecated
+replacement: openai/gpt-5.6-terra
+shutdownOn: 2026-12-11
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-5-nano.yaml
+++ b/models/openai/gpt-5-nano.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: gpt-5-nano
+status: deprecated
+replacement: openai/gpt-5.6-luna
+shutdownOn: 2026-12-11
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-5.1-codex-max-subscription.yaml
+++ b/models/openai/gpt-5.1-codex-max-subscription.yaml
@@ -3,7 +3,7 @@ provider: openai
 authType: subscription
 model: gpt-5.1-codex-max
 status: retired
-replacement: openai/gpt-5.3-codex
+replacement: openai/gpt-5.6-sol
 shutdownOn: 2026-07-23
 params:
   - path: reasoning.effort

--- a/models/openai/gpt-5.1-codex-max-subscription.yaml
+++ b/models/openai/gpt-5.1-codex-max-subscription.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: subscription
 model: gpt-5.1-codex-max
+status: retired
+replacement: openai/gpt-5.3-codex
+shutdownOn: 2026-07-23
 params:
   - path: reasoning.effort
     type: enum

--- a/models/openai/gpt-5.1-codex-subscription.yaml
+++ b/models/openai/gpt-5.1-codex-subscription.yaml
@@ -3,7 +3,7 @@ provider: openai
 authType: subscription
 model: gpt-5.1-codex
 status: retired
-replacement: openai/gpt-5.3-codex
+replacement: openai/gpt-5.6-sol
 shutdownOn: 2026-07-23
 params:
   - path: reasoning.effort

--- a/models/openai/gpt-5.1-codex-subscription.yaml
+++ b/models/openai/gpt-5.1-codex-subscription.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: subscription
 model: gpt-5.1-codex
+status: retired
+replacement: openai/gpt-5.3-codex
+shutdownOn: 2026-07-23
 params:
   - path: reasoning.effort
     type: enum

--- a/models/openai/gpt-5.2-codex-subscription.yaml
+++ b/models/openai/gpt-5.2-codex-subscription.yaml
@@ -3,7 +3,7 @@ provider: openai
 authType: subscription
 model: gpt-5.2-codex
 status: retired
-replacement: openai/gpt-5.3-codex
+replacement: openai/gpt-5.6-sol
 shutdownOn: 2026-07-23
 params:
   - path: reasoning.effort

--- a/models/openai/gpt-5.2-codex-subscription.yaml
+++ b/models/openai/gpt-5.2-codex-subscription.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: subscription
 model: gpt-5.2-codex
+status: retired
+replacement: openai/gpt-5.3-codex
+shutdownOn: 2026-07-23
 params:
   - path: reasoning.effort
     type: enum

--- a/models/openai/gpt-5.3-codex-spark-subscription.yaml
+++ b/models/openai/gpt-5.3-codex-spark-subscription.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: subscription
 model: gpt-5.3-codex-spark
+status: active
 params:
   - path: reasoning.effort
     type: enum

--- a/models/openai/gpt-5.3-codex-subscription.yaml
+++ b/models/openai/gpt-5.3-codex-subscription.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: subscription
 model: gpt-5.3-codex
+status: active
 params:
   - path: reasoning.effort
     type: enum

--- a/models/openai/gpt-5.3-codex.yaml
+++ b/models/openai/gpt-5.3-codex.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-5.3-codex
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-5.4-mini-subscription.yaml
+++ b/models/openai/gpt-5.4-mini-subscription.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: subscription
 model: gpt-5.4-mini
+status: active
 params:
   - path: reasoning.effort
     type: enum

--- a/models/openai/gpt-5.4-mini.yaml
+++ b/models/openai/gpt-5.4-mini.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-5.4-mini
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-5.4-nano.yaml
+++ b/models/openai/gpt-5.4-nano.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-5.4-nano
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-5.4-pro-subscription.yaml
+++ b/models/openai/gpt-5.4-pro-subscription.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: subscription
 model: gpt-5.4-pro
+status: active
 params:
   - path: reasoning.effort
     type: enum

--- a/models/openai/gpt-5.4-pro.yaml
+++ b/models/openai/gpt-5.4-pro.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-5.4-pro
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-5.4-subscription.yaml
+++ b/models/openai/gpt-5.4-subscription.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: subscription
 model: gpt-5.4
+status: active
 params:
   - path: reasoning.effort
     type: enum

--- a/models/openai/gpt-5.4.yaml
+++ b/models/openai/gpt-5.4.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-5.4
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-5.5-pro-subscription.yaml
+++ b/models/openai/gpt-5.5-pro-subscription.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: subscription
 model: gpt-5.5-pro
+status: active
 params:
   - path: reasoning.effort
     type: enum

--- a/models/openai/gpt-5.5-pro.yaml
+++ b/models/openai/gpt-5.5-pro.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-5.5-pro
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-5.5-subscription.yaml
+++ b/models/openai/gpt-5.5-subscription.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: subscription
 model: gpt-5.5
+status: active
 params:
   - path: reasoning.effort
     type: enum

--- a/models/openai/gpt-5.5.yaml
+++ b/models/openai/gpt-5.5.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-5.5
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-5.6-luna-subscription.yaml
+++ b/models/openai/gpt-5.6-luna-subscription.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: subscription
 model: gpt-5.6-luna
+status: active
 params:
   - path: reasoning.effort
     type: enum

--- a/models/openai/gpt-5.6-luna.yaml
+++ b/models/openai/gpt-5.6-luna.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-5.6-luna
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-5.6-sol-subscription.yaml
+++ b/models/openai/gpt-5.6-sol-subscription.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: subscription
 model: gpt-5.6-sol
+status: active
 params:
   - path: reasoning.effort
     type: enum

--- a/models/openai/gpt-5.6-sol.yaml
+++ b/models/openai/gpt-5.6-sol.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-5.6-sol
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-5.6-terra-subscription.yaml
+++ b/models/openai/gpt-5.6-terra-subscription.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: subscription
 model: gpt-5.6-terra
+status: active
 params:
   - path: reasoning.effort
     type: enum

--- a/models/openai/gpt-5.6-terra.yaml
+++ b/models/openai/gpt-5.6-terra.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-5.6-terra
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-5.yaml
+++ b/models/openai/gpt-5.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: gpt-5
+status: deprecated
+replacement: openai/gpt-5.6-sol
+shutdownOn: 2026-12-11
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-oss-120b.yaml
+++ b/models/openai/gpt-oss-120b.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-oss-120b
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/gpt-oss-20b.yaml
+++ b/models/openai/gpt-oss-20b.yaml
@@ -2,6 +2,7 @@
 provider: openai
 authType: api_key
 model: gpt-oss-20b
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/o1-mini.yaml
+++ b/models/openai/o1-mini.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: o1-mini
+status: retired
+replacement: openai/o4-mini
+shutdownOn: 2025-10-27
 params:
   - path: max_tokens
     type: integer

--- a/models/openai/o1-preview.yaml
+++ b/models/openai/o1-preview.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: o1-preview
+status: retired
+replacement: openai/o3
+shutdownOn: 2025-07-28
 params:
   - path: max_tokens
     type: integer

--- a/models/openai/o1.yaml
+++ b/models/openai/o1.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: o1
+status: deprecated
+replacement: openai/gpt-5.6-sol
+shutdownOn: 2026-10-23
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/o3-mini.yaml
+++ b/models/openai/o3-mini.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: o3-mini
+status: deprecated
+replacement: openai/gpt-5.6-sol
+shutdownOn: 2026-10-23
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/o3-pro.yaml
+++ b/models/openai/o3-pro.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: o3-pro
+status: deprecated
+replacement: openai/gpt-5.6-sol
+shutdownOn: 2026-12-11
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/o3.yaml
+++ b/models/openai/o3.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: o3
+status: deprecated
+replacement: openai/gpt-5.6-sol
+shutdownOn: 2026-12-11
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/openai/o4-mini.yaml
+++ b/models/openai/o4-mini.yaml
@@ -2,6 +2,9 @@
 provider: openai
 authType: api_key
 model: o4-mini
+status: deprecated
+replacement: openai/gpt-5.6-terra
+shutdownOn: 2026-10-23
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/xai/grok-4.20-0309-non-reasoning-subscription.yaml
+++ b/models/xai/grok-4.20-0309-non-reasoning-subscription.yaml
@@ -2,6 +2,7 @@
 provider: xai
 authType: subscription
 model: grok-4.20-0309-non-reasoning
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/xai/grok-4.20-0309-non-reasoning.yaml
+++ b/models/xai/grok-4.20-0309-non-reasoning.yaml
@@ -2,6 +2,7 @@
 provider: xai
 authType: api_key
 model: grok-4.20-0309-non-reasoning
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/xai/grok-4.20-0309-reasoning-subscription.yaml
+++ b/models/xai/grok-4.20-0309-reasoning-subscription.yaml
@@ -2,6 +2,7 @@
 provider: xai
 authType: subscription
 model: grok-4.20-0309-reasoning
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/xai/grok-4.20-0309-reasoning.yaml
+++ b/models/xai/grok-4.20-0309-reasoning.yaml
@@ -2,6 +2,7 @@
 provider: xai
 authType: api_key
 model: grok-4.20-0309-reasoning
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/xai/grok-4.20-multi-agent-0309.yaml
+++ b/models/xai/grok-4.20-multi-agent-0309.yaml
@@ -2,6 +2,7 @@
 provider: xai
 authType: api_key
 model: grok-4.20-multi-agent-0309
+status: active
 params:
   - path: max_output_tokens
     type: integer

--- a/models/xai/grok-4.3-subscription.yaml
+++ b/models/xai/grok-4.3-subscription.yaml
@@ -2,6 +2,7 @@
 provider: xai
 authType: subscription
 model: grok-4.3
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/xai/grok-4.3.yaml
+++ b/models/xai/grok-4.3.yaml
@@ -2,6 +2,7 @@
 provider: xai
 authType: api_key
 model: grok-4.3
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/xai/grok-4.5-subscription.yaml
+++ b/models/xai/grok-4.5-subscription.yaml
@@ -2,6 +2,7 @@
 provider: xai
 authType: subscription
 model: grok-4.5
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/xai/grok-4.5.yaml
+++ b/models/xai/grok-4.5.yaml
@@ -2,6 +2,7 @@
 provider: xai
 authType: api_key
 model: grok-4.5
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/xai/grok-build-0.1-subscription.yaml
+++ b/models/xai/grok-build-0.1-subscription.yaml
@@ -2,6 +2,7 @@
 provider: xai
 authType: subscription
 model: grok-build-0.1
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/xai/grok-build-0.1.yaml
+++ b/models/xai/grok-build-0.1.yaml
@@ -2,6 +2,7 @@
 provider: xai
 authType: api_key
 model: grok-build-0.1
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/xiaomi/mimo-v2.5-pro.yaml
+++ b/models/xiaomi/mimo-v2.5-pro.yaml
@@ -2,6 +2,7 @@
 provider: xiaomi
 authType: api_key
 model: mimo-v2.5-pro
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/xiaomi/mimo-v2.5-subscription.yaml
+++ b/models/xiaomi/mimo-v2.5-subscription.yaml
@@ -2,6 +2,7 @@
 provider: xiaomi
 authType: subscription
 model: mimo-v2.5
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/models/xiaomi/mimo-v2.5.yaml
+++ b/models/xiaomi/mimo-v2.5.yaml
@@ -2,6 +2,7 @@
 provider: xiaomi
 authType: api_key
 model: mimo-v2.5
+status: active
 params:
   - path: max_completion_tokens
     type: integer

--- a/packages/modelparams-mcp/tests/server.test.ts
+++ b/packages/modelparams-mcp/tests/server.test.ts
@@ -160,6 +160,7 @@ describe("get_model_params", () => {
   it("returns typed parameters and defaults", async () => {
     const out = await call<ModelParamsResult>("get_model_params", { model: "openai/gpt-5.5" });
     expect(out.model).toBe("openai/gpt-5.5");
+    expect(out.status).toBe("active");
     expect(out.parameterCount).toBeGreaterThan(0);
     const effort = out.params.find((p) => p.path === "reasoning_effort");
     expect(effort!.type).toBe("enum");

--- a/packages/modelparams-python/src/modelparams/_generated/catalog.json
+++ b/packages/modelparams-python/src/modelparams/_generated/catalog.json
@@ -2716,6 +2716,9 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-5-haiku-20241022",
+    "status": "retired",
+    "replacement": "anthropic/claude-haiku-4-5-20251001",
+    "shutdownOn": "2026-02-19",
     "params": [
       {
         "path": "max_tokens",
@@ -2802,6 +2805,9 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-5-haiku-latest",
+    "status": "retired",
+    "replacement": "anthropic/claude-haiku-4-5-20251001",
+    "shutdownOn": "2026-02-19",
     "params": [
       {
         "path": "max_tokens",
@@ -2888,6 +2894,9 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-5-sonnet-20241022",
+    "status": "retired",
+    "replacement": "anthropic/claude-sonnet-4-6",
+    "shutdownOn": "2025-10-28",
     "params": [
       {
         "path": "max_tokens",
@@ -2974,6 +2983,9 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-5-sonnet-latest",
+    "status": "retired",
+    "replacement": "anthropic/claude-sonnet-4-6",
+    "shutdownOn": "2025-10-28",
     "params": [
       {
         "path": "max_tokens",
@@ -3060,6 +3072,9 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-7-sonnet-20250219",
+    "status": "retired",
+    "replacement": "anthropic/claude-sonnet-4-6",
+    "shutdownOn": "2026-02-19",
     "params": [
       {
         "path": "max_tokens",
@@ -3174,6 +3189,9 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-7-sonnet-latest",
+    "status": "retired",
+    "replacement": "anthropic/claude-sonnet-4-6",
+    "shutdownOn": "2026-02-19",
     "params": [
       {
         "path": "max_tokens",
@@ -3288,6 +3306,9 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-opus-20240229",
+    "status": "retired",
+    "replacement": "anthropic/claude-opus-4-8",
+    "shutdownOn": "2026-01-05",
     "params": [
       {
         "path": "max_tokens",
@@ -3460,6 +3481,7 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-fable-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -3522,6 +3544,7 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-fable-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -3698,6 +3721,7 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-haiku-4-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -3812,6 +3836,7 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-haiku-4-5-20251001",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -3930,6 +3955,7 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-haiku-4-5-20251001",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -4048,6 +4074,7 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-haiku-4-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -4276,6 +4303,9 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-1-20250805",
+    "status": "retired",
+    "replacement": "anthropic/claude-opus-4-8",
+    "shutdownOn": "2026-08-05",
     "params": [
       {
         "path": "max_tokens",
@@ -4413,6 +4443,9 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-1-20250805",
+    "status": "retired",
+    "replacement": "anthropic/claude-opus-4-8",
+    "shutdownOn": "2026-08-05",
     "params": [
       {
         "path": "max_tokens",
@@ -4550,6 +4583,9 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-20250514",
+    "status": "retired",
+    "replacement": "anthropic/claude-opus-4-8",
+    "shutdownOn": "2026-06-15",
     "params": [
       {
         "path": "max_tokens",
@@ -4677,6 +4713,9 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-20250514",
+    "status": "retired",
+    "replacement": "anthropic/claude-opus-4-8",
+    "shutdownOn": "2026-06-15",
     "params": [
       {
         "path": "max_tokens",
@@ -4804,6 +4843,7 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-5-20251101",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -4954,6 +4994,7 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-5-20251101",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5104,6 +5145,7 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-6",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5260,6 +5302,7 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-6",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5416,6 +5459,7 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-7",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5480,6 +5524,7 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-7",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5544,6 +5589,7 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-8",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5608,6 +5654,7 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-8",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5787,6 +5834,7 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5859,6 +5907,7 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5931,6 +5980,9 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-sonnet-4-20250514",
+    "status": "retired",
+    "replacement": "anthropic/claude-sonnet-4-6",
+    "shutdownOn": "2026-06-15",
     "params": [
       {
         "path": "max_tokens",
@@ -6058,6 +6110,9 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-sonnet-4-20250514",
+    "status": "retired",
+    "replacement": "anthropic/claude-sonnet-4-6",
+    "shutdownOn": "2026-06-15",
     "params": [
       {
         "path": "max_tokens",
@@ -6185,6 +6240,7 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-sonnet-4-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -6300,6 +6356,7 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-sonnet-4-5-20250929",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -6418,6 +6475,7 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-sonnet-4-5-20250929",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -6536,6 +6594,7 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-sonnet-4-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -6651,6 +6710,7 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-sonnet-4-6",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -6807,6 +6867,7 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-sonnet-4-6",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -7078,6 +7139,7 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-sonnet-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -7142,6 +7204,7 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-sonnet-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -10403,6 +10466,7 @@
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-a-03-2025",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -10540,6 +10604,7 @@
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-a-plus-05-2026",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -10677,6 +10742,7 @@
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-a-reasoning-08-2025",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -10841,6 +10907,7 @@
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-a-translate-08-2025",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -10978,6 +11045,7 @@
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-a-vision-07-2025",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -11115,6 +11183,7 @@
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-r-08-2024",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -11242,6 +11311,7 @@
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-r-plus-08-2024",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -11369,6 +11439,7 @@
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-r7b-12-2024",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -11506,6 +11577,9 @@
     "provider": "deepseek",
     "authType": "api_key",
     "model": "deepseek-chat",
+    "status": "retired",
+    "replacement": "deepseek/deepseek-v4-flash",
+    "shutdownOn": "2026-07-24",
     "params": [
       {
         "path": "max_tokens",
@@ -11576,6 +11650,9 @@
     "provider": "deepseek",
     "authType": "api_key",
     "model": "deepseek-reasoner",
+    "status": "retired",
+    "replacement": "deepseek/deepseek-v4-flash",
+    "shutdownOn": "2026-07-24",
     "params": [
       {
         "path": "max_tokens",
@@ -11663,6 +11740,7 @@
     "provider": "deepseek",
     "authType": "api_key",
     "model": "deepseek-v4-flash",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -11750,6 +11828,7 @@
     "provider": "deepseek",
     "authType": "api_key",
     "model": "deepseek-v4-pro",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -13245,6 +13324,8 @@
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-2.5-flash",
+    "status": "active",
+    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13339,6 +13420,8 @@
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-2.5-flash-lite",
+    "status": "active",
+    "replacement": "google/gemini-3.1-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13429,6 +13512,8 @@
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-2.5-flash-lite",
+    "status": "active",
+    "replacement": "google/gemini-3.1-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13519,6 +13604,8 @@
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-2.5-flash",
+    "status": "active",
+    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13613,6 +13700,8 @@
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-2.5-pro",
+    "status": "active",
+    "replacement": "google/gemini-3.1-pro-preview",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13706,6 +13795,8 @@
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-2.5-pro",
+    "status": "active",
+    "replacement": "google/gemini-3.1-pro-preview",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13799,6 +13890,8 @@
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3-flash-preview",
+    "status": "active",
+    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13895,6 +13988,8 @@
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-3-flash-preview",
+    "status": "active",
+    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13991,6 +14086,8 @@
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3.1-flash-lite",
+    "status": "active",
+    "replacement": "google/gemini-3.5-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14087,6 +14184,9 @@
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3.1-flash-lite-preview",
+    "status": "retired",
+    "replacement": "google/gemini-3.1-flash-lite",
+    "shutdownOn": "2026-05-25",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14183,6 +14283,9 @@
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-3.1-flash-lite-preview",
+    "status": "retired",
+    "replacement": "google/gemini-3.1-flash-lite",
+    "shutdownOn": "2026-05-25",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14279,6 +14382,8 @@
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-3.1-flash-lite",
+    "status": "active",
+    "replacement": "google/gemini-3.5-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14375,6 +14480,7 @@
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3.1-pro-preview",
+    "status": "active",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14567,6 +14673,7 @@
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-3.1-pro-preview",
+    "status": "active",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14661,6 +14768,7 @@
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3.5-flash",
+    "status": "active",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14757,6 +14865,7 @@
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3.5-flash-lite",
+    "status": "active",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14853,6 +14962,7 @@
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3.6-flash",
+    "status": "active",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -16957,6 +17067,7 @@
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17102,6 +17213,7 @@
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2.1-highspeed",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17145,6 +17257,7 @@
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2.1",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17290,6 +17403,7 @@
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2.5-highspeed",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17333,6 +17447,7 @@
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2.5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17478,6 +17593,7 @@
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2.7-highspeed",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17521,6 +17637,7 @@
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2.7",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17615,6 +17732,7 @@
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M3",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17870,6 +17988,8 @@
     "provider": "mistral",
     "authType": "api_key",
     "model": "devstral-2512",
+    "status": "retired",
+    "shutdownOn": "2026-07-31",
     "params": [
       {
         "path": "max_tokens",
@@ -19692,6 +19812,8 @@
     "provider": "mistral",
     "authType": "api_key",
     "model": "open-mistral-nemo",
+    "status": "retired",
+    "shutdownOn": "2026-07-31",
     "params": [
       {
         "path": "max_tokens",
@@ -19798,6 +19920,9 @@
     "provider": "moonshot",
     "authType": "api_key",
     "model": "kimi-k2.5",
+    "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
+    "shutdownOn": "2026-08-31",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -19882,6 +20007,7 @@
     "provider": "moonshot",
     "authType": "api_key",
     "model": "kimi-k2.6",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -19978,6 +20104,7 @@
     "provider": "moonshot",
     "authType": "subscription",
     "model": "kimi-k2.6",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20031,6 +20158,7 @@
     "provider": "moonshot",
     "authType": "api_key",
     "model": "kimi-k2.7-code",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20116,6 +20244,7 @@
     "provider": "moonshot",
     "authType": "api_key",
     "model": "kimi-k2.7-code-highspeed",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20201,6 +20330,7 @@
     "provider": "moonshot",
     "authType": "subscription",
     "model": "kimi-k2.7-code-highspeed",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20241,6 +20371,7 @@
     "provider": "moonshot",
     "authType": "subscription",
     "model": "kimi-k2.7-code",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20281,6 +20412,7 @@
     "provider": "moonshot",
     "authType": "api_key",
     "model": "kimi-k3",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20355,6 +20487,9 @@
     "provider": "moonshot",
     "authType": "api_key",
     "model": "moonshot-v1-128k",
+    "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
+    "shutdownOn": "2026-08-31",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20492,6 +20627,9 @@
     "provider": "moonshot",
     "authType": "api_key",
     "model": "moonshot-v1-32k",
+    "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
+    "shutdownOn": "2026-08-31",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20629,6 +20767,9 @@
     "provider": "moonshot",
     "authType": "api_key",
     "model": "moonshot-v1-8k",
+    "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
+    "shutdownOn": "2026-08-31",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -21901,6 +22042,8 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "chatgpt-4o-latest",
+    "status": "retired",
+    "shutdownOn": "2026-02-17",
     "params": [
       {
         "path": "max_tokens",
@@ -21945,6 +22088,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-3.5-turbo",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-terra",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_tokens",
@@ -22033,6 +22179,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -22108,6 +22257,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4-0613",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_tokens",
@@ -22152,6 +22304,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4-turbo",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_tokens",
@@ -22196,6 +22351,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4-turbo-2024-04-09",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_tokens",
@@ -22240,6 +22398,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4.1",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -22284,6 +22443,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4.1-mini",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -22328,6 +22488,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4.1-nano",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-luna",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_tokens",
@@ -22372,6 +22535,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4o",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -22460,6 +22624,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4o-mini",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -22504,6 +22669,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-12-11",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -22536,6 +22704,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5-chat-latest",
+    "status": "retired",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-07-23",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -22554,6 +22725,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5-mini",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-terra",
+    "shutdownOn": "2026-12-11",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -22586,6 +22760,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5-nano",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-luna",
+    "shutdownOn": "2026-12-11",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -22650,6 +22827,9 @@
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.1-codex-max",
+    "status": "retired",
+    "replacement": "openai/gpt-5.3-codex",
+    "shutdownOn": "2026-07-23",
     "params": [
       {
         "path": "reasoning.effort",
@@ -22699,6 +22879,9 @@
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.1-codex",
+    "status": "retired",
+    "replacement": "openai/gpt-5.3-codex",
+    "shutdownOn": "2026-07-23",
     "params": [
       {
         "path": "reasoning.effort",
@@ -22780,6 +22963,9 @@
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.2-codex",
+    "status": "retired",
+    "replacement": "openai/gpt-5.3-codex",
+    "shutdownOn": "2026-07-23",
     "params": [
       {
         "path": "reasoning.effort",
@@ -22878,6 +23064,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.3-codex",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -22910,6 +23097,7 @@
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.3-codex-spark",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -22959,6 +23147,7 @@
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.3-codex",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23008,6 +23197,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.4",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23041,6 +23231,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.4-mini",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23074,6 +23265,7 @@
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.4-mini",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23123,6 +23315,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.4-nano",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23156,6 +23349,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.4-pro",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23187,6 +23381,7 @@
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.4-pro",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23234,6 +23429,7 @@
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.4",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23283,6 +23479,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.5",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23316,6 +23513,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.5-pro",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23347,6 +23545,7 @@
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.5-pro",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23394,6 +23593,7 @@
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.5",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23476,6 +23676,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.6-luna",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23509,6 +23710,7 @@
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.6-luna",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23558,6 +23760,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.6-sol",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23591,6 +23794,7 @@
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.6-sol",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23640,6 +23844,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.6-terra",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23673,6 +23878,7 @@
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.6-terra",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23722,6 +23928,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-oss-120b",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23797,6 +24004,7 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-oss-20b",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23974,6 +24182,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "o1",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -24006,6 +24217,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "o1-mini",
+    "status": "retired",
+    "replacement": "openai/o4-mini",
+    "shutdownOn": "2025-10-27",
     "params": [
       {
         "path": "max_tokens",
@@ -24038,6 +24252,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "o1-preview",
+    "status": "retired",
+    "replacement": "openai/o3",
+    "shutdownOn": "2025-07-28",
     "params": [
       {
         "path": "max_tokens",
@@ -24070,6 +24287,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "o3",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-12-11",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -24102,6 +24322,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "o3-mini",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -24134,6 +24357,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "o3-pro",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-12-11",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -24166,6 +24392,9 @@
     "provider": "openai",
     "authType": "api_key",
     "model": "o4-mini",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-terra",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26360,6 +26589,7 @@
     "provider": "xai",
     "authType": "api_key",
     "model": "grok-4.20-0309-non-reasoning",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26430,6 +26660,7 @@
     "provider": "xai",
     "authType": "subscription",
     "model": "grok-4.20-0309-non-reasoning",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26500,6 +26731,7 @@
     "provider": "xai",
     "authType": "api_key",
     "model": "grok-4.20-0309-reasoning",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26563,6 +26795,7 @@
     "provider": "xai",
     "authType": "subscription",
     "model": "grok-4.20-0309-reasoning",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26626,6 +26859,7 @@
     "provider": "xai",
     "authType": "api_key",
     "model": "grok-4.20-multi-agent-0309",
+    "status": "active",
     "params": [
       {
         "path": "max_output_tokens",
@@ -26695,6 +26929,7 @@
     "provider": "xai",
     "authType": "api_key",
     "model": "grok-4.3",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26772,6 +27007,7 @@
     "provider": "xai",
     "authType": "subscription",
     "model": "grok-4.3",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26849,6 +27085,7 @@
     "provider": "xai",
     "authType": "api_key",
     "model": "grok-4.5",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26926,6 +27163,7 @@
     "provider": "xai",
     "authType": "subscription",
     "model": "grok-4.5",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -27073,6 +27311,7 @@
     "provider": "xai",
     "authType": "api_key",
     "model": "grok-build-0.1",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -27136,6 +27375,7 @@
     "provider": "xai",
     "authType": "subscription",
     "model": "grok-build-0.1",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -27199,6 +27439,7 @@
     "provider": "xiaomi",
     "authType": "api_key",
     "model": "mimo-v2.5",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -27276,6 +27517,7 @@
     "provider": "xiaomi",
     "authType": "api_key",
     "model": "mimo-v2.5-pro",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -27386,6 +27628,7 @@
     "provider": "xiaomi",
     "authType": "subscription",
     "model": "mimo-v2.5",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",

--- a/packages/modelparams-python/src/modelparams/_generated/catalog.json
+++ b/packages/modelparams-python/src/modelparams/_generated/catalog.json
@@ -13325,7 +13325,6 @@
     "authType": "api_key",
     "model": "gemini-2.5-flash",
     "status": "active",
-    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13421,7 +13420,6 @@
     "authType": "api_key",
     "model": "gemini-2.5-flash-lite",
     "status": "active",
-    "replacement": "google/gemini-3.1-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13513,7 +13511,6 @@
     "authType": "subscription",
     "model": "gemini-2.5-flash-lite",
     "status": "active",
-    "replacement": "google/gemini-3.1-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13605,7 +13602,6 @@
     "authType": "subscription",
     "model": "gemini-2.5-flash",
     "status": "active",
-    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13701,7 +13697,6 @@
     "authType": "api_key",
     "model": "gemini-2.5-pro",
     "status": "active",
-    "replacement": "google/gemini-3.1-pro-preview",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13796,7 +13791,6 @@
     "authType": "subscription",
     "model": "gemini-2.5-pro",
     "status": "active",
-    "replacement": "google/gemini-3.1-pro-preview",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -17988,8 +17982,7 @@
     "provider": "mistral",
     "authType": "api_key",
     "model": "devstral-2512",
-    "status": "retired",
-    "shutdownOn": "2026-07-31",
+    "status": "deprecated",
     "params": [
       {
         "path": "max_tokens",
@@ -19812,8 +19805,7 @@
     "provider": "mistral",
     "authType": "api_key",
     "model": "open-mistral-nemo",
-    "status": "retired",
-    "shutdownOn": "2026-07-31",
+    "status": "deprecated",
     "params": [
       {
         "path": "max_tokens",
@@ -19921,7 +19913,7 @@
     "authType": "api_key",
     "model": "kimi-k2.5",
     "status": "deprecated",
-    "replacement": "moonshot/kimi-k2.6",
+    "replacement": "moonshot/kimi-k3",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -20488,7 +20480,7 @@
     "authType": "api_key",
     "model": "moonshot-v1-128k",
     "status": "deprecated",
-    "replacement": "moonshot/kimi-k2.6",
+    "replacement": "moonshot/kimi-k3",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -20628,7 +20620,7 @@
     "authType": "api_key",
     "model": "moonshot-v1-32k",
     "status": "deprecated",
-    "replacement": "moonshot/kimi-k2.6",
+    "replacement": "moonshot/kimi-k3",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -20768,7 +20760,7 @@
     "authType": "api_key",
     "model": "moonshot-v1-8k",
     "status": "deprecated",
-    "replacement": "moonshot/kimi-k2.6",
+    "replacement": "moonshot/kimi-k3",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -22828,7 +22820,7 @@
     "authType": "subscription",
     "model": "gpt-5.1-codex-max",
     "status": "retired",
-    "replacement": "openai/gpt-5.3-codex",
+    "replacement": "openai/gpt-5.6-sol",
     "shutdownOn": "2026-07-23",
     "params": [
       {
@@ -22880,7 +22872,7 @@
     "authType": "subscription",
     "model": "gpt-5.1-codex",
     "status": "retired",
-    "replacement": "openai/gpt-5.3-codex",
+    "replacement": "openai/gpt-5.6-sol",
     "shutdownOn": "2026-07-23",
     "params": [
       {
@@ -22964,7 +22956,7 @@
     "authType": "subscription",
     "model": "gpt-5.2-codex",
     "status": "retired",
-    "replacement": "openai/gpt-5.3-codex",
+    "replacement": "openai/gpt-5.6-sol",
     "shutdownOn": "2026-07-23",
     "params": [
       {

--- a/packages/modelparams-python/tests/test_catalog.py
+++ b/packages/modelparams-python/tests/test_catalog.py
@@ -45,7 +45,7 @@ def test_get_model_returns_frozen_pythonic_metadata() -> None:
     assert model.provider == "anthropic"
     assert model.auth_type == "api_key"
     assert model.model == "claude-haiku-4-5-20251001"
-    assert model.status is None
+    assert model.status == "active"
     assert model.params
     with pytest.raises(ValidationError):
         model.model = "changed"

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -13330,7 +13330,6 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "gemini-2.5-flash",
     "status": "active",
-    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13426,7 +13425,6 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "gemini-2.5-flash-lite",
     "status": "active",
-    "replacement": "google/gemini-3.1-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13518,7 +13516,6 @@ const GENERATED_CATALOG = [
     "authType": "subscription",
     "model": "gemini-2.5-flash-lite",
     "status": "active",
-    "replacement": "google/gemini-3.1-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13610,7 +13607,6 @@ const GENERATED_CATALOG = [
     "authType": "subscription",
     "model": "gemini-2.5-flash",
     "status": "active",
-    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13706,7 +13702,6 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "gemini-2.5-pro",
     "status": "active",
-    "replacement": "google/gemini-3.1-pro-preview",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13801,7 +13796,6 @@ const GENERATED_CATALOG = [
     "authType": "subscription",
     "model": "gemini-2.5-pro",
     "status": "active",
-    "replacement": "google/gemini-3.1-pro-preview",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -17993,8 +17987,7 @@ const GENERATED_CATALOG = [
     "provider": "mistral",
     "authType": "api_key",
     "model": "devstral-2512",
-    "status": "retired",
-    "shutdownOn": "2026-07-31",
+    "status": "deprecated",
     "params": [
       {
         "path": "max_tokens",
@@ -19817,8 +19810,7 @@ const GENERATED_CATALOG = [
     "provider": "mistral",
     "authType": "api_key",
     "model": "open-mistral-nemo",
-    "status": "retired",
-    "shutdownOn": "2026-07-31",
+    "status": "deprecated",
     "params": [
       {
         "path": "max_tokens",
@@ -19926,7 +19918,7 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "kimi-k2.5",
     "status": "deprecated",
-    "replacement": "moonshot/kimi-k2.6",
+    "replacement": "moonshot/kimi-k3",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -20493,7 +20485,7 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "moonshot-v1-128k",
     "status": "deprecated",
-    "replacement": "moonshot/kimi-k2.6",
+    "replacement": "moonshot/kimi-k3",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -20633,7 +20625,7 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "moonshot-v1-32k",
     "status": "deprecated",
-    "replacement": "moonshot/kimi-k2.6",
+    "replacement": "moonshot/kimi-k3",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -20773,7 +20765,7 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "moonshot-v1-8k",
     "status": "deprecated",
-    "replacement": "moonshot/kimi-k2.6",
+    "replacement": "moonshot/kimi-k3",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -22833,7 +22825,7 @@ const GENERATED_CATALOG = [
     "authType": "subscription",
     "model": "gpt-5.1-codex-max",
     "status": "retired",
-    "replacement": "openai/gpt-5.3-codex",
+    "replacement": "openai/gpt-5.6-sol",
     "shutdownOn": "2026-07-23",
     "params": [
       {
@@ -22885,7 +22877,7 @@ const GENERATED_CATALOG = [
     "authType": "subscription",
     "model": "gpt-5.1-codex",
     "status": "retired",
-    "replacement": "openai/gpt-5.3-codex",
+    "replacement": "openai/gpt-5.6-sol",
     "shutdownOn": "2026-07-23",
     "params": [
       {
@@ -22969,7 +22961,7 @@ const GENERATED_CATALOG = [
     "authType": "subscription",
     "model": "gpt-5.2-codex",
     "status": "retired",
-    "replacement": "openai/gpt-5.3-codex",
+    "replacement": "openai/gpt-5.6-sol",
     "shutdownOn": "2026-07-23",
     "params": [
       {

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -2721,6 +2721,9 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-5-haiku-20241022",
+    "status": "retired",
+    "replacement": "anthropic/claude-haiku-4-5-20251001",
+    "shutdownOn": "2026-02-19",
     "params": [
       {
         "path": "max_tokens",
@@ -2807,6 +2810,9 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-5-haiku-latest",
+    "status": "retired",
+    "replacement": "anthropic/claude-haiku-4-5-20251001",
+    "shutdownOn": "2026-02-19",
     "params": [
       {
         "path": "max_tokens",
@@ -2893,6 +2899,9 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-5-sonnet-20241022",
+    "status": "retired",
+    "replacement": "anthropic/claude-sonnet-4-6",
+    "shutdownOn": "2025-10-28",
     "params": [
       {
         "path": "max_tokens",
@@ -2979,6 +2988,9 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-5-sonnet-latest",
+    "status": "retired",
+    "replacement": "anthropic/claude-sonnet-4-6",
+    "shutdownOn": "2025-10-28",
     "params": [
       {
         "path": "max_tokens",
@@ -3065,6 +3077,9 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-7-sonnet-20250219",
+    "status": "retired",
+    "replacement": "anthropic/claude-sonnet-4-6",
+    "shutdownOn": "2026-02-19",
     "params": [
       {
         "path": "max_tokens",
@@ -3179,6 +3194,9 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-7-sonnet-latest",
+    "status": "retired",
+    "replacement": "anthropic/claude-sonnet-4-6",
+    "shutdownOn": "2026-02-19",
     "params": [
       {
         "path": "max_tokens",
@@ -3293,6 +3311,9 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-3-opus-20240229",
+    "status": "retired",
+    "replacement": "anthropic/claude-opus-4-8",
+    "shutdownOn": "2026-01-05",
     "params": [
       {
         "path": "max_tokens",
@@ -3465,6 +3486,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-fable-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -3527,6 +3549,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-fable-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -3703,6 +3726,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-haiku-4-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -3817,6 +3841,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-haiku-4-5-20251001",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -3935,6 +3960,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-haiku-4-5-20251001",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -4053,6 +4079,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-haiku-4-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -4281,6 +4308,9 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-1-20250805",
+    "status": "retired",
+    "replacement": "anthropic/claude-opus-4-8",
+    "shutdownOn": "2026-08-05",
     "params": [
       {
         "path": "max_tokens",
@@ -4418,6 +4448,9 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-1-20250805",
+    "status": "retired",
+    "replacement": "anthropic/claude-opus-4-8",
+    "shutdownOn": "2026-08-05",
     "params": [
       {
         "path": "max_tokens",
@@ -4555,6 +4588,9 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-20250514",
+    "status": "retired",
+    "replacement": "anthropic/claude-opus-4-8",
+    "shutdownOn": "2026-06-15",
     "params": [
       {
         "path": "max_tokens",
@@ -4682,6 +4718,9 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-20250514",
+    "status": "retired",
+    "replacement": "anthropic/claude-opus-4-8",
+    "shutdownOn": "2026-06-15",
     "params": [
       {
         "path": "max_tokens",
@@ -4809,6 +4848,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-5-20251101",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -4959,6 +4999,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-5-20251101",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5109,6 +5150,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-6",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5265,6 +5307,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-6",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5421,6 +5464,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-7",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5485,6 +5529,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-7",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5549,6 +5594,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-8",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5613,6 +5659,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-8",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5792,6 +5839,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5864,6 +5912,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -5936,6 +5985,9 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-sonnet-4-20250514",
+    "status": "retired",
+    "replacement": "anthropic/claude-sonnet-4-6",
+    "shutdownOn": "2026-06-15",
     "params": [
       {
         "path": "max_tokens",
@@ -6063,6 +6115,9 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-sonnet-4-20250514",
+    "status": "retired",
+    "replacement": "anthropic/claude-sonnet-4-6",
+    "shutdownOn": "2026-06-15",
     "params": [
       {
         "path": "max_tokens",
@@ -6190,6 +6245,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-sonnet-4-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -6305,6 +6361,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-sonnet-4-5-20250929",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -6423,6 +6480,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-sonnet-4-5-20250929",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -6541,6 +6599,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-sonnet-4-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -6656,6 +6715,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-sonnet-4-6",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -6812,6 +6872,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-sonnet-4-6",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -7083,6 +7144,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-sonnet-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -7147,6 +7209,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-sonnet-5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -10408,6 +10471,7 @@ const GENERATED_CATALOG = [
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-a-03-2025",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -10545,6 +10609,7 @@ const GENERATED_CATALOG = [
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-a-plus-05-2026",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -10682,6 +10747,7 @@ const GENERATED_CATALOG = [
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-a-reasoning-08-2025",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -10846,6 +10912,7 @@ const GENERATED_CATALOG = [
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-a-translate-08-2025",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -10983,6 +11050,7 @@ const GENERATED_CATALOG = [
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-a-vision-07-2025",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -11120,6 +11188,7 @@ const GENERATED_CATALOG = [
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-r-08-2024",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -11247,6 +11316,7 @@ const GENERATED_CATALOG = [
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-r-plus-08-2024",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -11374,6 +11444,7 @@ const GENERATED_CATALOG = [
     "provider": "cohere",
     "authType": "api_key",
     "model": "command-r7b-12-2024",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -11511,6 +11582,9 @@ const GENERATED_CATALOG = [
     "provider": "deepseek",
     "authType": "api_key",
     "model": "deepseek-chat",
+    "status": "retired",
+    "replacement": "deepseek/deepseek-v4-flash",
+    "shutdownOn": "2026-07-24",
     "params": [
       {
         "path": "max_tokens",
@@ -11581,6 +11655,9 @@ const GENERATED_CATALOG = [
     "provider": "deepseek",
     "authType": "api_key",
     "model": "deepseek-reasoner",
+    "status": "retired",
+    "replacement": "deepseek/deepseek-v4-flash",
+    "shutdownOn": "2026-07-24",
     "params": [
       {
         "path": "max_tokens",
@@ -11668,6 +11745,7 @@ const GENERATED_CATALOG = [
     "provider": "deepseek",
     "authType": "api_key",
     "model": "deepseek-v4-flash",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -11755,6 +11833,7 @@ const GENERATED_CATALOG = [
     "provider": "deepseek",
     "authType": "api_key",
     "model": "deepseek-v4-pro",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -13250,6 +13329,8 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-2.5-flash",
+    "status": "active",
+    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13344,6 +13425,8 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-2.5-flash-lite",
+    "status": "active",
+    "replacement": "google/gemini-3.1-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13434,6 +13517,8 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-2.5-flash-lite",
+    "status": "active",
+    "replacement": "google/gemini-3.1-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13524,6 +13609,8 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-2.5-flash",
+    "status": "active",
+    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13618,6 +13705,8 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-2.5-pro",
+    "status": "active",
+    "replacement": "google/gemini-3.1-pro-preview",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13711,6 +13800,8 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-2.5-pro",
+    "status": "active",
+    "replacement": "google/gemini-3.1-pro-preview",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13804,6 +13895,8 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3-flash-preview",
+    "status": "active",
+    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13900,6 +13993,8 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-3-flash-preview",
+    "status": "active",
+    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13996,6 +14091,8 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3.1-flash-lite",
+    "status": "active",
+    "replacement": "google/gemini-3.5-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14092,6 +14189,9 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3.1-flash-lite-preview",
+    "status": "retired",
+    "replacement": "google/gemini-3.1-flash-lite",
+    "shutdownOn": "2026-05-25",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14188,6 +14288,9 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-3.1-flash-lite-preview",
+    "status": "retired",
+    "replacement": "google/gemini-3.1-flash-lite",
+    "shutdownOn": "2026-05-25",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14284,6 +14387,8 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-3.1-flash-lite",
+    "status": "active",
+    "replacement": "google/gemini-3.5-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14380,6 +14485,7 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3.1-pro-preview",
+    "status": "active",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14572,6 +14678,7 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "subscription",
     "model": "gemini-3.1-pro-preview",
+    "status": "active",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14666,6 +14773,7 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3.5-flash",
+    "status": "active",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14762,6 +14870,7 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3.5-flash-lite",
+    "status": "active",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -14858,6 +14967,7 @@ const GENERATED_CATALOG = [
     "provider": "google",
     "authType": "api_key",
     "model": "gemini-3.6-flash",
+    "status": "active",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -16962,6 +17072,7 @@ const GENERATED_CATALOG = [
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17107,6 +17218,7 @@ const GENERATED_CATALOG = [
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2.1-highspeed",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17150,6 +17262,7 @@ const GENERATED_CATALOG = [
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2.1",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17295,6 +17408,7 @@ const GENERATED_CATALOG = [
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2.5-highspeed",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17338,6 +17452,7 @@ const GENERATED_CATALOG = [
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2.5",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17483,6 +17598,7 @@ const GENERATED_CATALOG = [
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2.7-highspeed",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17526,6 +17642,7 @@ const GENERATED_CATALOG = [
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M2.7",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17620,6 +17737,7 @@ const GENERATED_CATALOG = [
     "provider": "minimax",
     "authType": "subscription",
     "model": "MiniMax-M3",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -17875,6 +17993,8 @@ const GENERATED_CATALOG = [
     "provider": "mistral",
     "authType": "api_key",
     "model": "devstral-2512",
+    "status": "retired",
+    "shutdownOn": "2026-07-31",
     "params": [
       {
         "path": "max_tokens",
@@ -19697,6 +19817,8 @@ const GENERATED_CATALOG = [
     "provider": "mistral",
     "authType": "api_key",
     "model": "open-mistral-nemo",
+    "status": "retired",
+    "shutdownOn": "2026-07-31",
     "params": [
       {
         "path": "max_tokens",
@@ -19803,6 +19925,9 @@ const GENERATED_CATALOG = [
     "provider": "moonshot",
     "authType": "api_key",
     "model": "kimi-k2.5",
+    "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
+    "shutdownOn": "2026-08-31",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -19887,6 +20012,7 @@ const GENERATED_CATALOG = [
     "provider": "moonshot",
     "authType": "api_key",
     "model": "kimi-k2.6",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -19983,6 +20109,7 @@ const GENERATED_CATALOG = [
     "provider": "moonshot",
     "authType": "subscription",
     "model": "kimi-k2.6",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20036,6 +20163,7 @@ const GENERATED_CATALOG = [
     "provider": "moonshot",
     "authType": "api_key",
     "model": "kimi-k2.7-code",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20121,6 +20249,7 @@ const GENERATED_CATALOG = [
     "provider": "moonshot",
     "authType": "api_key",
     "model": "kimi-k2.7-code-highspeed",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20206,6 +20335,7 @@ const GENERATED_CATALOG = [
     "provider": "moonshot",
     "authType": "subscription",
     "model": "kimi-k2.7-code-highspeed",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20246,6 +20376,7 @@ const GENERATED_CATALOG = [
     "provider": "moonshot",
     "authType": "subscription",
     "model": "kimi-k2.7-code",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20286,6 +20417,7 @@ const GENERATED_CATALOG = [
     "provider": "moonshot",
     "authType": "api_key",
     "model": "kimi-k3",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20360,6 +20492,9 @@ const GENERATED_CATALOG = [
     "provider": "moonshot",
     "authType": "api_key",
     "model": "moonshot-v1-128k",
+    "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
+    "shutdownOn": "2026-08-31",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20497,6 +20632,9 @@ const GENERATED_CATALOG = [
     "provider": "moonshot",
     "authType": "api_key",
     "model": "moonshot-v1-32k",
+    "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
+    "shutdownOn": "2026-08-31",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -20634,6 +20772,9 @@ const GENERATED_CATALOG = [
     "provider": "moonshot",
     "authType": "api_key",
     "model": "moonshot-v1-8k",
+    "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
+    "shutdownOn": "2026-08-31",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -21906,6 +22047,8 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "chatgpt-4o-latest",
+    "status": "retired",
+    "shutdownOn": "2026-02-17",
     "params": [
       {
         "path": "max_tokens",
@@ -21950,6 +22093,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-3.5-turbo",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-terra",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_tokens",
@@ -22038,6 +22184,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -22113,6 +22262,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4-0613",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_tokens",
@@ -22157,6 +22309,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4-turbo",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_tokens",
@@ -22201,6 +22356,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4-turbo-2024-04-09",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_tokens",
@@ -22245,6 +22403,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4.1",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -22289,6 +22448,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4.1-mini",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -22333,6 +22493,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4.1-nano",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-luna",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_tokens",
@@ -22377,6 +22540,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4o",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -22465,6 +22629,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-4o-mini",
+    "status": "active",
     "params": [
       {
         "path": "max_tokens",
@@ -22509,6 +22674,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-12-11",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -22541,6 +22709,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5-chat-latest",
+    "status": "retired",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-07-23",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -22559,6 +22730,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5-mini",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-terra",
+    "shutdownOn": "2026-12-11",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -22591,6 +22765,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5-nano",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-luna",
+    "shutdownOn": "2026-12-11",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -22655,6 +22832,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.1-codex-max",
+    "status": "retired",
+    "replacement": "openai/gpt-5.3-codex",
+    "shutdownOn": "2026-07-23",
     "params": [
       {
         "path": "reasoning.effort",
@@ -22704,6 +22884,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.1-codex",
+    "status": "retired",
+    "replacement": "openai/gpt-5.3-codex",
+    "shutdownOn": "2026-07-23",
     "params": [
       {
         "path": "reasoning.effort",
@@ -22785,6 +22968,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.2-codex",
+    "status": "retired",
+    "replacement": "openai/gpt-5.3-codex",
+    "shutdownOn": "2026-07-23",
     "params": [
       {
         "path": "reasoning.effort",
@@ -22883,6 +23069,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.3-codex",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -22915,6 +23102,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.3-codex-spark",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -22964,6 +23152,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.3-codex",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23013,6 +23202,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.4",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23046,6 +23236,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.4-mini",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23079,6 +23270,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.4-mini",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23128,6 +23320,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.4-nano",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23161,6 +23354,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.4-pro",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23192,6 +23386,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.4-pro",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23239,6 +23434,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.4",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23288,6 +23484,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.5",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23321,6 +23518,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.5-pro",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23352,6 +23550,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.5-pro",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23399,6 +23598,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.5",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23481,6 +23681,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.6-luna",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23514,6 +23715,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.6-luna",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23563,6 +23765,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.6-sol",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23596,6 +23799,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.6-sol",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23645,6 +23849,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-5.6-terra",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23678,6 +23883,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "subscription",
     "model": "gpt-5.6-terra",
+    "status": "active",
     "params": [
       {
         "path": "reasoning.effort",
@@ -23727,6 +23933,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-oss-120b",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23802,6 +24009,7 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "gpt-oss-20b",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -23979,6 +24187,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "o1",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -24011,6 +24222,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "o1-mini",
+    "status": "retired",
+    "replacement": "openai/o4-mini",
+    "shutdownOn": "2025-10-27",
     "params": [
       {
         "path": "max_tokens",
@@ -24043,6 +24257,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "o1-preview",
+    "status": "retired",
+    "replacement": "openai/o3",
+    "shutdownOn": "2025-07-28",
     "params": [
       {
         "path": "max_tokens",
@@ -24075,6 +24292,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "o3",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-12-11",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -24107,6 +24327,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "o3-mini",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -24139,6 +24362,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "o3-pro",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-sol",
+    "shutdownOn": "2026-12-11",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -24171,6 +24397,9 @@ const GENERATED_CATALOG = [
     "provider": "openai",
     "authType": "api_key",
     "model": "o4-mini",
+    "status": "deprecated",
+    "replacement": "openai/gpt-5.6-terra",
+    "shutdownOn": "2026-10-23",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26365,6 +26594,7 @@ const GENERATED_CATALOG = [
     "provider": "xai",
     "authType": "api_key",
     "model": "grok-4.20-0309-non-reasoning",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26435,6 +26665,7 @@ const GENERATED_CATALOG = [
     "provider": "xai",
     "authType": "subscription",
     "model": "grok-4.20-0309-non-reasoning",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26505,6 +26736,7 @@ const GENERATED_CATALOG = [
     "provider": "xai",
     "authType": "api_key",
     "model": "grok-4.20-0309-reasoning",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26568,6 +26800,7 @@ const GENERATED_CATALOG = [
     "provider": "xai",
     "authType": "subscription",
     "model": "grok-4.20-0309-reasoning",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26631,6 +26864,7 @@ const GENERATED_CATALOG = [
     "provider": "xai",
     "authType": "api_key",
     "model": "grok-4.20-multi-agent-0309",
+    "status": "active",
     "params": [
       {
         "path": "max_output_tokens",
@@ -26700,6 +26934,7 @@ const GENERATED_CATALOG = [
     "provider": "xai",
     "authType": "api_key",
     "model": "grok-4.3",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26777,6 +27012,7 @@ const GENERATED_CATALOG = [
     "provider": "xai",
     "authType": "subscription",
     "model": "grok-4.3",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26854,6 +27090,7 @@ const GENERATED_CATALOG = [
     "provider": "xai",
     "authType": "api_key",
     "model": "grok-4.5",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -26931,6 +27168,7 @@ const GENERATED_CATALOG = [
     "provider": "xai",
     "authType": "subscription",
     "model": "grok-4.5",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -27078,6 +27316,7 @@ const GENERATED_CATALOG = [
     "provider": "xai",
     "authType": "api_key",
     "model": "grok-build-0.1",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -27141,6 +27380,7 @@ const GENERATED_CATALOG = [
     "provider": "xai",
     "authType": "subscription",
     "model": "grok-build-0.1",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -27204,6 +27444,7 @@ const GENERATED_CATALOG = [
     "provider": "xiaomi",
     "authType": "api_key",
     "model": "mimo-v2.5",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -27281,6 +27522,7 @@ const GENERATED_CATALOG = [
     "provider": "xiaomi",
     "authType": "api_key",
     "model": "mimo-v2.5-pro",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",
@@ -27391,6 +27633,7 @@ const GENERATED_CATALOG = [
     "provider": "xiaomi",
     "authType": "subscription",
     "model": "mimo-v2.5",
+    "status": "active",
     "params": [
       {
         "path": "max_completion_tokens",

--- a/packages/modelparams/tests/runtime.test.ts
+++ b/packages/modelparams/tests/runtime.test.ts
@@ -57,7 +57,7 @@ describe("getModel", () => {
     expect(m.provider).toBe("anthropic");
     expect(m.authType).toBe("api_key");
     expect(m.model).toBe("claude-haiku-4-5-20251001");
-    expect(m.status).toBeUndefined();
+    expect(m.status).toBe("active");
     expect(m.params.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## What changed

- Add verified lifecycle metadata to 148 model/auth rows matched from 101 modeldeprecations.dev records.
- Publish 104 active, 20 deprecated, and 24 retired statuses, plus 45 replacement suggestions and 42 firm shutdown dates.
- Regenerate the TypeScript and Python catalogs so the site, packages, and MCP response stay aligned.

## Source verification

- Checked the import against the official-provider snapshots in [modeldeprecations.dev#9](https://github.com/mnfst/modeldeprecations.dev/pull/9), plus current official docs for providers not covered by that snapshot PR.
- Corrected source drift before import: unsupported Gemini 2.5 replacements were removed, Mistral models still marked deprecated were not treated as retired, retired Codex models use OpenAI's documented substitute, and Moonshot suggestions point to the current Kimi K3 successor.
- Omit soft `earliest_shutdown_on` dates and replacement targets that do not exist in modelparams.dev.

## Validation

- `npm run validate`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- TypeScript package tests, build, and type tests
- MCP package tests, build, and typecheck
- Python Ruff, mypy, and pytest checks
- Parameter-removal guard against `feat/model-lifecycle-metadata`

Stacked on #316.
