### PR TITLE
feat: sync lifecycle status from modeldeprecations.dev

### DIFF
--- a/.github/workflows/sync-lifecycle.yml
+++ b/.github/workflows/sync-lifecycle.yml
@@ -1,0 +1,82 @@
+name: Sync lifecycle status
+
+# Pulls lifecycle metadata (status, replacement, shutdownOn) from
+# modeldeprecations.dev and opens a draft PR when anything changed, keeping this
+# catalog's status fields from going stale between manual imports.
+#
+# modeldeprecations.dev is the lifecycle source of truth; this workflow only
+# mirrors it and never invents dates or replacements.
+
+on:
+  schedule:
+    - cron: "30 4 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: sync-lifecycle-status
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync status and open PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out the default branch without credentials
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sync lifecycle status
+        run: npm run sync:status
+
+      - name: Regenerate modelparams package
+        run: npm run codegen --workspace=modelparams
+
+      - name: Regenerate modelparams Python package
+        run: npm run codegen:python
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update lifecycle sync pull request
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ github.event.repository.default_branch }}
+          branch: automation/sync-lifecycle-status
+          delete-branch: true
+          draft: true
+          commit-message: "chore: sync model lifecycle status from modeldeprecations.dev"
+          title: "chore: sync model lifecycle status"
+          body: |
+            ### What changed
+            - Mirrors `status`, `replacement`, and `shutdownOn` from modeldeprecations.dev.
+            - Regenerates the modelparams TypeScript and Python packages.
+
+            ### Why
+            This catalog's lifecycle fields otherwise go stale between manual imports.
+
+            Review the Files tab before merging. This PR never changes parameter data.

--- a/models/anthropic/claude-opus-4-1-20250805-subscription.yaml
+++ b/models/anthropic/claude-opus-4-1-20250805-subscription.yaml
@@ -2,7 +2,7 @@
 provider: anthropic
 authType: subscription
 model: claude-opus-4-1-20250805
-status: retired
+status: deprecated
 replacement: anthropic/claude-opus-4-8
 shutdownOn: 2026-08-05
 params:

--- a/models/anthropic/claude-opus-4-1-20250805.yaml
+++ b/models/anthropic/claude-opus-4-1-20250805.yaml
@@ -2,7 +2,7 @@
 provider: anthropic
 authType: api_key
 model: claude-opus-4-1-20250805
-status: retired
+status: deprecated
 replacement: anthropic/claude-opus-4-8
 shutdownOn: 2026-08-05
 params:

--- a/models/google/gemini-2.5-flash-lite-subscription.yaml
+++ b/models/google/gemini-2.5-flash-lite-subscription.yaml
@@ -3,6 +3,7 @@ provider: google
 authType: subscription
 model: gemini-2.5-flash-lite
 status: active
+replacement: google/gemini-3.1-flash-lite
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-flash-lite.yaml
+++ b/models/google/gemini-2.5-flash-lite.yaml
@@ -3,6 +3,7 @@ provider: google
 authType: api_key
 model: gemini-2.5-flash-lite
 status: active
+replacement: google/gemini-3.1-flash-lite
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-flash-subscription.yaml
+++ b/models/google/gemini-2.5-flash-subscription.yaml
@@ -3,6 +3,7 @@ provider: google
 authType: subscription
 model: gemini-2.5-flash
 status: active
+replacement: google/gemini-3.6-flash
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-flash.yaml
+++ b/models/google/gemini-2.5-flash.yaml
@@ -3,6 +3,7 @@ provider: google
 authType: api_key
 model: gemini-2.5-flash
 status: active
+replacement: google/gemini-3.6-flash
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-pro-subscription.yaml
+++ b/models/google/gemini-2.5-pro-subscription.yaml
@@ -3,6 +3,7 @@ provider: google
 authType: subscription
 model: gemini-2.5-pro
 status: active
+replacement: google/gemini-3.1-pro-preview
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/google/gemini-2.5-pro.yaml
+++ b/models/google/gemini-2.5-pro.yaml
@@ -3,6 +3,7 @@ provider: google
 authType: api_key
 model: gemini-2.5-pro
 status: active
+replacement: google/gemini-3.1-pro-preview
 params:
   - path: generationConfig.maxOutputTokens
     type: integer

--- a/models/mistral/devstral-2512.yaml
+++ b/models/mistral/devstral-2512.yaml
@@ -2,7 +2,9 @@
 provider: mistral
 authType: api_key
 model: devstral-2512
-status: deprecated
+status: retired
+replacement: mistral/mistral-medium-3-5-26-04
+shutdownOn: 2026-07-31
 params:
   - path: max_tokens
     type: integer

--- a/models/moonshot/kimi-k2.5.yaml
+++ b/models/moonshot/kimi-k2.5.yaml
@@ -3,6 +3,7 @@ provider: moonshot
 authType: api_key
 model: kimi-k2.5
 status: deprecated
+replacement: moonshot/kimi-k2.6
 shutdownOn: 2026-08-31
 params:
   - path: max_completion_tokens

--- a/models/moonshot/moonshot-v1-128k.yaml
+++ b/models/moonshot/moonshot-v1-128k.yaml
@@ -3,6 +3,7 @@ provider: moonshot
 authType: api_key
 model: moonshot-v1-128k
 status: deprecated
+replacement: moonshot/kimi-k2.6
 shutdownOn: 2026-08-31
 params:
   - path: max_completion_tokens

--- a/models/moonshot/moonshot-v1-32k.yaml
+++ b/models/moonshot/moonshot-v1-32k.yaml
@@ -3,6 +3,7 @@ provider: moonshot
 authType: api_key
 model: moonshot-v1-32k
 status: deprecated
+replacement: moonshot/kimi-k2.6
 shutdownOn: 2026-08-31
 params:
   - path: max_completion_tokens

--- a/models/moonshot/moonshot-v1-8k.yaml
+++ b/models/moonshot/moonshot-v1-8k.yaml
@@ -3,6 +3,7 @@ provider: moonshot
 authType: api_key
 model: moonshot-v1-8k
 status: deprecated
+replacement: moonshot/kimi-k2.6
 shutdownOn: 2026-08-31
 params:
   - path: max_completion_tokens

--- a/models/openai/chatgpt-4o-latest.yaml
+++ b/models/openai/chatgpt-4o-latest.yaml
@@ -3,6 +3,7 @@ provider: openai
 authType: api_key
 model: chatgpt-4o-latest
 status: retired
+replacement: openai/gpt-5.1-chat-latest
 shutdownOn: 2026-02-17
 params:
   - path: max_tokens

--- a/models/openai/gpt-5.1-codex-max-subscription.yaml
+++ b/models/openai/gpt-5.1-codex-max-subscription.yaml
@@ -3,7 +3,7 @@ provider: openai
 authType: subscription
 model: gpt-5.1-codex-max
 status: retired
-replacement: openai/gpt-5.6-sol
+replacement: openai/gpt-5.3-codex
 shutdownOn: 2026-07-23
 params:
   - path: reasoning.effort

--- a/models/openai/gpt-5.1-codex-subscription.yaml
+++ b/models/openai/gpt-5.1-codex-subscription.yaml
@@ -3,7 +3,7 @@ provider: openai
 authType: subscription
 model: gpt-5.1-codex
 status: retired
-replacement: openai/gpt-5.6-sol
+replacement: openai/gpt-5.3-codex
 shutdownOn: 2026-07-23
 params:
   - path: reasoning.effort

--- a/models/openai/gpt-5.2-codex-subscription.yaml
+++ b/models/openai/gpt-5.2-codex-subscription.yaml
@@ -3,7 +3,7 @@ provider: openai
 authType: subscription
 model: gpt-5.2-codex
 status: retired
-replacement: openai/gpt-5.6-sol
+replacement: openai/gpt-5.3-codex
 shutdownOn: 2026-07-23
 params:
   - path: reasoning.effort

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "codegen:python": "tsx packages/modelparams-python/scripts/codegen.ts",
     "dev": "tsx watch src/server/dev.ts",
     "validate": "tsx src/data/validate.ts",
+    "sync:status": "tsx src/sync/run.ts",
     "guard:params": "tsx src/data/check-removals.ts",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.api.json",
     "lint": "eslint . --ext .ts,.tsx",

--- a/packages/modelparams-python/src/modelparams/_generated/catalog.json
+++ b/packages/modelparams-python/src/modelparams/_generated/catalog.json
@@ -4303,7 +4303,7 @@
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-1-20250805",
-    "status": "retired",
+    "status": "deprecated",
     "replacement": "anthropic/claude-opus-4-8",
     "shutdownOn": "2026-08-05",
     "params": [
@@ -4443,7 +4443,7 @@
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-1-20250805",
-    "status": "retired",
+    "status": "deprecated",
     "replacement": "anthropic/claude-opus-4-8",
     "shutdownOn": "2026-08-05",
     "params": [
@@ -13325,6 +13325,7 @@
     "authType": "api_key",
     "model": "gemini-2.5-flash",
     "status": "active",
+    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13420,6 +13421,7 @@
     "authType": "api_key",
     "model": "gemini-2.5-flash-lite",
     "status": "active",
+    "replacement": "google/gemini-3.1-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13511,6 +13513,7 @@
     "authType": "subscription",
     "model": "gemini-2.5-flash-lite",
     "status": "active",
+    "replacement": "google/gemini-3.1-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13602,6 +13605,7 @@
     "authType": "subscription",
     "model": "gemini-2.5-flash",
     "status": "active",
+    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13697,6 +13701,7 @@
     "authType": "api_key",
     "model": "gemini-2.5-pro",
     "status": "active",
+    "replacement": "google/gemini-3.1-pro-preview",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13791,6 +13796,7 @@
     "authType": "subscription",
     "model": "gemini-2.5-pro",
     "status": "active",
+    "replacement": "google/gemini-3.1-pro-preview",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -17982,7 +17988,9 @@
     "provider": "mistral",
     "authType": "api_key",
     "model": "devstral-2512",
-    "status": "deprecated",
+    "status": "retired",
+    "replacement": "mistral/mistral-medium-3-5-26-04",
+    "shutdownOn": "2026-07-31",
     "params": [
       {
         "path": "max_tokens",
@@ -19913,6 +19921,7 @@
     "authType": "api_key",
     "model": "kimi-k2.5",
     "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -20479,6 +20488,7 @@
     "authType": "api_key",
     "model": "moonshot-v1-128k",
     "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -20618,6 +20628,7 @@
     "authType": "api_key",
     "model": "moonshot-v1-32k",
     "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -20757,6 +20768,7 @@
     "authType": "api_key",
     "model": "moonshot-v1-8k",
     "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -22031,6 +22043,7 @@
     "authType": "api_key",
     "model": "chatgpt-4o-latest",
     "status": "retired",
+    "replacement": "openai/gpt-5.1-chat-latest",
     "shutdownOn": "2026-02-17",
     "params": [
       {
@@ -22816,7 +22829,7 @@
     "authType": "subscription",
     "model": "gpt-5.1-codex-max",
     "status": "retired",
-    "replacement": "openai/gpt-5.6-sol",
+    "replacement": "openai/gpt-5.3-codex",
     "shutdownOn": "2026-07-23",
     "params": [
       {
@@ -22868,7 +22881,7 @@
     "authType": "subscription",
     "model": "gpt-5.1-codex",
     "status": "retired",
-    "replacement": "openai/gpt-5.6-sol",
+    "replacement": "openai/gpt-5.3-codex",
     "shutdownOn": "2026-07-23",
     "params": [
       {
@@ -22952,7 +22965,7 @@
     "authType": "subscription",
     "model": "gpt-5.2-codex",
     "status": "retired",
-    "replacement": "openai/gpt-5.6-sol",
+    "replacement": "openai/gpt-5.3-codex",
     "shutdownOn": "2026-07-23",
     "params": [
       {

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -4308,7 +4308,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "api_key",
     "model": "claude-opus-4-1-20250805",
-    "status": "retired",
+    "status": "deprecated",
     "replacement": "anthropic/claude-opus-4-8",
     "shutdownOn": "2026-08-05",
     "params": [
@@ -4448,7 +4448,7 @@ const GENERATED_CATALOG = [
     "provider": "anthropic",
     "authType": "subscription",
     "model": "claude-opus-4-1-20250805",
-    "status": "retired",
+    "status": "deprecated",
     "replacement": "anthropic/claude-opus-4-8",
     "shutdownOn": "2026-08-05",
     "params": [
@@ -13330,6 +13330,7 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "gemini-2.5-flash",
     "status": "active",
+    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13425,6 +13426,7 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "gemini-2.5-flash-lite",
     "status": "active",
+    "replacement": "google/gemini-3.1-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13516,6 +13518,7 @@ const GENERATED_CATALOG = [
     "authType": "subscription",
     "model": "gemini-2.5-flash-lite",
     "status": "active",
+    "replacement": "google/gemini-3.1-flash-lite",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13607,6 +13610,7 @@ const GENERATED_CATALOG = [
     "authType": "subscription",
     "model": "gemini-2.5-flash",
     "status": "active",
+    "replacement": "google/gemini-3.6-flash",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13702,6 +13706,7 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "gemini-2.5-pro",
     "status": "active",
+    "replacement": "google/gemini-3.1-pro-preview",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -13796,6 +13801,7 @@ const GENERATED_CATALOG = [
     "authType": "subscription",
     "model": "gemini-2.5-pro",
     "status": "active",
+    "replacement": "google/gemini-3.1-pro-preview",
     "params": [
       {
         "path": "generationConfig.maxOutputTokens",
@@ -17987,7 +17993,9 @@ const GENERATED_CATALOG = [
     "provider": "mistral",
     "authType": "api_key",
     "model": "devstral-2512",
-    "status": "deprecated",
+    "status": "retired",
+    "replacement": "mistral/mistral-medium-3-5-26-04",
+    "shutdownOn": "2026-07-31",
     "params": [
       {
         "path": "max_tokens",
@@ -19918,6 +19926,7 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "kimi-k2.5",
     "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -20484,6 +20493,7 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "moonshot-v1-128k",
     "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -20623,6 +20633,7 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "moonshot-v1-32k",
     "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -20762,6 +20773,7 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "moonshot-v1-8k",
     "status": "deprecated",
+    "replacement": "moonshot/kimi-k2.6",
     "shutdownOn": "2026-08-31",
     "params": [
       {
@@ -22036,6 +22048,7 @@ const GENERATED_CATALOG = [
     "authType": "api_key",
     "model": "chatgpt-4o-latest",
     "status": "retired",
+    "replacement": "openai/gpt-5.1-chat-latest",
     "shutdownOn": "2026-02-17",
     "params": [
       {
@@ -22821,7 +22834,7 @@ const GENERATED_CATALOG = [
     "authType": "subscription",
     "model": "gpt-5.1-codex-max",
     "status": "retired",
-    "replacement": "openai/gpt-5.6-sol",
+    "replacement": "openai/gpt-5.3-codex",
     "shutdownOn": "2026-07-23",
     "params": [
       {
@@ -22873,7 +22886,7 @@ const GENERATED_CATALOG = [
     "authType": "subscription",
     "model": "gpt-5.1-codex",
     "status": "retired",
-    "replacement": "openai/gpt-5.6-sol",
+    "replacement": "openai/gpt-5.3-codex",
     "shutdownOn": "2026-07-23",
     "params": [
       {
@@ -22957,7 +22970,7 @@ const GENERATED_CATALOG = [
     "authType": "subscription",
     "model": "gpt-5.2-codex",
     "status": "retired",
-    "replacement": "openai/gpt-5.6-sol",
+    "replacement": "openai/gpt-5.3-codex",
     "shutdownOn": "2026-07-23",
     "params": [
       {

--- a/src/sync/run.ts
+++ b/src/sync/run.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import yaml from "js-yaml";
+import { MODELS_DIR } from "../data/paths.js";
+import { applyLifecycle, indexDeprecations, keyOf } from "./status.js";
+
+const DEFAULT_URL = "https://modeldeprecations.dev/api/v1/models.json";
+
+interface DeprecationsPayload {
+  models: unknown[];
+}
+
+async function walkYamlFiles(dir: string): Promise<string[]> {
+  const found: string[] = [];
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...(await walkYamlFiles(full)));
+    else if (entry.isFile() && /\.(ya?ml)$/i.test(entry.name)) found.push(full);
+  }
+  return found.sort();
+}
+
+function readIdentity(file: string, raw: unknown): { provider: string; model: string } | undefined {
+  if (typeof raw !== "object" || raw === null) return undefined;
+  const { provider, model } = raw as { provider?: unknown; model?: unknown };
+  if (typeof provider !== "string" || typeof model !== "string") return undefined;
+  return { provider, model };
+}
+
+async function main(): Promise<void> {
+  const urlIndex = process.argv.indexOf("--url");
+  const url = urlIndex === -1 ? DEFAULT_URL : (process.argv[urlIndex + 1] ?? DEFAULT_URL);
+
+  const response = await fetch(url, {
+    headers: { "user-agent": "modelparams.dev lifecycle sync/1.0" },
+  });
+  if (!response.ok) {
+    throw new Error(`fetch ${url} returned HTTP ${response.status}`);
+  }
+  const payload = (await response.json()) as DeprecationsPayload;
+  const index = indexDeprecations(payload.models);
+
+  const files = await walkYamlFiles(MODELS_DIR);
+  let matched = 0;
+  let changed = 0;
+  for (const file of files) {
+    const text = await fs.readFile(file, "utf8");
+    let raw: unknown;
+    try {
+      raw = yaml.load(text, { schema: yaml.JSON_SCHEMA });
+    } catch {
+      continue;
+    }
+    const identity = readIdentity(file, raw);
+    if (!identity) continue;
+    const record = index.get(keyOf(identity.provider, identity.model));
+    if (!record) continue;
+    matched += 1;
+
+    const next = applyLifecycle(text, record);
+    if (next !== text) {
+      await fs.writeFile(file, next, "utf8");
+      changed += 1;
+    }
+  }
+
+  console.log(`Lifecycle sync: ${matched} model(s) matched, ${changed} file(s) changed.`);
+}
+
+main().catch((error) => {
+  console.error(`Lifecycle sync failed: ${(error as Error).message}`);
+  process.exitCode = 1;
+});

--- a/src/sync/status.ts
+++ b/src/sync/status.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * The fields we import from modeldeprecations.dev for each model.
+ *
+ * `status` is always present. `replacement` and `shutdownOn` are omitted when
+ * the deprecations source does not publish them, and their absence also clears
+ * any previously-synced value (the source of truth wins, stale data is dropped).
+ */
+export interface LifecycleRecord {
+  provider: string;
+  model: string;
+  status: "active" | "deprecated" | "retired";
+  replacement?: string;
+  shutdownOn?: string;
+}
+
+const ReplacementSchema = z.object({
+  provider: z.string().min(1),
+  model: z.string().min(1),
+  recommended: z.boolean().optional(),
+});
+
+const DeprecationEntrySchema = z.object({
+  provider: z.string().min(1),
+  model: z.string().min(1),
+  status: z.enum(["active", "deprecated", "retired"]),
+  shutdown_on: z.string().regex(ISO_DATE).nullable().optional(),
+  replacements: z.array(ReplacementSchema).optional(),
+});
+
+export function toLifecycleRecord(entry: unknown): LifecycleRecord | undefined {
+  const parsed = DeprecationEntrySchema.safeParse(entry);
+  if (!parsed.success) return undefined;
+
+  const { provider, model, status, shutdown_on, replacements } = parsed.data;
+  const recommended =
+    replacements?.find((replacement) => replacement.recommended) ?? replacements?.[0];
+
+  return {
+    provider,
+    model,
+    status,
+    replacement: recommended ? `${recommended.provider}/${recommended.model}` : undefined,
+    shutdownOn: shutdown_on ?? undefined,
+  };
+}
+
+export function keyOf(provider: string, model: string): string {
+  return `${provider}/${model}`;
+}
+
+export function indexDeprecations(models: unknown): Map<string, LifecycleRecord> {
+  if (!Array.isArray(models)) {
+    throw new Error("deprecations payload `models` must be an array");
+  }
+  const index = new Map<string, LifecycleRecord>();
+  for (const entry of models) {
+    const record = toLifecycleRecord(entry);
+    if (record) index.set(keyOf(record.provider, record.model), record);
+  }
+  return index;
+}
+
+const LIFECYCLE_KEYS = /^(status|replacement|shutdownOn):/;
+
+function blockFor(record: LifecycleRecord): string[] {
+  const block: string[] = [`status: ${record.status}`];
+  if (record.replacement) block.push(`replacement: ${record.replacement}`);
+  if (record.shutdownOn) block.push(`shutdownOn: ${record.shutdownOn}`);
+  return block;
+}
+
+/**
+ * Rewrites the top-level lifecycle block of a model YAML to match `record`,
+ * preserving every other line (including comments and block scalars).
+ *
+ * The block is kept immediately after the top-level `model:` line, mirroring the
+ * ordering produced by the original lifecycle import.
+ */
+export function applyLifecycle(text: string, record: LifecycleRecord): string {
+  const lines = text.split("\n");
+  const modelIndex = lines.findIndex((line) => /^model:\s+\S+/.test(line));
+  if (modelIndex === -1) return text;
+
+  const kept = lines.filter((line) => !LIFECYCLE_KEYS.test(line));
+  const keptModelIndex = kept.findIndex((line) => /^model:\s+\S+/.test(line));
+  if (keptModelIndex === -1) return text;
+
+  kept.splice(keptModelIndex + 1, 0, ...blockFor(record));
+  return kept.join("\n");
+}

--- a/tests/sync-status.test.ts
+++ b/tests/sync-status.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyLifecycle,
+  indexDeprecations,
+  toLifecycleRecord,
+  type LifecycleRecord,
+} from "../src/sync/status.js";
+
+const SAMPLE = `# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
+provider: anthropic
+authType: api_key
+model: claude-opus-4-1-20250805
+params:
+  - path: temperature
+    type: number
+    label: Temperature
+    description: Controls randomness.
+    default: 1
+    group: sampling
+`;
+
+describe("toLifecycleRecord", () => {
+  it("maps deprecations fields onto the lifecycle shape", () => {
+    expect(
+      toLifecycleRecord({
+        provider: "anthropic",
+        model: "claude-opus-4-1-20250805",
+        status: "retired",
+        shutdown_on: "2026-08-05",
+        replacements: [{ provider: "anthropic", model: "claude-opus-4-8", recommended: true }],
+      }),
+    ).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-1-20250805",
+      status: "retired",
+      replacement: "anthropic/claude-opus-4-8",
+      shutdownOn: "2026-08-05",
+    });
+  });
+
+  it("omits replacement and shutdownOn when absent, and drops null dates", () => {
+    expect(
+      toLifecycleRecord({
+        provider: "xai",
+        model: "grok-4.5",
+        status: "active",
+        shutdown_on: null,
+      }),
+    ).toEqual({ provider: "xai", model: "grok-4.5", status: "active" });
+  });
+
+  it("falls back to the first replacement when none is recommended", () => {
+    const record = toLifecycleRecord({
+      provider: "openai",
+      model: "gpt-4",
+      status: "deprecated",
+      replacements: [{ provider: "openai", model: "gpt-4.1" }],
+    });
+    expect(record?.replacement).toBe("openai/gpt-4.1");
+  });
+
+  it("ignores malformed entries", () => {
+    expect(toLifecycleRecord({ provider: "anthropic" })).toBeUndefined();
+    expect(toLifecycleRecord({ status: "retired" })).toBeUndefined();
+  });
+});
+
+describe("indexDeprecations", () => {
+  it("keys records by provider/model", () => {
+    const index = indexDeprecations([
+      { provider: "anthropic", model: "claude-opus-4-1-20250805", status: "retired" },
+      { provider: "xai", model: "grok-4.5", status: "active" },
+      { junk: true },
+    ]);
+    expect(index.size).toBe(2);
+    expect(index.get("anthropic/claude-opus-4-1-20250805")?.status).toBe("retired");
+  });
+
+  it("rejects a non-array payload", () => {
+    expect(() => indexDeprecations({})).toThrow();
+  });
+});
+
+describe("applyLifecycle", () => {
+  const retired: LifecycleRecord = {
+    provider: "anthropic",
+    model: "claude-opus-4-1-20250805",
+    status: "retired",
+    replacement: "anthropic/claude-opus-4-8",
+    shutdownOn: "2026-08-05",
+  };
+
+  it("inserts the lifecycle block after the model line", () => {
+    const result = applyLifecycle(SAMPLE, retired);
+    expect(result).toContain(
+      [
+        "model: claude-opus-4-1-20250805",
+        "status: retired",
+        "replacement: anthropic/claude-opus-4-8",
+        "shutdownOn: 2026-08-05",
+        "params:",
+      ].join("\n"),
+    );
+    expect(result).toContain("# yaml-language-server:");
+  });
+
+  it("is idempotent", () => {
+    const once = applyLifecycle(SAMPLE, retired);
+    expect(applyLifecycle(once, retired)).toBe(once);
+  });
+
+  it("replaces a stale block and drops fields the source no longer provides", () => {
+    const stale = applyLifecycle(SAMPLE, retired);
+    const active: LifecycleRecord = {
+      provider: "anthropic",
+      model: "claude-opus-4-1-20250805",
+      status: "active",
+    };
+    const result = applyLifecycle(stale, active);
+    expect(result).toContain("status: active\nparams:");
+    expect(result).not.toContain("replacement:");
+    expect(result).not.toContain("shutdownOn:");
+  });
+
+  it("leaves text without a model line unchanged", () => {
+    const noModel = "provider: anthropic\nparams: []\n";
+    expect(applyLifecycle(noModel, retired)).toBe(noModel);
+  });
+});


### PR DESCRIPTION
### What changed
- Adds `npm run sync:status` (new `src/sync/`): fetches `modeldeprecations.dev/api/v1/models.json` and mirrors `status`, `replacement`, and `shutdownOn` into each matched model YAML, keyed by `provider/model`.
- Adds a daily `.github/workflows/sync-lifecycle.yml`: syncs, regenerates the TypeScript and Python packages, and opens a draft PR when anything changed.
- Applies the first sync (17 models): adds Gemini/Moonshot replacements, updates OpenAI codex replacement targets, flips a couple of statuses to match the source.

### Why
Lifecycle fields here were imported once (#320) and have no ongoing sync, so they drift from modeldeprecations.dev — the lifecycle source of truth.

### Notes for review
- The sync is source-of-truth faithful. Notable: `claude-opus-4-1-20250805` flips `retired → deprecated` because modeldeprecations.dev still carries `status: deprecated` for it (its `shutdown_on` of 2026-08-05 is in the past). If that's wrong, it should be fixed upstream in modeldeprecations.dev, not here.
- Replacements come from the first `recommended` entry in the source's `replacements` array.
- Verified end-to-end locally: `validate` (382 models), typecheck, lint, and 240 tests all pass; sync + codegen ran clean.