### PR TITLE
fix: scope sync PR to models and generated packages

### DIFF
--- a/.github/workflows/sync-lifecycle.yml
+++ b/.github/workflows/sync-lifecycle.yml
@@ -69,6 +69,9 @@ jobs:
           branch: automation/sync-lifecycle-status
           delete-branch: true
           draft: true
+          add-paths: |
+            models/**
+            packages/**
           commit-message: "chore: sync model lifecycle status from modeldeprecations.dev"
           title: "chore: sync model lifecycle status"
           body: |


### PR DESCRIPTION
### What changed
- Scopes the sync PR to `models/**` and `packages/**` via `add-paths`.

### Why
The previous auto-sync (#322) accidentally deleted the repo's committed `node_modules` symlink — `npm ci` removes it and `create-pull-request` staged that deletion. Restricting the paths means a sync can only ever touch model YAMLs and the regenerated packages.

### Notes
- The `node_modules` symlink (a broken local-path artifact from #307) is already gone from `main` as a side effect; this prevents any future recurrence.
