### PR TITLE
feat: dedicated MCP page (content negotiation at /mcp)

### DIFF
--- a/.fieldflow/inspect/fde3fce0530fad3c.json
+++ b/.fieldflow/inspect/fde3fce0530fad3c.json
@@ -1,0 +1,75 @@
+{
+  "manifest_version": 1,
+  "command": [
+    "gh",
+    "issue",
+    "list",
+    "--repo",
+    "mnfst/modelparams.dev",
+    "--state",
+    "open",
+    "--limit",
+    "50",
+    "--json",
+    "number,title,labels,url,updatedAt,createdAt,body"
+  ],
+  "command_hash": "fde3fce0530fad3c",
+  "root_type": "list",
+  "paths": [
+    {
+      "path": "[]",
+      "types": ["object"]
+    },
+    {
+      "path": "[].body",
+      "types": ["string"]
+    },
+    {
+      "path": "[].createdAt",
+      "types": ["string"]
+    },
+    {
+      "path": "[].labels",
+      "types": ["list"]
+    },
+    {
+      "path": "[].labels[]",
+      "types": ["object"]
+    },
+    {
+      "path": "[].labels[].color",
+      "types": ["string"]
+    },
+    {
+      "path": "[].labels[].description",
+      "types": ["string"]
+    },
+    {
+      "path": "[].labels[].id",
+      "types": ["string"]
+    },
+    {
+      "path": "[].labels[].name",
+      "types": ["string"]
+    },
+    {
+      "path": "[].number",
+      "types": ["integer"]
+    },
+    {
+      "path": "[].title",
+      "types": ["string"]
+    },
+    {
+      "path": "[].updatedAt",
+      "types": ["string"]
+    },
+    {
+      "path": "[].url",
+      "types": ["string"]
+    }
+  ],
+  "path_count": 13,
+  "input_items": 8,
+  "sampled_items": 8
+}

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -13,6 +13,7 @@
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { createServer } from "../packages/modelparams-mcp/src/server.js";
+import { renderMcpHtml } from "../src/build/render-mcp.js";
 
 const MAX_BODY_BYTES = 256 * 1024;
 
@@ -123,10 +124,20 @@ export default {
 
     // A GET is either an MCP client opening the optional server-to-client
     // stream, which a stateless server has nothing to put on, or a person
-    // opening the URL. Answer each in its own terms.
+    // opening the URL. Answer each in its own terms: browsers get the docs
+    // page, event-stream clients get a 405, and plain API clients get JSON.
     if (request.method === "GET") {
       if ((request.headers.get("accept") ?? "").includes("text/event-stream")) {
         return json({ error: "streaming_not_supported", usage: USAGE }, 405, { Allow: "POST" });
+      }
+      if ((request.headers.get("accept") ?? "").includes("text/html")) {
+        return new Response(renderMcpHtml(), {
+          status: 200,
+          headers: {
+            "Content-Type": "text/html; charset=utf-8",
+            "Cache-Control": "no-store",
+          },
+        });
       }
       return json(USAGE);
     }

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -13,7 +13,6 @@
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { createServer } from "../packages/modelparams-mcp/src/server.js";
-import { renderMcpHtml } from "../src/build/render-mcp.js";
 
 const MAX_BODY_BYTES = 256 * 1024;
 
@@ -124,20 +123,11 @@ export default {
 
     // A GET is either an MCP client opening the optional server-to-client
     // stream, which a stateless server has nothing to put on, or a person
-    // opening the URL. Answer each in its own terms: browsers get the docs
-    // page, event-stream clients get a 405, and plain API clients get JSON.
+    // opening the URL. Answer each in its own terms: event-stream clients get
+    // a 405, everyone else gets the JSON usage object.
     if (request.method === "GET") {
       if ((request.headers.get("accept") ?? "").includes("text/event-stream")) {
         return json({ error: "streaming_not_supported", usage: USAGE }, 405, { Allow: "POST" });
-      }
-      if ((request.headers.get("accept") ?? "").includes("text/html")) {
-        return new Response(renderMcpHtml(), {
-          status: 200,
-          headers: {
-            "Content-Type": "text/html; charset=utf-8",
-            "Cache-Control": "no-store",
-          },
-        });
       }
       return json(USAGE);
     }

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -23,6 +23,7 @@ import {
   API_PATH,
   DISAMBIGUATION_PATH,
   GLOSSARY_PATH,
+  MCP_PATH,
   modelPagePath,
   parameterPagePath,
   providerPagePath,
@@ -36,6 +37,7 @@ import { renderIndex } from "./render.js";
 import { renderApiPage } from "./render-api.js";
 import { renderDisambiguationPage } from "./render-disambiguation.js";
 import { renderGlossaryPage } from "./render-glossary.js";
+import { renderMcpPage } from "./render-mcp.js";
 import { renderModelPage } from "./render-model.js";
 import { defaultSummary,renderParameterPage, rangeSummary } from "./render-parameter.js";
 import { renderNotFoundPage } from "./render-not-found.js";
@@ -80,6 +82,7 @@ async function writeRobotsAndSitemap(models: Model[]): Promise<void> {
     { path: GLOSSARY_PATH, priority: "0.7", lastmod: freshest(models) },
     { path: DISAMBIGUATION_PATH, priority: "0.6", lastmod: freshest(models) },
     { path: API_PATH, priority: "0.5", lastmod: freshest(models) },
+    { path: MCP_PATH, priority: "0.5", lastmod: freshest(models) },
     ...uniqueProviders(models).map((provider) => ({
       path: providerPagePath(provider),
       priority: "0.8",
@@ -133,6 +136,7 @@ async function writeHtmlPages(models: Model[]): Promise<void> {
     "utf8",
   );
   await fs.writeFile(path.join(DIST_DIR, "api.html"), await renderApiPage(models), "utf8");
+  await fs.writeFile(path.join(DIST_DIR, "mcp-server.html"), await renderMcpPage(models), "utf8");
   await fs.writeFile(path.join(DIST_DIR, "404.html"), await renderNotFoundPage(models), "utf8");
 }
 

--- a/src/build/highlight.ts
+++ b/src/build/highlight.ts
@@ -1,0 +1,28 @@
+/** Escape HTML special characters so highlighted JSON can be injected into markup. */
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Minimal JSON syntax highlighter. Returns HTML where each token is wrapped in a
+ * span with a Tailwind text color, tuned for the site's dark code blocks
+ * (`bg-slate-900`). Punctuation is left in the surrounding text color.
+ *
+ * Colours: keys sky, strings emerald, numbers violet, booleans amber, null rose.
+ */
+export function highlightJson(json: string): string {
+  const token =
+    /("(?:\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(?:\s*:)?|\b(?:true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g;
+
+  return json.replace(token, (match) => {
+    let cls = "text-violet-300";
+    if (/^"/.test(match)) {
+      cls = /:$/.test(match) ? "text-sky-300" : "text-emerald-300";
+    } else if (/^(true|false)$/.test(match)) {
+      cls = "text-amber-300";
+    } else if (match === "null") {
+      cls = "text-rose-300";
+    }
+    return `<span class="${cls}">${escapeHtml(match)}</span>`;
+  });
+}

--- a/src/build/highlight.ts
+++ b/src/build/highlight.ts
@@ -26,3 +26,18 @@ export function highlightJson(json: string): string {
     return `<span class="${cls}">${escapeHtml(match)}</span>`;
   });
 }
+
+/**
+ * A self-contained code block for JSON: a header bar with a label and a Copy
+ * button, and a body that wraps long lines instead of overflowing. The copy
+ * button is wired by `[data-json-copy]`; it copies the sibling `<code>` text.
+ */
+export function jsonBlock(json: string, label = "JSON"): string {
+  return `<figure>
+  <div class="flex items-center justify-between rounded-t-md border border-slate-200 border-b-0 bg-slate-800 px-4 py-1.5 dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#161616]">
+    <span class="font-mono text-xs font-medium text-slate-400">${escapeHtml(label)}</span>
+    <button type="button" data-json-copy class="font-mono text-xs font-medium text-slate-400 hover:text-white">Copy</button>
+  </div>
+  <pre class="rounded-b-md border border-slate-200 bg-slate-900 px-5 py-4 font-mono text-sm leading-relaxed text-slate-200 whitespace-pre-wrap break-words dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code>${highlightJson(json)}</code></pre>
+</figure>`;
+}

--- a/src/build/render-mcp.ts
+++ b/src/build/render-mcp.ts
@@ -1,271 +1,34 @@
-import { MCP_CLIENTS, MCP_ENDPOINT, MCP_TOOLS } from "../data/mcp.js";
+import path from "node:path";
+import ejs from "ejs";
+import { MCP_CLIENTS, MCP_TOOLS } from "../data/mcp.js";
+import { VIEWS_DIR } from "../data/paths.js";
+import { SITE_NAME, SITE_URL } from "../data/site.js";
+import { MCP_PATH, absolute, ogImagePath } from "../data/urls.js";
+import { type Model } from "../schema/model.js";
 import { jsonBlock } from "./highlight.js";
+import { hubLinks, renderShell, viewHelpers } from "./render.js";
 
-/**
- * The MCP docs page. Rendered as a self-contained HTML document that reuses the
- * site's compiled stylesheet, fonts, and chrome (header/footer/theme) so it is
- * visually identical to every other page — but has no ejs/filesystem dependency,
- * so the Vercel function serving `/mcp` can return it for a browser GET.
- */
-export function renderMcpHtml(): string {
-  const clientButtons = MCP_CLIENTS.map(
-    (client, i) => `
-        <button
-          type="button"
-          data-mcp-client="${client.id}"
-          class="inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-colors ${i === 0 ? "border-slate-900 bg-slate-900 text-white dark:border-white dark:bg-white dark:text-slate-900" : "border-slate-300 text-slate-700 hover:border-slate-500 dark:border-slate-700 dark:text-slate-300"}"
-        >
-          <span class="provider-logo inline-flex h-4 w-4 shrink-0 items-center justify-center" aria-hidden="true">${client.logo}</span>
-          ${esc(client.name)}
-        </button>`,
-  ).join("");
+const MCP_TITLE = `MCP server · ${SITE_NAME}`;
+const MCP_DESCRIPTION =
+  "A Model Context Protocol server for the modelparams.dev catalog — let a coding agent check which parameters a model accepts before it calls one.";
 
-  const clientPanels = MCP_CLIENTS.map(
-    (client, i) => `
-        <div data-mcp-panel="${client.id}" class="${i === 0 ? "" : "hidden"}">
-          ${client.note ? `<p class="mb-2 text-sm text-slate-500 dark:text-slate-400">${esc(client.note)}</p>` : ""}
-          <div class="flex items-center border-2 border-slate-700 bg-slate-800 px-5 py-3 dark:border-slate-500 dark:bg-slate-900">
-            <pre class="flex-1 overflow-x-auto font-mono text-sm text-slate-200"><code data-mcp-command="${client.id}">${esc(client.command)}</code></pre>
-            <button
-              type="button"
-              data-copy-mcp="${client.id}"
-              aria-label="Copy to clipboard"
-              class="group ml-6 shrink-0 text-slate-400 hover:text-white"
-            >
-              <svg viewBox="0 0 16 16" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" data-copy-mcp-idle>
-                <rect x="5" y="5" width="9" height="9" rx="1" />
-                <path d="M5 11H3.5A1.5 1.5 0 012 9.5v-7A1.5 1.5 0 013.5 1h7A1.5 1.5 0 0112 2.5V5" />
-              </svg>
-              <svg viewBox="0 0 16 16" class="hidden h-4 w-4 text-emerald-400" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" data-copy-mcp-done>
-                <path stroke-linecap="round" stroke-linejoin="round" d="M3.5 8.5l3 3 6-6" />
-              </svg>
-            </button>
-          </div>
-        </div>`,
-  ).join("");
+export async function renderMcpPage(allModels: Model[]): Promise<string> {
+  const body = await ejs.renderFile(path.join(VIEWS_DIR, "mcp.ejs"), {
+    clients: MCP_CLIENTS,
+    tools: MCP_TOOLS,
+    jsonBlock,
+    helpers: viewHelpers,
+  });
 
-  const toolSections = MCP_TOOLS.map(
-    (tool) => `
-      <div id="${esc(tool.name)}" class="border-l-2 border-slate-200 pl-5 dark:border-slate-800">
-        <h3 class="font-mono text-base font-semibold text-slate-900 dark:text-slate-100">${esc(tool.name)}</h3>
-        <p class="mt-1.5 text-sm text-slate-600 dark:text-slate-300">${esc(tool.description)}</p>
-        <div class="mt-4 space-y-4">
-          ${jsonBlock(JSON.stringify(tool.inputSchema, null, 2), "Input")}
-          ${jsonBlock(JSON.stringify(tool.example, null, 2), "Example output")}
-        </div>
-      </div>`,
-  ).join("");
-
-  return `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>MCP server · modelparams.dev</title>
-  <meta name="description" content="A Model Context Protocol server for the modelparams.dev catalog — let a coding agent check which parameters a model accepts before it calls one." />
-  <link rel="canonical" href="https://modelparams.dev/mcp" />
-  <link rel="alternate" type="text/markdown" href="/llms.txt" title="LLM-friendly site overview" />
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="MCP server · modelparams.dev" />
-  <meta property="og:description" content="A Model Context Protocol server for the modelparams.dev catalog." />
-  <meta property="og:url" content="https://modelparams.dev/mcp" />
-  <meta property="og:site_name" content="modelparams.dev" />
-  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&family=Ovo&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/assets/styles.css" />
-  <script>
-    (function () {
-      try {
-        var stored = localStorage.getItem("mp-theme");
-        var prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-        document.documentElement.classList.toggle("dark", (stored || (prefersDark ? "dark" : "light")) === "dark");
-      } catch (_e) {}
-    })();
-  </script>
-</head>
-<body class="bg-site text-slate-900 dark:text-slate-100 antialiased">
-
-<header class="relative border-b border-slate-200 dark:border-slate-800">
-  <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:px-8">
-    <a href="/" class="flex items-center gap-2 font-semibold tracking-tight">
-      <span class="logo-gradient inline-flex h-7 w-7 items-center justify-center rounded-md" aria-hidden="true">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4">
-          <g fill="white" opacity="0.7"><path d="M8 16A2 2 0 1 0 8 20 2 2 0 1 0 8 16z"/><path d="m8,11h8c2.76,0,5-2.24,5-5s-2.24-5-5-5h-8c-2.76,0-5,2.24-5,5s2.24,5,5,5Zm8-7.5c1.36,0,2.5,1.14,2.5,2.5s-1.14,2.5-2.5,2.5-2.5-1.14-2.5-2.5,1.14-2.5,2.5-2.5Z"/></g>
-          <g fill="white"><path d="m16,13h-8c-2.76,0-5,2.24-5,5s2.24,5,5,5h8c2.76,0,5-2.24,5-5s-2.24-5-5-5Zm0,8h-8c-1.65,0-3-1.35-3-3s1.35-3,3-3h8c1.65,0,3,1.35,3,3s-1.35,3-3,3Z"/></g>
-        </svg>
-      </span>
-      <span class="text-base sm:text-lg">modelparams.dev</span>
-    </a>
-    <div class="flex items-center gap-1">
-      <nav class="hidden items-center gap-1 text-sm sm:flex">
-        <a href="/" class="rounded-md px-3 py-1.5 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">Catalog</a>
-        <a href="/api" class="rounded-md px-3 py-1.5 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">API</a>
-        <a href="/mcp" class="rounded-md px-3 py-1.5 text-slate-900 dark:text-white" aria-current="page">MCP</a>
-        <a href="https://github.com/mnfst/modelparams.dev" target="_blank" rel="noopener noreferrer" class="rounded-md px-3 py-1.5 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">GitHub</a>
-      </nav>
-      <button type="button" data-theme-toggle aria-label="Toggle dark mode" class="inline-flex h-9 w-9 items-center justify-center rounded-md text-slate-600 hover:bg-warm-hover dark:text-slate-300 dark:hover:bg-slate-800">
-        <svg class="h-4 w-4 dark:hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-          <circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
-        </svg>
-        <svg class="hidden h-4 w-4 dark:block" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-          <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z" />
-        </svg>
-      </button>
-    </div>
-  </div>
-</header>
-
-<main class="mx-auto max-w-6xl px-4 pb-24 sm:px-6 lg:px-8">
-  <nav class="pt-6 text-sm text-slate-500 dark:text-slate-400" aria-label="Breadcrumb">
-    <a href="/" class="hover:text-slate-900 dark:hover:text-white">Home</a>
-    <span class="mx-1">/</span>
-    <span class="text-slate-700 dark:text-slate-300">MCP</span>
-  </nav>
-
-  <section class="pt-6 pb-16">
-    <h1 class="tracking-tight">MCP server</h1>
-    <p class="mt-3 max-w-2xl text-pretty text-slate-600 dark:text-slate-300">
-      Give your coding agent the catalog, so it can check which parameters a model accepts
-      before it calls one — instead of guessing from training data and eating a 400, or worse,
-      having a parameter silently ignored. Hosted over Streamable HTTP, nothing to install.
-    </p>
-
-    <div class="mt-10 max-w-3xl space-y-12">
-      <section>
-        <h2 class="text-slate-900 dark:text-slate-100">Connect a client</h2>
-        <p class="mt-2 text-slate-600 dark:text-slate-300">
-          Endpoint: <code class="font-mono text-xs">${esc(MCP_ENDPOINT)}</code>. Pick a client to see its install command.
-        </p>
-        <div class="mt-4 flex flex-wrap gap-2">${clientButtons}</div>
-        <div class="mt-4">${clientPanels}</div>
-      </section>
-
-      <section>
-        <h2 class="text-slate-900 dark:text-slate-100">Tools</h2>
-        <p class="mt-2 text-slate-600 dark:text-slate-300">
-          Four read-only tools, all answering from the catalog this site is serving.
-        </p>
-        <div class="mt-4 space-y-10">${toolSections}</div>
-      </section>
-
-      <section>
-        <h2 class="text-slate-900 dark:text-slate-100">For agents</h2>
-        <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
-          Prefer a plain file? The whole catalog, including this MCP server, is described in
-          <a href="/llms.txt" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-hover">/llms.txt</a>
-          and
-          <a href="/llms-full.txt" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-hover">/llms-full.txt</a>.
-        </p>
-      </section>
-    </div>
-  </section>
-</main>
-
-<footer class="mt-16 border-t border-slate-200 dark:border-slate-800">
-  <div class="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
-    <div class="grid grid-cols-1 gap-8 sm:grid-cols-3">
-      <div>
-        <span class="text-sm font-semibold text-slate-900 dark:text-white">modelparams.dev</span>
-        <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">An open catalog of LLM API parameters.</p>
-      </div>
-      <div class="flex flex-col gap-2 text-sm">
-        <a href="/api" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">API</a>
-        <a href="/mcp" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">MCP server</a>
-        <a href="/glossary" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">Glossary</a>
-        <a href="/llms.txt" target="_blank" rel="noopener noreferrer" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">llms.txt</a>
-      </div>
-      <div class="flex flex-col gap-2 text-sm">
-        <a href="/" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">Full catalog</a>
-        <a href="https://www.npmjs.com/package/modelparams" target="_blank" rel="noopener noreferrer" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">npm package</a>
-        <a href="https://github.com/mnfst/modelparams.dev" target="_blank" rel="noopener noreferrer" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">GitHub</a>
-      </div>
-    </div>
-    <div class="mt-8 border-t border-slate-200 pt-6 text-center text-xs text-slate-400 dark:border-slate-800 dark:text-slate-500">
-      &copy; 2026 modelparams.dev &middot; MIT licensed
-    </div>
-  </div>
-</footer>
-
-<script>
-  (function () {
-    var toggle = document.querySelector("[data-theme-toggle]");
-    if (toggle) {
-      toggle.addEventListener("click", function () {
-        var isDark = document.documentElement.classList.toggle("dark");
-        try { localStorage.setItem("mp-theme", isDark ? "dark" : "light"); } catch (_e) {}
-      });
-    }
-
-    var buttons = document.querySelectorAll("[data-mcp-client]");
-    var panels = document.querySelectorAll("[data-mcp-panel]");
-    var activeClass = ["border-slate-900", "bg-slate-900", "text-white", "dark:border-white", "dark:bg-white", "dark:text-slate-900"];
-    var idleClass = ["border-slate-300", "text-slate-700", "hover:border-slate-500", "dark:border-slate-700", "dark:text-slate-300"];
-    buttons.forEach(function (button) {
-      button.addEventListener("click", function () {
-        var id = button.getAttribute("data-mcp-client");
-        buttons.forEach(function (b) {
-          var on = b === button;
-          b.classList.remove.apply(b.classList, on ? idleClass : activeClass);
-          b.classList.add.apply(b.classList, on ? activeClass : idleClass);
-        });
-        panels.forEach(function (p) { p.classList.toggle("hidden", p.getAttribute("data-mcp-panel") !== id); });
-      });
-    });
-
-    function copyText(text) {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        return navigator.clipboard.writeText(text).catch(function () { return legacyCopy(text); });
-      }
-      return Promise.resolve(legacyCopy(text));
-    }
-    function legacyCopy(text) {
-      var ta = document.createElement("textarea");
-      ta.value = text; ta.setAttribute("readonly", ""); ta.style.position = "fixed"; ta.style.opacity = "0";
-      document.body.appendChild(ta); ta.select();
-      var ok = false;
-      try { ok = document.execCommand("copy"); } catch (_e) {}
-      document.body.removeChild(ta);
-      return ok;
-    }
-    var copyButtons = document.querySelectorAll("[data-copy-mcp]");
-    copyButtons.forEach(function (button) {
-      button.addEventListener("click", function () {
-        var id = button.getAttribute("data-copy-mcp");
-        var code = document.querySelector('[data-mcp-command="' + id + '"]');
-        if (!code) return;
-        var idle = button.querySelector("[data-copy-mcp-idle]");
-        var done = button.querySelector("[data-copy-mcp-done]");
-        copyText(code.textContent.trim()).then(function () {
-          idle && idle.classList.add("hidden");
-          done && done.classList.remove("hidden");
-          setTimeout(function () { idle && idle.classList.remove("hidden"); done && done.classList.add("hidden"); }, 2000);
-        });
-      });
-    });
-
-    document.querySelectorAll("[data-json-copy]").forEach(function (button) {
-      button.addEventListener("click", function () {
-        var figure = button.closest("figure");
-        var code = figure && figure.querySelector("code");
-        if (!code) return;
-        copyText(code.textContent.trim()).then(function () {
-          var original = button.textContent;
-          button.textContent = "Copied";
-          setTimeout(function () { button.textContent = original; }, 2000);
-        });
-      });
-    });
-  })();
-</script>
-</body>
-</html>`;
-}
-
-function esc(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+  return renderShell(
+    {
+      title: MCP_TITLE,
+      description: MCP_DESCRIPTION,
+      canonicalUrl: absolute(SITE_URL, MCP_PATH),
+      ogImage: ogImagePath(MCP_PATH),
+      structuredData: "{}",
+      providerHubs: hubLinks(allModels),
+    },
+    body,
+  );
 }

--- a/src/build/render-mcp.ts
+++ b/src/build/render-mcp.ts
@@ -1,4 +1,5 @@
 import { MCP_CLIENTS, MCP_ENDPOINT, MCP_TOOLS } from "../data/mcp.js";
+import { highlightJson } from "./highlight.js";
 
 /**
  * The MCP docs page. Rendered as a self-contained HTML document that reuses the
@@ -51,11 +52,11 @@ export function renderMcpHtml(): string {
         <div class="mt-4 grid gap-4 lg:grid-cols-2">
           <div>
             <p class="mb-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">Input</p>
-            <pre class="overflow-x-auto border border-slate-200 bg-slate-50 px-4 py-3 font-mono text-xs leading-relaxed text-slate-700 dark:border-slate-800 dark:bg-[#0d0d0d] dark:text-slate-300"><code>${esc(JSON.stringify(tool.inputSchema, null, 2))}</code></pre>
+            <pre class="overflow-x-auto border border-slate-200 bg-slate-900 px-4 py-3 font-mono text-xs leading-relaxed text-slate-200 dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code>${highlightJson(JSON.stringify(tool.inputSchema, null, 2))}</code></pre>
           </div>
           <div>
             <p class="mb-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">Example output</p>
-            <pre class="overflow-x-auto border border-slate-200 bg-slate-50 px-4 py-3 font-mono text-xs leading-relaxed text-slate-700 dark:border-slate-800 dark:bg-[#0d0d0d] dark:text-slate-300"><code>${esc(JSON.stringify(tool.example, null, 2))}</code></pre>
+            <pre class="overflow-x-auto border border-slate-200 bg-slate-900 px-4 py-3 font-mono text-xs leading-relaxed text-slate-200 dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code>${highlightJson(JSON.stringify(tool.example, null, 2))}</code></pre>
           </div>
         </div>
       </div>`,

--- a/src/build/render-mcp.ts
+++ b/src/build/render-mcp.ts
@@ -1,5 +1,5 @@
 import { MCP_CLIENTS, MCP_ENDPOINT, MCP_TOOLS } from "../data/mcp.js";
-import { highlightJson } from "./highlight.js";
+import { jsonBlock } from "./highlight.js";
 
 /**
  * The MCP docs page. Rendered as a self-contained HTML document that reuses the
@@ -49,15 +49,9 @@ export function renderMcpHtml(): string {
       <div id="${esc(tool.name)}" class="border-l-2 border-slate-200 pl-5 dark:border-slate-800">
         <h3 class="font-mono text-base font-semibold text-slate-900 dark:text-slate-100">${esc(tool.name)}</h3>
         <p class="mt-1.5 text-sm text-slate-600 dark:text-slate-300">${esc(tool.description)}</p>
-        <div class="mt-4 grid gap-4 lg:grid-cols-2">
-          <div>
-            <p class="mb-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">Input</p>
-            <pre class="overflow-x-auto border border-slate-200 bg-slate-900 px-4 py-3 font-mono text-xs leading-relaxed text-slate-200 dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code>${highlightJson(JSON.stringify(tool.inputSchema, null, 2))}</code></pre>
-          </div>
-          <div>
-            <p class="mb-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">Example output</p>
-            <pre class="overflow-x-auto border border-slate-200 bg-slate-900 px-4 py-3 font-mono text-xs leading-relaxed text-slate-200 dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code>${highlightJson(JSON.stringify(tool.example, null, 2))}</code></pre>
-          </div>
+        <div class="mt-4 space-y-4">
+          ${jsonBlock(JSON.stringify(tool.inputSchema, null, 2), "Input")}
+          ${jsonBlock(JSON.stringify(tool.example, null, 2), "Example output")}
         </div>
       </div>`,
   ).join("");
@@ -247,6 +241,19 @@ export function renderMcpHtml(): string {
           idle && idle.classList.add("hidden");
           done && done.classList.remove("hidden");
           setTimeout(function () { idle && idle.classList.remove("hidden"); done && done.classList.add("hidden"); }, 2000);
+        });
+      });
+    });
+
+    document.querySelectorAll("[data-json-copy]").forEach(function (button) {
+      button.addEventListener("click", function () {
+        var figure = button.closest("figure");
+        var code = figure && figure.querySelector("code");
+        if (!code) return;
+        copyText(code.textContent.trim()).then(function () {
+          var original = button.textContent;
+          button.textContent = "Copied";
+          setTimeout(function () { button.textContent = original; }, 2000);
         });
       });
     });

--- a/src/build/render-mcp.ts
+++ b/src/build/render-mcp.ts
@@ -1,150 +1,223 @@
-import { MCP_CLIENTS, MCP_ENDPOINT, MCP_TOOLS, type McpClient } from "../data/mcp.js";
+import { MCP_CLIENTS, MCP_ENDPOINT, MCP_TOOLS } from "../data/mcp.js";
 
 /**
- * The MCP docs page as a fully self-contained HTML document — no external
- * stylesheet or script, so the Vercel function that serves the `/mcp` endpoint
- * can also answer a browser GET with this page without touching the static
- * build's filesystem.
+ * The MCP docs page. Rendered as a self-contained HTML document that reuses the
+ * site's compiled stylesheet, fonts, and chrome (header/footer/theme) so it is
+ * visually identical to every other page — but has no ejs/filesystem dependency,
+ * so the Vercel function serving `/mcp` can return it for a browser GET.
  */
 export function renderMcpHtml(): string {
-  const clients = MCP_CLIENTS;
-  const tools = MCP_TOOLS;
+  const clientButtons = MCP_CLIENTS.map(
+    (client, i) => `
+        <button
+          type="button"
+          data-mcp-client="${client.id}"
+          class="rounded-full border px-4 py-2 text-sm font-medium transition-colors ${i === 0 ? "border-slate-900 bg-slate-900 text-white dark:border-white dark:bg-white dark:text-slate-900" : "border-slate-300 text-slate-700 hover:border-slate-500 dark:border-slate-700 dark:text-slate-300"}"
+        >
+          ${esc(client.name)}
+        </button>`,
+  ).join("");
 
-  const clientButtons = clients
-    .map(
-      (client, i) => `
-        <button type="button" data-client="${client.id}" class="client${i === 0 ? " active" : ""}">${esc(client.name)}</button>`,
-    )
-    .join("");
-
-  const clientPanels = clients
-    .map(
-      (client, i) => `
-        <div class="panel${i === 0 ? "" : " hidden"}" data-panel="${client.id}">
-          ${client.note ? `<p class="note">${esc(client.note)}</p>` : ""}
-          <div class="cmd">
-            <pre><code data-cmd="${client.id}">${esc(client.command)}</code></pre>
-            <button type="button" class="copy" data-copy="${client.id}">Copy</button>
+  const clientPanels = MCP_CLIENTS.map(
+    (client, i) => `
+        <div data-mcp-panel="${client.id}" class="${i === 0 ? "" : "hidden"}">
+          ${client.note ? `<p class="mb-2 text-sm text-slate-500 dark:text-slate-400">${esc(client.note)}</p>` : ""}
+          <div class="flex items-center border-2 border-slate-700 bg-slate-800 px-5 py-3 dark:border-slate-500 dark:bg-slate-900">
+            <pre class="flex-1 overflow-x-auto font-mono text-sm text-slate-200"><code data-mcp-command="${client.id}">${esc(client.command)}</code></pre>
+            <button
+              type="button"
+              data-copy-mcp="${client.id}"
+              aria-label="Copy to clipboard"
+              class="group ml-6 shrink-0 text-slate-400 hover:text-white"
+            >
+              <svg viewBox="0 0 16 16" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" data-copy-mcp-idle>
+                <rect x="5" y="5" width="9" height="9" rx="1" />
+                <path d="M5 11H3.5A1.5 1.5 0 012 9.5v-7A1.5 1.5 0 013.5 1h7A1.5 1.5 0 0112 2.5V5" />
+              </svg>
+              <svg viewBox="0 0 16 16" class="hidden h-4 w-4 text-emerald-400" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" data-copy-mcp-done>
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3.5 8.5l3 3 6-6" />
+              </svg>
+            </button>
           </div>
         </div>`,
-    )
-    .join("");
+  ).join("");
 
-  const toolSections = tools
-    .map(
-      (tool) => `
-        <section class="tool" id="${esc(tool.name)}">
-          <h3><code>${esc(tool.name)}</code></h3>
-          <p class="desc">${esc(tool.description)}</p>
-          <div class="grid">
-            <div>
-              <p class="label">Input</p>
-              <pre><code>${esc(JSON.stringify(tool.inputSchema, null, 2))}</code></pre>
-            </div>
-            <div>
-              <p class="label">Example output</p>
-              <pre><code>${esc(JSON.stringify(tool.example, null, 2))}</code></pre>
-            </div>
+  const toolSections = MCP_TOOLS.map(
+    (tool) => `
+      <div id="${esc(tool.name)}" class="border-l-2 border-slate-200 pl-5 dark:border-slate-800">
+        <h3 class="font-mono text-base font-semibold text-slate-900 dark:text-slate-100">${esc(tool.name)}</h3>
+        <p class="mt-1.5 text-sm text-slate-600 dark:text-slate-300">${esc(tool.description)}</p>
+        <div class="mt-4 grid gap-4 lg:grid-cols-2">
+          <div>
+            <p class="mb-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">Input</p>
+            <pre class="overflow-x-auto border border-slate-200 bg-slate-50 px-4 py-3 font-mono text-xs leading-relaxed text-slate-700 dark:border-slate-800 dark:bg-[#0d0d0d] dark:text-slate-300"><code>${esc(JSON.stringify(tool.inputSchema, null, 2))}</code></pre>
           </div>
-        </section>`,
-    )
-    .join("");
+          <div>
+            <p class="mb-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">Example output</p>
+            <pre class="overflow-x-auto border border-slate-200 bg-slate-50 px-4 py-3 font-mono text-xs leading-relaxed text-slate-700 dark:border-slate-800 dark:bg-[#0d0d0d] dark:text-slate-300"><code>${esc(JSON.stringify(tool.example, null, 2))}</code></pre>
+          </div>
+        </div>
+      </div>`,
+  ).join("");
 
   return `<!doctype html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>MCP server · modelparams.dev</title>
-<meta name="description" content="A Model Context Protocol server for the modelparams.dev catalog — let a coding agent check which parameters a model accepts before it calls one." />
-<style>
-  :root { color-scheme: light dark; }
-  * { box-sizing: border-box; }
-  body { margin: 0; font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background: #fafafa; color: #1f2937; }
-  @media (prefers-color-scheme: dark) { body { background: #0d0d0d; color: #e5e7eb; } }
-  .wrap { max-width: 880px; margin: 0 auto; padding: 0 24px 80px; }
-  header { display: flex; align-items: center; justify-content: space-between; padding: 20px 24px; border-bottom: 1px solid #e5e7eb; }
-  @media (prefers-color-scheme: dark) { header { border-color: #262626; } }
-  .brand { font-weight: 700; letter-spacing: -0.02em; color: inherit; text-decoration: none; }
-  .brand span { opacity: 0.55; font-weight: 500; }
-  .home { color: #059669; text-decoration: none; font-size: 14px; }
-  h1 { font-size: 40px; line-height: 1.1; letter-spacing: -0.03em; margin: 48px 0 8px; }
-  .lede { color: #4b5563; max-width: 60ch; margin: 0 0 40px; }
-  @media (prefers-color-scheme: dark) { .lede { color: #9ca3af; } }
-  h2 { font-size: 22px; letter-spacing: -0.02em; margin: 40px 0 8px; }
-  .sub { color: #6b7280; font-size: 14px; margin: 0 0 16px; }
-  @media (prefers-color-scheme: dark) { .sub { color: #9ca3af; } }
-  code, pre { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace; }
-  .endpoint { display: inline-block; background: #1f2937; color: #e5e7eb; border-radius: 8px; padding: 8px 12px; font-size: 13px; }
-  @media (prefers-color-scheme: dark) { .endpoint { background: #1f1f1f; } }
-  .clients { display: flex; flex-wrap: wrap; gap: 8px; margin: 16px 0; }
-  .client { border: 1px solid #d1d5db; background: transparent; color: #374151; border-radius: 999px; padding: 8px 16px; font-size: 14px; cursor: pointer; }
-  @media (prefers-color-scheme: dark) { .client { border-color: #374151; color: #d1d5db; } }
-  .client.active { background: #1f2937; color: #fff; border-color: #1f2937; }
-  @media (prefers-color-scheme: dark) { .client.active { background: #e5e7eb; color: #111; border-color: #e5e7eb; } }
-  .hidden { display: none; }
-  .note { color: #6b7280; font-size: 13px; margin: 0 0 8px; }
-  .cmd { display: flex; align-items: stretch; border: 1px solid #e5e7eb; border-radius: 8px; overflow: hidden; }
-  @media (prefers-color-scheme: dark) { .cmd { border-color: #262626; } }
-  .cmd pre { margin: 0; padding: 14px 16px; flex: 1; overflow-x: auto; background: #1f2937; color: #e5e7eb; font-size: 13px; }
-  @media (prefers-color-scheme: dark) { .cmd pre { background: #1f1f1f; } }
-  .copy { border: none; border-left: 1px solid #374151; background: #1f2937; color: #9ca3af; padding: 0 18px; font-size: 13px; cursor: pointer; }
-  @media (prefers-color-scheme: dark) { .copy { background: #1f1f1f; } }
-  .copy:hover { color: #fff; }
-  .tool { border-left: 3px solid #e5e7eb; padding-left: 20px; margin: 28px 0; }
-  @media (prefers-color-scheme: dark) { .tool { border-color: #262626; } }
-  .tool h3 { margin: 0 0 6px; font-size: 17px; }
-  .tool h3 code { color: #059669; }
-  .desc { color: #4b5563; font-size: 14px; margin: 0 0 14px; }
-  @media (prefers-color-scheme: dark) { .desc { color: #9ca3af; } }
-  .grid { display: grid; gap: 16px; grid-template-columns: 1fr; }
-  @media (min-width: 760px) { .grid { grid-template-columns: 1fr 1fr; } }
-  .label { font-size: 11px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: #9ca3af; margin: 0 0 6px; }
-  .grid pre { margin: 0; padding: 14px 16px; background: #f3f4f6; border-radius: 8px; overflow-x: auto; font-size: 12px; line-height: 1.5; color: #1f2937; }
-  @media (prefers-color-scheme: dark) { .grid pre { background: #1f1f1f; color: #d1d5db; } }
-  footer { margin-top: 56px; padding-top: 20px; border-top: 1px solid #e5e7eb; color: #6b7280; font-size: 14px; }
-  @media (prefers-color-scheme: dark) { footer { border-color: #262626; } }
-  a { color: #059669; }
-</style>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MCP server · modelparams.dev</title>
+  <meta name="description" content="A Model Context Protocol server for the modelparams.dev catalog — let a coding agent check which parameters a model accepts before it calls one." />
+  <link rel="canonical" href="https://modelparams.dev/mcp" />
+  <link rel="alternate" type="text/markdown" href="/llms.txt" title="LLM-friendly site overview" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="MCP server · modelparams.dev" />
+  <meta property="og:description" content="A Model Context Protocol server for the modelparams.dev catalog." />
+  <meta property="og:url" content="https://modelparams.dev/mcp" />
+  <meta property="og:site_name" content="modelparams.dev" />
+  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&family=Ovo&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/assets/styles.css" />
+  <script>
+    (function () {
+      try {
+        var stored = localStorage.getItem("mp-theme");
+        var prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+        document.documentElement.classList.toggle("dark", (stored || (prefersDark ? "dark" : "light")) === "dark");
+      } catch (_e) {}
+    })();
+  </script>
 </head>
-<body>
-<header>
-  <a class="brand" href="/">modelparams.dev <span>/ MCP server</span></a>
-  <a class="home" href="/">← Back to catalog</a>
+<body class="bg-site text-slate-900 dark:text-slate-100 antialiased">
+
+<header class="relative border-b border-slate-200 dark:border-slate-800">
+  <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:px-8">
+    <a href="/" class="flex items-center gap-2 font-semibold tracking-tight">
+      <span class="logo-gradient inline-flex h-7 w-7 items-center justify-center rounded-md" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4">
+          <g fill="white" opacity="0.7"><path d="M8 16A2 2 0 1 0 8 20 2 2 0 1 0 8 16z"/><path d="m8,11h8c2.76,0,5-2.24,5-5s-2.24-5-5-5h-8c-2.76,0-5,2.24-5,5s2.24,5,5,5Zm8-7.5c1.36,0,2.5,1.14,2.5,2.5s-1.14,2.5-2.5,2.5-2.5-1.14-2.5-2.5,1.14-2.5,2.5-2.5Z"/></g>
+          <g fill="white"><path d="m16,13h-8c-2.76,0-5,2.24-5,5s2.24,5,5,5h8c2.76,0,5-2.24,5-5s-2.24-5-5-5Zm0,8h-8c-1.65,0-3-1.35-3-3s1.35-3,3-3h8c1.65,0,3,1.35,3,3s-1.35,3-3,3Z"/></g>
+        </svg>
+      </span>
+      <span class="text-base sm:text-lg">modelparams.dev</span>
+    </a>
+    <div class="flex items-center gap-1">
+      <nav class="hidden items-center gap-1 text-sm sm:flex">
+        <a href="/" class="rounded-md px-3 py-1.5 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">Catalog</a>
+        <a href="/api" class="rounded-md px-3 py-1.5 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">API</a>
+        <a href="/mcp" class="rounded-md px-3 py-1.5 text-slate-900 dark:text-white" aria-current="page">MCP</a>
+        <a href="https://github.com/mnfst/modelparams.dev" target="_blank" rel="noopener noreferrer" class="rounded-md px-3 py-1.5 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">GitHub</a>
+      </nav>
+      <button type="button" data-theme-toggle aria-label="Toggle dark mode" class="inline-flex h-9 w-9 items-center justify-center rounded-md text-slate-600 hover:bg-warm-hover dark:text-slate-300 dark:hover:bg-slate-800">
+        <svg class="h-4 w-4 dark:hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+        </svg>
+        <svg class="hidden h-4 w-4 dark:block" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z" />
+        </svg>
+      </button>
+    </div>
+  </div>
 </header>
-<div class="wrap">
-  <h1>MCP server</h1>
-  <p class="lede">Give your coding agent the catalog, so it can check which parameters a model accepts before it calls one — instead of guessing from training data and eating a 400, or worse, having a parameter silently ignored. Hosted over Streamable HTTP, nothing to install.</p>
 
-  <p class="label">Endpoint</p>
-  <code class="endpoint">${esc(MCP_ENDPOINT)}</code>
+<main class="mx-auto max-w-6xl px-4 pb-24 sm:px-6 lg:px-8">
+  <nav class="pt-6 text-sm text-slate-500 dark:text-slate-400" aria-label="Breadcrumb">
+    <a href="/" class="hover:text-slate-900 dark:hover:text-white">Home</a>
+    <span class="mx-1">/</span>
+    <span class="text-slate-700 dark:text-slate-300">MCP</span>
+  </nav>
 
-  <h2>Connect a client</h2>
-  <p class="sub">Pick a client to see its install command.</p>
-  <div class="clients">${clientButtons}</div>
-  ${clientPanels}
+  <section class="pt-6 pb-16">
+    <h1 class="tracking-tight">MCP server</h1>
+    <p class="mt-3 max-w-2xl text-pretty text-slate-600 dark:text-slate-300">
+      Give your coding agent the catalog, so it can check which parameters a model accepts
+      before it calls one — instead of guessing from training data and eating a 400, or worse,
+      having a parameter silently ignored. Hosted over Streamable HTTP, nothing to install.
+    </p>
 
-  <h2>Tools</h2>
-  <p class="sub">Four read-only tools, all answering from the catalog this site is serving.</p>
-  ${toolSections}
+    <div class="mt-10 max-w-3xl space-y-12">
+      <section>
+        <h2 class="text-slate-900 dark:text-slate-100">Connect a client</h2>
+        <p class="mt-2 text-slate-600 dark:text-slate-300">
+          Endpoint: <code class="font-mono text-xs">${esc(MCP_ENDPOINT)}</code>. Pick a client to see its install command.
+        </p>
+        <div class="mt-4 flex flex-wrap gap-2">${clientButtons}</div>
+        <div class="mt-4">${clientPanels}</div>
+      </section>
 
-  <footer>
-    Prefer a plain file? The whole catalog, including this MCP server, is described in
-    <a href="/llms.txt">/llms.txt</a> and <a href="/llms-full.txt">/llms-full.txt</a>.
-  </footer>
-</div>
+      <section>
+        <h2 class="text-slate-900 dark:text-slate-100">Tools</h2>
+        <p class="mt-2 text-slate-600 dark:text-slate-300">
+          Four read-only tools, all answering from the catalog this site is serving.
+        </p>
+        <div class="mt-4 space-y-10">${toolSections}</div>
+      </section>
+
+      <section>
+        <h2 class="text-slate-900 dark:text-slate-100">For agents</h2>
+        <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Prefer a plain file? The whole catalog, including this MCP server, is described in
+          <a href="/llms.txt" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-hover">/llms.txt</a>
+          and
+          <a href="/llms-full.txt" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-hover">/llms-full.txt</a>.
+        </p>
+      </section>
+    </div>
+  </section>
+</main>
+
+<footer class="mt-16 border-t border-slate-200 dark:border-slate-800">
+  <div class="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+    <div class="grid grid-cols-1 gap-8 sm:grid-cols-3">
+      <div>
+        <span class="text-sm font-semibold text-slate-900 dark:text-white">modelparams.dev</span>
+        <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">An open catalog of LLM API parameters.</p>
+      </div>
+      <div class="flex flex-col gap-2 text-sm">
+        <a href="/api" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">API</a>
+        <a href="/mcp" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">MCP server</a>
+        <a href="/glossary" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">Glossary</a>
+        <a href="/llms.txt" target="_blank" rel="noopener noreferrer" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">llms.txt</a>
+      </div>
+      <div class="flex flex-col gap-2 text-sm">
+        <a href="/" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">Full catalog</a>
+        <a href="https://www.npmjs.com/package/modelparams" target="_blank" rel="noopener noreferrer" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">npm package</a>
+        <a href="https://github.com/mnfst/modelparams.dev" target="_blank" rel="noopener noreferrer" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">GitHub</a>
+      </div>
+    </div>
+    <div class="mt-8 border-t border-slate-200 pt-6 text-center text-xs text-slate-400 dark:border-slate-800 dark:text-slate-500">
+      &copy; 2026 modelparams.dev &middot; MIT licensed
+    </div>
+  </div>
+</footer>
+
 <script>
   (function () {
-    var clients = document.querySelectorAll("[data-client]");
-    var panels = document.querySelectorAll("[data-panel]");
-    var copyButtons = document.querySelectorAll("[data-copy]");
-    clients.forEach(function (btn) {
-      btn.addEventListener("click", function () {
-        var id = btn.getAttribute("data-client");
-        clients.forEach(function (b) { b.classList.toggle("active", b === btn); });
-        panels.forEach(function (p) { p.classList.toggle("hidden", p.getAttribute("data-panel") !== id); });
+    var toggle = document.querySelector("[data-theme-toggle]");
+    if (toggle) {
+      toggle.addEventListener("click", function () {
+        var isDark = document.documentElement.classList.toggle("dark");
+        try { localStorage.setItem("mp-theme", isDark ? "dark" : "light"); } catch (_e) {}
+      });
+    }
+
+    var buttons = document.querySelectorAll("[data-mcp-client]");
+    var panels = document.querySelectorAll("[data-mcp-panel]");
+    var activeClass = ["border-slate-900", "bg-slate-900", "text-white", "dark:border-white", "dark:bg-white", "dark:text-slate-900"];
+    var idleClass = ["border-slate-300", "text-slate-700", "hover:border-slate-500", "dark:border-slate-700", "dark:text-slate-300"];
+    buttons.forEach(function (button) {
+      button.addEventListener("click", function () {
+        var id = button.getAttribute("data-mcp-client");
+        buttons.forEach(function (b) {
+          var on = b === button;
+          b.classList.remove.apply(b.classList, on ? idleClass : activeClass);
+          b.classList.add.apply(b.classList, on ? activeClass : idleClass);
+        });
+        panels.forEach(function (p) { p.classList.toggle("hidden", p.getAttribute("data-mcp-panel") !== id); });
       });
     });
+
     function copyText(text) {
       if (navigator.clipboard && navigator.clipboard.writeText) {
         return navigator.clipboard.writeText(text).catch(function () { return legacyCopy(text); });
@@ -156,19 +229,22 @@ export function renderMcpHtml(): string {
       ta.value = text; ta.setAttribute("readonly", ""); ta.style.position = "fixed"; ta.style.opacity = "0";
       document.body.appendChild(ta); ta.select();
       var ok = false;
-      try { ok = document.execCommand("copy"); } catch (e) {}
+      try { ok = document.execCommand("copy"); } catch (_e) {}
       document.body.removeChild(ta);
       return ok;
     }
-    copyButtons.forEach(function (btn) {
-      btn.addEventListener("click", function () {
-        var id = btn.getAttribute("data-copy");
-        var code = document.querySelector('[data-cmd="' + id + '"]');
+    var copyButtons = document.querySelectorAll("[data-copy-mcp]");
+    copyButtons.forEach(function (button) {
+      button.addEventListener("click", function () {
+        var id = button.getAttribute("data-copy-mcp");
+        var code = document.querySelector('[data-mcp-command="' + id + '"]');
         if (!code) return;
+        var idle = button.querySelector("[data-copy-mcp-idle]");
+        var done = button.querySelector("[data-copy-mcp-done]");
         copyText(code.textContent.trim()).then(function () {
-          var original = btn.textContent;
-          btn.textContent = "Copied";
-          setTimeout(function () { btn.textContent = original; }, 2000);
+          idle && idle.classList.add("hidden");
+          done && done.classList.remove("hidden");
+          setTimeout(function () { idle && idle.classList.remove("hidden"); done && done.classList.add("hidden"); }, 2000);
         });
       });
     });

--- a/src/build/render-mcp.ts
+++ b/src/build/render-mcp.ts
@@ -12,8 +12,9 @@ export function renderMcpHtml(): string {
         <button
           type="button"
           data-mcp-client="${client.id}"
-          class="rounded-full border px-4 py-2 text-sm font-medium transition-colors ${i === 0 ? "border-slate-900 bg-slate-900 text-white dark:border-white dark:bg-white dark:text-slate-900" : "border-slate-300 text-slate-700 hover:border-slate-500 dark:border-slate-700 dark:text-slate-300"}"
+          class="inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-colors ${i === 0 ? "border-slate-900 bg-slate-900 text-white dark:border-white dark:bg-white dark:text-slate-900" : "border-slate-300 text-slate-700 hover:border-slate-500 dark:border-slate-700 dark:text-slate-300"}"
         >
+          <span class="provider-logo inline-flex h-4 w-4 shrink-0 items-center justify-center" aria-hidden="true">${client.logo}</span>
           ${esc(client.name)}
         </button>`,
   ).join("");

--- a/src/build/render-mcp.ts
+++ b/src/build/render-mcp.ts
@@ -1,0 +1,186 @@
+import { MCP_CLIENTS, MCP_ENDPOINT, MCP_TOOLS, type McpClient } from "../data/mcp.js";
+
+/**
+ * The MCP docs page as a fully self-contained HTML document — no external
+ * stylesheet or script, so the Vercel function that serves the `/mcp` endpoint
+ * can also answer a browser GET with this page without touching the static
+ * build's filesystem.
+ */
+export function renderMcpHtml(): string {
+  const clients = MCP_CLIENTS;
+  const tools = MCP_TOOLS;
+
+  const clientButtons = clients
+    .map(
+      (client, i) => `
+        <button type="button" data-client="${client.id}" class="client${i === 0 ? " active" : ""}">${esc(client.name)}</button>`,
+    )
+    .join("");
+
+  const clientPanels = clients
+    .map(
+      (client, i) => `
+        <div class="panel${i === 0 ? "" : " hidden"}" data-panel="${client.id}">
+          ${client.note ? `<p class="note">${esc(client.note)}</p>` : ""}
+          <div class="cmd">
+            <pre><code data-cmd="${client.id}">${esc(client.command)}</code></pre>
+            <button type="button" class="copy" data-copy="${client.id}">Copy</button>
+          </div>
+        </div>`,
+    )
+    .join("");
+
+  const toolSections = tools
+    .map(
+      (tool) => `
+        <section class="tool" id="${esc(tool.name)}">
+          <h3><code>${esc(tool.name)}</code></h3>
+          <p class="desc">${esc(tool.description)}</p>
+          <div class="grid">
+            <div>
+              <p class="label">Input</p>
+              <pre><code>${esc(JSON.stringify(tool.inputSchema, null, 2))}</code></pre>
+            </div>
+            <div>
+              <p class="label">Example output</p>
+              <pre><code>${esc(JSON.stringify(tool.example, null, 2))}</code></pre>
+            </div>
+          </div>
+        </section>`,
+    )
+    .join("");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>MCP server · modelparams.dev</title>
+<meta name="description" content="A Model Context Protocol server for the modelparams.dev catalog — let a coding agent check which parameters a model accepts before it calls one." />
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body { margin: 0; font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background: #fafafa; color: #1f2937; }
+  @media (prefers-color-scheme: dark) { body { background: #0d0d0d; color: #e5e7eb; } }
+  .wrap { max-width: 880px; margin: 0 auto; padding: 0 24px 80px; }
+  header { display: flex; align-items: center; justify-content: space-between; padding: 20px 24px; border-bottom: 1px solid #e5e7eb; }
+  @media (prefers-color-scheme: dark) { header { border-color: #262626; } }
+  .brand { font-weight: 700; letter-spacing: -0.02em; color: inherit; text-decoration: none; }
+  .brand span { opacity: 0.55; font-weight: 500; }
+  .home { color: #059669; text-decoration: none; font-size: 14px; }
+  h1 { font-size: 40px; line-height: 1.1; letter-spacing: -0.03em; margin: 48px 0 8px; }
+  .lede { color: #4b5563; max-width: 60ch; margin: 0 0 40px; }
+  @media (prefers-color-scheme: dark) { .lede { color: #9ca3af; } }
+  h2 { font-size: 22px; letter-spacing: -0.02em; margin: 40px 0 8px; }
+  .sub { color: #6b7280; font-size: 14px; margin: 0 0 16px; }
+  @media (prefers-color-scheme: dark) { .sub { color: #9ca3af; } }
+  code, pre { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace; }
+  .endpoint { display: inline-block; background: #1f2937; color: #e5e7eb; border-radius: 8px; padding: 8px 12px; font-size: 13px; }
+  @media (prefers-color-scheme: dark) { .endpoint { background: #1f1f1f; } }
+  .clients { display: flex; flex-wrap: wrap; gap: 8px; margin: 16px 0; }
+  .client { border: 1px solid #d1d5db; background: transparent; color: #374151; border-radius: 999px; padding: 8px 16px; font-size: 14px; cursor: pointer; }
+  @media (prefers-color-scheme: dark) { .client { border-color: #374151; color: #d1d5db; } }
+  .client.active { background: #1f2937; color: #fff; border-color: #1f2937; }
+  @media (prefers-color-scheme: dark) { .client.active { background: #e5e7eb; color: #111; border-color: #e5e7eb; } }
+  .hidden { display: none; }
+  .note { color: #6b7280; font-size: 13px; margin: 0 0 8px; }
+  .cmd { display: flex; align-items: stretch; border: 1px solid #e5e7eb; border-radius: 8px; overflow: hidden; }
+  @media (prefers-color-scheme: dark) { .cmd { border-color: #262626; } }
+  .cmd pre { margin: 0; padding: 14px 16px; flex: 1; overflow-x: auto; background: #1f2937; color: #e5e7eb; font-size: 13px; }
+  @media (prefers-color-scheme: dark) { .cmd pre { background: #1f1f1f; } }
+  .copy { border: none; border-left: 1px solid #374151; background: #1f2937; color: #9ca3af; padding: 0 18px; font-size: 13px; cursor: pointer; }
+  @media (prefers-color-scheme: dark) { .copy { background: #1f1f1f; } }
+  .copy:hover { color: #fff; }
+  .tool { border-left: 3px solid #e5e7eb; padding-left: 20px; margin: 28px 0; }
+  @media (prefers-color-scheme: dark) { .tool { border-color: #262626; } }
+  .tool h3 { margin: 0 0 6px; font-size: 17px; }
+  .tool h3 code { color: #059669; }
+  .desc { color: #4b5563; font-size: 14px; margin: 0 0 14px; }
+  @media (prefers-color-scheme: dark) { .desc { color: #9ca3af; } }
+  .grid { display: grid; gap: 16px; grid-template-columns: 1fr; }
+  @media (min-width: 760px) { .grid { grid-template-columns: 1fr 1fr; } }
+  .label { font-size: 11px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: #9ca3af; margin: 0 0 6px; }
+  .grid pre { margin: 0; padding: 14px 16px; background: #f3f4f6; border-radius: 8px; overflow-x: auto; font-size: 12px; line-height: 1.5; color: #1f2937; }
+  @media (prefers-color-scheme: dark) { .grid pre { background: #1f1f1f; color: #d1d5db; } }
+  footer { margin-top: 56px; padding-top: 20px; border-top: 1px solid #e5e7eb; color: #6b7280; font-size: 14px; }
+  @media (prefers-color-scheme: dark) { footer { border-color: #262626; } }
+  a { color: #059669; }
+</style>
+</head>
+<body>
+<header>
+  <a class="brand" href="/">modelparams.dev <span>/ MCP server</span></a>
+  <a class="home" href="/">← Back to catalog</a>
+</header>
+<div class="wrap">
+  <h1>MCP server</h1>
+  <p class="lede">Give your coding agent the catalog, so it can check which parameters a model accepts before it calls one — instead of guessing from training data and eating a 400, or worse, having a parameter silently ignored. Hosted over Streamable HTTP, nothing to install.</p>
+
+  <p class="label">Endpoint</p>
+  <code class="endpoint">${esc(MCP_ENDPOINT)}</code>
+
+  <h2>Connect a client</h2>
+  <p class="sub">Pick a client to see its install command.</p>
+  <div class="clients">${clientButtons}</div>
+  ${clientPanels}
+
+  <h2>Tools</h2>
+  <p class="sub">Four read-only tools, all answering from the catalog this site is serving.</p>
+  ${toolSections}
+
+  <footer>
+    Prefer a plain file? The whole catalog, including this MCP server, is described in
+    <a href="/llms.txt">/llms.txt</a> and <a href="/llms-full.txt">/llms-full.txt</a>.
+  </footer>
+</div>
+<script>
+  (function () {
+    var clients = document.querySelectorAll("[data-client]");
+    var panels = document.querySelectorAll("[data-panel]");
+    var copyButtons = document.querySelectorAll("[data-copy]");
+    clients.forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var id = btn.getAttribute("data-client");
+        clients.forEach(function (b) { b.classList.toggle("active", b === btn); });
+        panels.forEach(function (p) { p.classList.toggle("hidden", p.getAttribute("data-panel") !== id); });
+      });
+    });
+    function copyText(text) {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).catch(function () { return legacyCopy(text); });
+      }
+      return Promise.resolve(legacyCopy(text));
+    }
+    function legacyCopy(text) {
+      var ta = document.createElement("textarea");
+      ta.value = text; ta.setAttribute("readonly", ""); ta.style.position = "fixed"; ta.style.opacity = "0";
+      document.body.appendChild(ta); ta.select();
+      var ok = false;
+      try { ok = document.execCommand("copy"); } catch (e) {}
+      document.body.removeChild(ta);
+      return ok;
+    }
+    copyButtons.forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var id = btn.getAttribute("data-copy");
+        var code = document.querySelector('[data-cmd="' + id + '"]');
+        if (!code) return;
+        copyText(code.textContent.trim()).then(function () {
+          var original = btn.textContent;
+          btn.textContent = "Copied";
+          setTimeout(function () { btn.textContent = original; }, 2000);
+        });
+      });
+    });
+  })();
+</script>
+</body>
+</html>`;
+}
+
+function esc(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/src/build/render.ts
+++ b/src/build/render.ts
@@ -27,6 +27,7 @@ import {
 } from "../data/urls.js";
 import { modelId, type Catalog, type Model } from "../schema/model.js";
 import { fitDescription, fitTitle } from "./meta.js";
+import { highlightJson } from "./highlight.js";
 import { buildHomeStructuredData } from "./structured-data.js";
 
 const LAYOUT_PATH = path.join(VIEWS_DIR, "layout.ejs");
@@ -49,6 +50,7 @@ export const viewHelpers = {
   parameterPagePath,
   parameterAnchorId,
   providerPagePath,
+  highlightJson,
 };
 
 export interface HubLink {

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -117,6 +117,76 @@ function setupCopyNpm(): void {
   });
 }
 
+function setupMcpClients(): void {
+  const buttons = document.querySelectorAll<HTMLButtonElement>("[data-mcp-client]");
+  const panels = document.querySelectorAll<HTMLElement>("[data-mcp-panel]");
+  if (buttons.length === 0) return;
+
+  const activeClass = [
+    "border-slate-900",
+    "bg-slate-900",
+    "text-white",
+    "dark:border-white",
+    "dark:bg-white",
+    "dark:text-slate-900",
+  ];
+  const idleClass = [
+    "border-slate-300",
+    "text-slate-700",
+    "hover:border-slate-500",
+    "dark:border-slate-700",
+    "dark:text-slate-300",
+  ];
+
+  buttons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const id = button.dataset.mcpClient;
+      buttons.forEach((b) => {
+        const on = b === button;
+        b.classList.remove(...(on ? idleClass : activeClass));
+        b.classList.add(...(on ? activeClass : idleClass));
+      });
+      panels.forEach((panel) => panel.classList.toggle("hidden", panel.dataset.mcpPanel !== id));
+    });
+  });
+
+  const copyButtons = document.querySelectorAll<HTMLButtonElement>("[data-copy-mcp]");
+  copyButtons.forEach((button) => {
+    const idle = button.querySelector<HTMLElement>("[data-copy-mcp-idle]");
+    const done = button.querySelector<HTMLElement>("[data-copy-mcp-done]");
+    let timer = 0;
+    button.addEventListener("click", async () => {
+      const code = document.querySelector<HTMLElement>(
+        `[data-mcp-command="${button.dataset.copyMcp}"]`,
+      );
+      if (!code) return;
+      await copyText(code.textContent?.trim() ?? "");
+      idle?.classList.add("hidden");
+      done?.classList.remove("hidden");
+      window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        idle?.classList.remove("hidden");
+        done?.classList.add("hidden");
+      }, 2000);
+    });
+  });
+}
+
+function setupJsonCopy(): void {
+  document.querySelectorAll<HTMLButtonElement>("[data-json-copy]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const code = button.closest("figure")?.querySelector("code");
+      if (!code) return;
+      await copyText(code.textContent?.trim() ?? "");
+      const original = button.textContent;
+      button.textContent = "Copied";
+      window.setTimeout(() => {
+        button.textContent = original;
+      }, 2000);
+    });
+  });
+}
+
 function setupThemeToggle(): void {
   const toggle = document.querySelector<HTMLButtonElement>("[data-theme-toggle]");
   if (!toggle) return;
@@ -534,6 +604,8 @@ function setupMobileMenu(): void {
 document.addEventListener("DOMContentLoaded", () => {
   setupThemeToggle();
   setupCopyNpm();
+  setupMcpClients();
+  setupJsonCopy();
   setupHowToUseModal();
   setupCopyHowToUse();
   setupProvidersMenu();

--- a/src/data/mcp.ts
+++ b/src/data/mcp.ts
@@ -123,17 +123,16 @@ export const MCP_TOOLS: McpTool[] = [
       properties: {
         model: {
           ...STRING,
-          description:
-            "Catalog id or bare model slug, or with baseUrl the wire string your SDK sends.",
+          description: "Catalog id, bare slug, or wire string with baseUrl.",
         },
         baseUrl: {
           ...OPTIONAL_STRING,
-          description: 'The base URL your SDK uses, e.g. "https://api.fireworks.ai/inference/v1".',
+          description: "The base URL your SDK uses.",
         },
         params: {
           type: "object",
           additionalProperties: true,
-          description: 'Provider-native parameter paths to values, e.g. {"temperature": 0.7}.',
+          description: "Provider-native parameter paths to values.",
         },
       },
       required: ["model"],
@@ -166,8 +165,7 @@ export const MCP_TOOLS: McpTool[] = [
       properties: {
         model: {
           ...STRING,
-          description:
-            "Catalog id or bare model slug, or with baseUrl the wire string your SDK sends.",
+          description: "Catalog id, bare slug, or wire string with baseUrl.",
         },
         baseUrl: { ...OPTIONAL_STRING, description: "The base URL your SDK uses." },
       },

--- a/src/data/mcp.ts
+++ b/src/data/mcp.ts
@@ -89,7 +89,7 @@ export const MCP_CLIENTS: McpClient[] = [
   },
   {
     id: "other",
-    name: "Claude Desktop, Zed, …",
+    name: "Other",
     logo: GENERIC_LOGO,
     kind: "json",
     command: MCP_SERVERS_JSON,

--- a/src/data/mcp.ts
+++ b/src/data/mcp.ts
@@ -4,28 +4,61 @@ export const MCP_ENDPOINT = "https://modelparams.dev/mcp";
 export interface McpClient {
   id: string;
   name: string;
+  /** Inline SVG logo (monochrome `currentColor` or brand colors). */
+  logo: string;
   /** How the install instruction is shown: a one-liner or a JSON config. */
   kind: "cli" | "json";
   command: string;
   note?: string;
 }
 
+const CLAUDE_CODE_LOGO =
+  '<svg height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="M20.998 10.949H24v3.102h-3v3.028h-1.487V20H18v-2.921h-1.487V20H15v-2.921H9V20H7.488v-2.921H6V20H4.487v-2.921H3V14.05H0V10.95h3V5h17.998v5.949zM6 10.949h1.488V8.102H6v2.847zm10.51 0H18V8.102h-1.49v2.847z" fill="#D97757" fill-rule="evenodd"></path></svg>';
+
+const CODEX_LOGO =
+  '<svg height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M19.503 0H4.496A4.496 4.496 0 000 4.496v15.007A4.496 4.496 0 004.496 24h15.007A4.496 4.496 0 0024 19.503V4.496A4.496 4.496 0 0019.503 0z" fill="#fff"></path><path d="M9.064 3.344a4.578 4.578 0 012.285-.312c1 .115 1.891.54 2.673 1.275.01.01.024.017.037.021a.09.09 0 00.043 0 4.55 4.55 0 013.046.275l.047.022.116.057a4.581 4.581 0 012.188 2.399c.209.51.313 1.041.315 1.595a4.24 4.24 0 01-.134 1.223.123.123 0 00.03.115c.594.607.988 1.33 1.183 2.17.289 1.425-.007 2.71-.887 3.854l-.136.166a4.548 4.548 0 01-2.201 1.388.123.123 0 00-.081.076c-.191.551-.383 1.023-.74 1.494-.9 1.187-2.222 1.846-3.711 1.838-1.187-.006-2.239-.44-3.157-1.302a.107.107 0 00-.105-.024c-.388.125-.78.143-1.204.138a4.441 4.441 0 01-1.945-.466 4.544 4.544 0 01-1.61-1.335c-.152-.202-.303-.392-.414-.617a5.81 5.81 0 01-.37-.961 4.582 4.582 0 01-.014-2.298.124.124 0 00.006-.056.085.085 0 00-.027-.048 4.467 4.467 0 01-1.034-1.651 3.896 3.896 0 01-.251-1.192 5.189 5.189 0 01.141-1.6c.337-1.112.982-1.985 1.933-2.618.212-.141.413-.251.601-.33.215-.089.43-.164.646-.227a.098.098 0 00.065-.066 4.51 4.51 0 01.829-1.615 4.535 4.535 0 011.837-1.388zm3.482 10.565a.637.637 0 000 1.272h3.636a.637.637 0 100-1.272h-3.636zM8.462 9.23a.637.637 0 00-1.106.631l1.272 2.224-1.266 2.136a.636.636 0 101.095.649l1.454-2.455a.636.636 0 00.005-.64L8.462 9.23z" fill="url(#lobe-icons-codex-_R_0_)"></path><defs><linearGradient gradientUnits="userSpaceOnUse" id="lobe-icons-codex-_R_0_" x1="12" x2="12" y1="3" y2="21"><stop stop-color="#B1A7FF"></stop><stop offset=".5" stop-color="#7A9DFF"></stop><stop offset="1" stop-color="#3941FF"></stop></linearGradient></defs></svg>';
+
+const OPENCODE_LOGO =
+  '<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M16 6H8v12h8V6zm4 16H4V2h16v20z"></path></svg>';
+
+const CURSOR_LOGO =
+  '<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M22.106 5.68L12.5.135a.998.998 0 00-.998 0L1.893 5.68a.84.84 0 00-.419.726v11.186c0 .3.16.577.42.727l9.607 5.547a.999.999 0 00.998 0l9.608-5.547a.84.84 0 00.42-.727V6.407a.84.84 0 00-.42-.726zm-.603 1.176L12.228 22.92c-.063.108-.228.064-.228-.061V12.34a.59.59 0 00-.295-.51l-9.11-5.26c-.107-.062-.063-.228.062-.228h18.55c.264 0 .428.286.296.514z"></path></svg>';
+
+const WINDSURF_LOGO =
+  '<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="M23.78 5.004h-.228a2.187 2.187 0 00-2.18 2.196v4.912c0 .98-.804 1.775-1.76 1.775a1.818 1.818 0 01-1.472-.773L13.168 5.95a2.197 2.197 0 00-1.81-.95c-1.134 0-2.154.972-2.154 2.173v4.94c0 .98-.797 1.775-1.76 1.775-.57 0-1.136-.289-1.472-.773L.408 5.098C.282 4.918 0 5.007 0 5.228v4.284c0 .216.066.426.188.604l5.475 7.889c.324.466.8.812 1.351.938 1.377.316 2.645-.754 2.645-2.117V11.89c0-.98.787-1.775 1.76-1.775h.002c.586 0 1.135.288 1.472.773l4.972 7.163a2.15 2.15 0 001.81.95c1.158 0 2.151-.973 2.151-2.173v-4.939c0-.98.787-1.775 1.76-1.775h.194c.122 0 .22-.1.22-.222V5.225a.221.221 0 00-.22-.222z"></path></svg>';
+
+const GENERIC_LOGO =
+  '<svg fill="none" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>';
+
+const MCP_SERVERS_JSON = JSON.stringify(
+  {
+    mcpServers: {
+      modelparams: { type: "http", url: MCP_ENDPOINT },
+    },
+  },
+  null,
+  2,
+);
+
 export const MCP_CLIENTS: McpClient[] = [
   {
     id: "claude-code",
     name: "Claude Code",
+    logo: CLAUDE_CODE_LOGO,
     kind: "cli",
     command: `claude mcp add --transport http modelparams ${MCP_ENDPOINT}`,
   },
   {
     id: "codex",
     name: "Codex",
+    logo: CODEX_LOGO,
     kind: "cli",
     command: `codex mcp add modelparams --url ${MCP_ENDPOINT}`,
   },
   {
     id: "opencode",
     name: "OpenCode",
+    logo: OPENCODE_LOGO,
     kind: "json",
     command: JSON.stringify(
       {
@@ -39,18 +72,27 @@ export const MCP_CLIENTS: McpClient[] = [
     note: "Add to opencode.json under `mcp`.",
   },
   {
-    id: "mcp-spec",
-    name: "Claude Desktop, Cursor, Windsurf, Zed",
+    id: "cursor",
+    name: "Cursor",
+    logo: CURSOR_LOGO,
     kind: "json",
-    command: JSON.stringify(
-      {
-        mcpServers: {
-          modelparams: { type: "http", url: MCP_ENDPOINT },
-        },
-      },
-      null,
-      2,
-    ),
+    command: MCP_SERVERS_JSON,
+    note: "Cursor Settings → MCP → add a server.",
+  },
+  {
+    id: "windsurf",
+    name: "Windsurf",
+    logo: WINDSURF_LOGO,
+    kind: "json",
+    command: MCP_SERVERS_JSON,
+    note: "Any client that takes a JSON `mcpServers` block.",
+  },
+  {
+    id: "other",
+    name: "Claude Desktop, Zed, …",
+    logo: GENERIC_LOGO,
+    kind: "json",
+    command: MCP_SERVERS_JSON,
     note: "Any client that takes a JSON `mcpServers` block.",
   },
 ];

--- a/src/data/mcp.ts
+++ b/src/data/mcp.ts
@@ -1,0 +1,238 @@
+/** The MCP protocol endpoint. Browsers get the docs page here; machines get the protocol. */
+export const MCP_ENDPOINT = "https://modelparams.dev/mcp";
+
+export interface McpClient {
+  id: string;
+  name: string;
+  /** How the install instruction is shown: a one-liner or a JSON config. */
+  kind: "cli" | "json";
+  command: string;
+  note?: string;
+}
+
+export const MCP_CLIENTS: McpClient[] = [
+  {
+    id: "claude-code",
+    name: "Claude Code",
+    kind: "cli",
+    command: `claude mcp add --transport http modelparams ${MCP_ENDPOINT}`,
+  },
+  {
+    id: "codex",
+    name: "Codex",
+    kind: "cli",
+    command: `codex mcp add modelparams --url ${MCP_ENDPOINT}`,
+  },
+  {
+    id: "opencode",
+    name: "OpenCode",
+    kind: "json",
+    command: JSON.stringify(
+      {
+        mcp: {
+          modelparams: { type: "remote", url: MCP_ENDPOINT, enabled: true },
+        },
+      },
+      null,
+      2,
+    ),
+    note: "Add to opencode.json under `mcp`.",
+  },
+  {
+    id: "mcp-spec",
+    name: "Claude Desktop, Cursor, Windsurf, Zed",
+    kind: "json",
+    command: JSON.stringify(
+      {
+        mcpServers: {
+          modelparams: { type: "http", url: MCP_ENDPOINT },
+        },
+      },
+      null,
+      2,
+    ),
+    note: "Any client that takes a JSON `mcpServers` block.",
+  },
+];
+
+export interface McpTool {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  example: Record<string, unknown>;
+}
+
+const STRING = { type: "string" } as const;
+const OPTIONAL_STRING = { type: "string" } as const;
+const OPTIONAL_INTEGER = { type: "integer", minimum: 1 } as const;
+
+export const MCP_TOOLS: McpTool[] = [
+  {
+    name: "validate_model_params",
+    title: "Validate model parameters",
+    description:
+      "Check a set of request parameters against what a model actually accepts, before you call it. " +
+      "Catches unknown parameters, out-of-range values, and combinations the provider rejects — " +
+      "such as top_p alongside a non-default temperature on Anthropic models. Returns a corrected " +
+      "`safeParams` payload that is guaranteed to validate.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        model: {
+          ...STRING,
+          description:
+            "Catalog id or bare model slug, or with baseUrl the wire string your SDK sends.",
+        },
+        baseUrl: {
+          ...OPTIONAL_STRING,
+          description: 'The base URL your SDK uses, e.g. "https://api.fireworks.ai/inference/v1".',
+        },
+        params: {
+          type: "object",
+          additionalProperties: true,
+          description: 'Provider-native parameter paths to values, e.g. {"temperature": 0.7}.',
+        },
+      },
+      required: ["model"],
+      additionalProperties: false,
+    },
+    example: {
+      model: "anthropic/claude-3-opus-20240229",
+      valid: false,
+      summary:
+        "1 parameter(s) would be rejected or silently ignored by anthropic/claude-3-opus-20240229.",
+      issues: [
+        {
+          path: "top_p",
+          code: "not_applicable",
+          message: "top_p does not apply when temperature ≠ 1",
+          conflictsWith: ["temperature"],
+        },
+      ],
+      safeParams: { temperature: 0.5 },
+    },
+  },
+  {
+    name: "get_model_params",
+    title: "Get model parameters",
+    description:
+      "Every parameter one model accepts — type, allowed range or enum values, default, and the " +
+      "conditional rules that gate it. Also returns lifecycle status and migration guidance when tracked.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        model: {
+          ...STRING,
+          description:
+            "Catalog id or bare model slug, or with baseUrl the wire string your SDK sends.",
+        },
+        baseUrl: { ...OPTIONAL_STRING, description: "The base URL your SDK uses." },
+      },
+      required: ["model"],
+      additionalProperties: false,
+    },
+    example: {
+      model: "anthropic/claude-opus-4-8",
+      provider: "anthropic",
+      authType: "api_key",
+      status: "active",
+      parameterCount: 6,
+      params: [
+        {
+          path: "temperature",
+          type: "number",
+          default: 1,
+          range: { min: 0, max: 1 },
+          group: "sampling",
+        },
+      ],
+      defaults: { temperature: 1 },
+      docs: "https://modelparams.dev/models/anthropic/claude-opus-4-8",
+    },
+  },
+  {
+    name: "list_models",
+    title: "List catalog models",
+    description:
+      "Model ids in the catalog, optionally filtered by provider or a substring. Use it to resolve " +
+      "the exact id the other tools expect.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        provider: {
+          ...OPTIONAL_STRING,
+          description: 'Restrict to one provider slug, e.g. "anthropic".',
+        },
+        query: {
+          ...OPTIONAL_STRING,
+          description: "Case-insensitive substring match on the model id.",
+        },
+        limit: { ...OPTIONAL_INTEGER, description: "Default 100." },
+      },
+      additionalProperties: false,
+    },
+    example: {
+      total: 382,
+      returned: 3,
+      truncated: false,
+      providers: ["alibaba", "anthropic", "bedrock"],
+      models: [
+        "anthropic/claude-opus-4-8",
+        "anthropic/claude-sonnet-4-6",
+        "anthropic/claude-haiku-4-5",
+      ],
+    },
+  },
+  {
+    name: "list_provider_models",
+    title: "List a provider's models and their parameters",
+    description:
+      "Everything one provider serves in one call: its models, the wire id each one needs, their " +
+      "lifecycle status, and the parameter surfaces they expose. Models that share a surface share a " +
+      "profile, so a provider with dozens of models stays small enough to read. Use it to pick a model " +
+      "and configure it in one step — especially on Bedrock and Vertex, where parameter paths differ " +
+      "from the model's native API.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        provider: {
+          ...STRING,
+          description: 'Provider slug, e.g. "bedrock", "vertex", "anthropic".',
+        },
+        query: {
+          ...OPTIONAL_STRING,
+          description: "Case-insensitive substring match on the model id.",
+        },
+        limit: { ...OPTIONAL_INTEGER, description: "Default 200." },
+      },
+      required: ["provider"],
+      additionalProperties: false,
+    },
+    example: {
+      provider: "bedrock",
+      baseUrls: ["https://bedrock-runtime.*.amazonaws.com"],
+      total: 56,
+      returned: 56,
+      truncated: false,
+      paramProfiles: [
+        {
+          id: "p1",
+          modelCount: 41,
+          parameterCount: 4,
+          params: [{ path: "inferenceConfig.maxTokens", type: "integer", range: { min: 1 } }],
+          defaults: {},
+        },
+      ],
+      models: [
+        {
+          model: "bedrock/claude-opus-4-6",
+          authType: "api_key",
+          wireId: "{scope}.anthropic.claude-opus-4-6-v1",
+          profile: "p2",
+        },
+      ],
+      wireIdNote: "A wireId containing {scope} needs one substitution before you send it…",
+    },
+  },
+];

--- a/src/data/urls.ts
+++ b/src/data/urls.ts
@@ -22,6 +22,9 @@ export const GLOSSARY_PATH = "/glossary";
 /** API documentation page. The HTML docs, not the JSON endpoints under /api/v1. */
 export const API_PATH = "/api";
 
+/** MCP server documentation page. The protocol endpoint itself lives at /mcp. */
+export const MCP_PATH = "/mcp-server";
+
 /**
  * The page that separates the two meanings of "model parameters": weight count
  * versus the request settings this catalog documents. Every other page links

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -12,6 +12,7 @@ import { renderProviderPage } from "../build/render-provider.js";
 import { renderGlossaryPage } from "../build/render-glossary.js";
 import { renderDisambiguationPage } from "../build/render-disambiguation.js";
 import { renderApiPage } from "../build/render-api.js";
+import { renderMcpHtml } from "../build/render-mcp.js";
 import { SITE_URL } from "../data/site.js";
 import { DISAMBIGUATION_PATH } from "../data/urls.js";
 import { modelId, type Model } from "../schema/model.js";
@@ -61,6 +62,11 @@ export function makeApp(loadModels: LoadModels): express.Express {
     } catch (err) {
       next(err);
     }
+  });
+
+  app.get("/mcp", (_req, res) => {
+    res.setHeader("Cache-Control", "no-store");
+    res.type("html").send(renderMcpHtml());
   });
 
   app.get("/glossary", async (_req, res, next) => {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -12,7 +12,7 @@ import { renderProviderPage } from "../build/render-provider.js";
 import { renderGlossaryPage } from "../build/render-glossary.js";
 import { renderDisambiguationPage } from "../build/render-disambiguation.js";
 import { renderApiPage } from "../build/render-api.js";
-import { renderMcpHtml } from "../build/render-mcp.js";
+import { renderMcpPage } from "../build/render-mcp.js";
 import { SITE_URL } from "../data/site.js";
 import { DISAMBIGUATION_PATH } from "../data/urls.js";
 import { modelId, type Model } from "../schema/model.js";
@@ -64,9 +64,14 @@ export function makeApp(loadModels: LoadModels): express.Express {
     }
   });
 
-  app.get("/mcp", (_req, res) => {
-    res.setHeader("Cache-Control", "no-store");
-    res.type("html").send(renderMcpHtml());
+  app.get("/mcp-server", async (_req, res, next) => {
+    try {
+      const models = await loadModels();
+      res.setHeader("Cache-Control", "no-store");
+      res.type("html").send(await renderMcpPage(models));
+    } catch (err) {
+      next(err);
+    }
   });
 
   app.get("/glossary", async (_req, res, next) => {

--- a/src/views/api.ejs
+++ b/src/views/api.ejs
@@ -110,7 +110,7 @@
     </section>
 
     <!-- MCP -->
-    <section>
+    <section id="mcp">
       <h2 class="text-slate-900 dark:text-slate-100">MCP server</h2>
       <p class="mt-2 text-slate-600 dark:text-slate-300">
         Let a coding agent check the catalog itself. Hosted at

--- a/src/views/api.ejs
+++ b/src/views/api.ejs
@@ -114,7 +114,7 @@
       <h2 class="text-slate-900 dark:text-slate-100">MCP server</h2>
       <p class="mt-2 text-slate-600 dark:text-slate-300">
         Want your coding agent to check the catalog itself? The MCP server has its own page:
-        <a href="/mcp" class="text-accent hover:text-accent-hover">/mcp</a> — install commands,
+        <a href="/mcp-server" class="text-accent hover:text-accent-hover">/mcp-server</a> — install commands,
         the four tools, and their schemas.
       </p>
     </section>

--- a/src/views/api.ejs
+++ b/src/views/api.ejs
@@ -86,7 +86,7 @@
   -d '{"model":"anthropic/claude-3-opus-20240229","params":{"temperature":0.5,"top_p":0.9}}'</code></pre>
       </div>
       <div class="mt-3">
-        <pre class="overflow-x-auto border border-slate-200 bg-slate-900 px-5 py-4 font-mono text-sm leading-relaxed text-slate-200 dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code><%- helpers.highlightJson(`{
+        <pre class="border border-slate-200 bg-slate-900 px-5 py-4 font-mono text-sm leading-relaxed text-slate-200 whitespace-pre-wrap break-words dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code><%- helpers.highlightJson(`{
   "model": "anthropic/claude-3-opus-20240229",
   "valid": false,
   "issues": [

--- a/src/views/api.ejs
+++ b/src/views/api.ejs
@@ -86,7 +86,7 @@
   -d '{"model":"anthropic/claude-3-opus-20240229","params":{"temperature":0.5,"top_p":0.9}}'</code></pre>
       </div>
       <div class="mt-3">
-        <pre class="overflow-x-auto border border-slate-200 bg-slate-900 px-5 py-4 font-mono text-sm leading-relaxed text-slate-200 dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code>{
+        <pre class="overflow-x-auto border border-slate-200 bg-slate-900 px-5 py-4 font-mono text-sm leading-relaxed text-slate-200 dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code><%- helpers.highlightJson(`{
   "model": "anthropic/claude-3-opus-20240229",
   "valid": false,
   "issues": [
@@ -98,7 +98,7 @@
     }
   ],
   "safeParams": { "temperature": 0.5 }
-}</code></pre>
+}`) %></code></pre>
       </div>
       <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">
         Every issue carries a

--- a/src/views/api.ejs
+++ b/src/views/api.ejs
@@ -110,27 +110,12 @@
     </section>
 
     <!-- MCP -->
-    <section id="mcp">
+    <section>
       <h2 class="text-slate-900 dark:text-slate-100">MCP server</h2>
       <p class="mt-2 text-slate-600 dark:text-slate-300">
-        Let a coding agent check the catalog itself. Hosted at
-        <code class="font-mono text-xs">https://modelparams.dev/mcp</code>, over Streamable HTTP — nothing to install,
-        and it always answers from the catalog this site is serving.
-      </p>
-      <div class="mt-4">
-        <pre class="overflow-x-auto border border-slate-200 bg-slate-900 px-5 py-4 font-mono text-sm leading-relaxed text-slate-200 dark:border-[hsla(60,2%,12%,0.17)] dark:bg-[#0d0d0d]"><code>claude mcp add --transport http modelparams https://modelparams.dev/mcp
-codex mcp add modelparams --url https://modelparams.dev/mcp</code></pre>
-      </div>
-      <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">
-        Tools:
-        <code class="font-mono text-xs">validate_model_params</code>,
-        <code class="font-mono text-xs">get_model_params</code>,
-        <code class="font-mono text-xs">list_models</code>,
-        <code class="font-mono text-xs">list_provider_models</code>.
-      </p>
-      <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">
-        Using a coding agent that supports skills? Install the companion skill with
-        <code class="bg-warm-tag px-1.5 py-0.5 font-mono text-xs text-slate-700 dark:bg-[#262626] dark:text-slate-300">npx skills add mnfst/modelparams.dev</code>.
+        Want your coding agent to check the catalog itself? The MCP server has its own page:
+        <a href="/mcp" class="text-accent hover:text-accent-hover">/mcp</a> — install commands,
+        the four tools, and their schemas.
       </p>
     </section>
 

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -6,7 +6,7 @@
     <p class="mt-4 max-w-2xl text-pretty text-base text-slate-600 dark:text-slate-400 sm:text-lg">
       An open, community-maintained catalog of LLM API parameters — temperature, top_p,
       max_tokens and the rest of the request body.
-      Browse the UI below, query the API, or install the npm package.
+      Browse the UI below, query the API, install the npm package, or give your coding agent the MCP server.
     </p>
 
     <div class="mt-8 flex flex-wrap items-center gap-4">
@@ -51,6 +51,17 @@
           <path d="M6 13h6v4l6-5-6-5v4H6z" />
         </svg>
         Use the API
+      </a>
+
+      <!-- MCP — ghost link -->
+      <a
+        href="/api#mcp"
+        class="inline-flex items-center gap-1 text-sm font-medium text-slate-700 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4 shrink-0" aria-hidden="true">
+          <path d="M6 13h6v4l6-5-6-5v4H6z" />
+        </svg>
+        MCP for agents
       </a>
     </div>
   </div>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -55,7 +55,7 @@
 
       <!-- MCP — ghost link -->
       <a
-        href="/api#mcp"
+        href="/mcp"
         class="inline-flex items-center gap-1 text-sm font-medium text-slate-700 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white"
       >
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4 shrink-0" aria-hidden="true">

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -55,7 +55,7 @@
 
       <!-- MCP — ghost link -->
       <a
-        href="/mcp"
+        href="/mcp-server"
         class="inline-flex items-center gap-1 text-sm font-medium text-slate-700 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white"
       >
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4 shrink-0" aria-hidden="true">

--- a/src/views/mcp.ejs
+++ b/src/views/mcp.ejs
@@ -1,0 +1,99 @@
+<%- include("partials/breadcrumbs", { items: [
+  { name: "Home", href: "/" },
+  { name: "MCP" }
+] }) %>
+
+<section class="pt-6 pb-16">
+  <h1 class="tracking-tight">MCP server</h1>
+  <p class="mt-3 max-w-2xl text-pretty text-slate-600 dark:text-slate-300">
+    Give your coding agent the catalog, so it can check which parameters a model accepts
+    before it calls one — instead of guessing from training data and eating a 400, or worse,
+    having a parameter silently ignored. Hosted over Streamable HTTP, nothing to install.
+  </p>
+
+  <div class="mt-10 max-w-3xl space-y-12">
+
+    <!-- Connect a client -->
+    <section>
+      <h2 class="text-slate-900 dark:text-slate-100">Connect a client</h2>
+      <p class="mt-2 text-slate-600 dark:text-slate-300">
+        Endpoint:
+        <code class="font-mono text-xs">https://modelparams.dev/mcp</code>.
+        Pick a client to see its install command.
+      </p>
+
+      <div class="mt-4 flex flex-wrap gap-2">
+        <% for (const client of clients) { %>
+        <button
+          type="button"
+          data-mcp-client="<%= client.id %>"
+          class="inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-colors <%= client === clients[0] ? 'border-slate-900 bg-slate-900 text-white dark:border-white dark:bg-white dark:text-slate-900' : 'border-slate-300 text-slate-700 hover:border-slate-500 dark:border-slate-700 dark:text-slate-300' %>"
+        >
+          <span class="provider-logo inline-flex h-4 w-4 shrink-0 items-center justify-center" aria-hidden="true"><%- client.logo %></span>
+          <%= client.name %>
+        </button>
+        <% } %>
+      </div>
+
+      <div class="mt-4">
+        <% for (const client of clients) { %>
+        <div data-mcp-panel="<%= client.id %>" class="<%= client === clients[0] ? '' : 'hidden' %>">
+          <% if (client.note) { %>
+          <p class="mb-2 text-sm text-slate-500 dark:text-slate-400"><%= client.note %></p>
+          <% } %>
+          <div class="flex items-center border-2 border-slate-700 bg-slate-800 px-5 py-3 dark:border-slate-500 dark:bg-slate-900">
+            <pre class="flex-1 overflow-x-auto font-mono text-sm text-slate-200"><code data-mcp-command="<%= client.id %>"><%= client.command %></code></pre>
+            <button
+              type="button"
+              data-copy-mcp="<%= client.id %>"
+              aria-label="Copy to clipboard"
+              class="group ml-6 shrink-0 text-slate-400 hover:text-white"
+            >
+              <svg viewBox="0 0 16 16" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" data-copy-mcp-idle>
+                <rect x="5" y="5" width="9" height="9" rx="1" />
+                <path d="M5 11H3.5A1.5 1.5 0 012 9.5v-7A1.5 1.5 0 013.5 1h7A1.5 1.5 0 0112 2.5V5" />
+              </svg>
+              <svg viewBox="0 0 16 16" class="hidden h-4 w-4 text-emerald-400" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" data-copy-mcp-done>
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3.5 8.5l3 3 6-6" />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <% } %>
+      </div>
+    </section>
+
+    <!-- Tools -->
+    <section>
+      <h2 class="text-slate-900 dark:text-slate-100">Tools</h2>
+      <p class="mt-2 text-slate-600 dark:text-slate-300">
+        Four read-only tools, all answering from the catalog this site is serving.
+      </p>
+
+      <div class="mt-4 space-y-10">
+        <% for (const tool of tools) { %>
+        <div id="<%= tool.name %>" class="border-l-2 border-slate-200 pl-5 dark:border-slate-800">
+          <h3 class="font-mono text-base font-semibold text-slate-900 dark:text-slate-100"><%= tool.name %></h3>
+          <p class="mt-1.5 text-sm text-slate-600 dark:text-slate-300"><%= tool.description %></p>
+
+          <div class="mt-4 space-y-4">
+            <%- jsonBlock(JSON.stringify(tool.inputSchema, null, 2), "Input") %>
+            <%- jsonBlock(JSON.stringify(tool.example, null, 2), "Example output") %>
+          </div>
+        </div>
+        <% } %>
+      </div>
+    </section>
+
+    <!-- For agents -->
+    <section>
+      <h2 class="text-slate-900 dark:text-slate-100">For agents</h2>
+      <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
+        Prefer a plain file? The whole catalog, including this MCP server, is described in
+        <a href="/llms.txt" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-hover">/llms.txt</a>
+        and
+        <a href="/llms-full.txt" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-hover">/llms-full.txt</a>.
+      </p>
+    </section>
+  </div>
+</section>

--- a/src/views/partials/footer.ejs
+++ b/src/views/partials/footer.ejs
@@ -20,6 +20,7 @@
       <!-- Column 2: Resources -->
       <div class="flex flex-col gap-2 text-sm">
         <a href="/api" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">API</a>
+        <a href="/api#mcp" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">MCP server</a>
         <a href="/glossary" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">Glossary</a>
         <a href="/model-parameters-vs-api-parameters" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">Parameters vs. weights</a>
         <a href="/api/v1/models.json" target="_blank" rel="noopener noreferrer nofollow" class="inline-flex items-center gap-1 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">JSON API <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-3 w-3 shrink-0" aria-hidden="true"><path d="M17 16V7H8v2h5.59l-6.3 6.29 1.42 1.42 6.29-6.3V16z"></path></svg></a>

--- a/src/views/partials/footer.ejs
+++ b/src/views/partials/footer.ejs
@@ -20,7 +20,7 @@
       <!-- Column 2: Resources -->
       <div class="flex flex-col gap-2 text-sm">
         <a href="/api" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">API</a>
-        <a href="/api#mcp" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">MCP server</a>
+        <a href="/mcp" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">MCP server</a>
         <a href="/glossary" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">Glossary</a>
         <a href="/model-parameters-vs-api-parameters" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">Parameters vs. weights</a>
         <a href="/api/v1/models.json" target="_blank" rel="noopener noreferrer nofollow" class="inline-flex items-center gap-1 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">JSON API <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-3 w-3 shrink-0" aria-hidden="true"><path d="M17 16V7H8v2h5.59l-6.3 6.29 1.42 1.42 6.29-6.3V16z"></path></svg></a>

--- a/src/views/partials/footer.ejs
+++ b/src/views/partials/footer.ejs
@@ -20,7 +20,7 @@
       <!-- Column 2: Resources -->
       <div class="flex flex-col gap-2 text-sm">
         <a href="/api" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">API</a>
-        <a href="/mcp" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">MCP server</a>
+        <a href="/mcp-server" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">MCP server</a>
         <a href="/glossary" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">Glossary</a>
         <a href="/model-parameters-vs-api-parameters" class="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">Parameters vs. weights</a>
         <a href="/api/v1/models.json" target="_blank" rel="noopener noreferrer nofollow" class="inline-flex items-center gap-1 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">JSON API <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-3 w-3 shrink-0" aria-hidden="true"><path d="M17 16V7H8v2h5.59l-6.3 6.29 1.42 1.42 6.29-6.3V16z"></path></svg></a>

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -39,7 +39,7 @@
           API
         </a>
         <a
-          href="/api#mcp"
+          href="/mcp"
           class="rounded-md px-3 py-1.5 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white"
         >
           MCP
@@ -102,7 +102,7 @@
         </summary>
         <div class="absolute right-0 top-full z-30 mt-2 w-56 overflow-hidden border border-slate-200 bg-white py-1 text-sm shadow-lg dark:border-slate-800 dark:bg-[#1f1f1f]">
           <a href="/api" class="block px-4 py-2 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">API</a>
-          <a href="/api#mcp" class="block px-4 py-2 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">MCP</a>
+          <a href="/mcp" class="block px-4 py-2 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">MCP</a>
           <a href="https://github.com/mnfst/modelparams.dev" target="_blank" rel="noopener noreferrer" class="block px-4 py-2 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">GitHub</a>
           <div class="my-1 border-t border-slate-200 dark:border-slate-800"></div>
           <p class="px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">Providers</p>

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -39,7 +39,7 @@
           API
         </a>
         <a
-          href="/mcp"
+          href="/mcp-server"
           class="rounded-md px-3 py-1.5 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white"
         >
           MCP
@@ -102,7 +102,7 @@
         </summary>
         <div class="absolute right-0 top-full z-30 mt-2 w-56 overflow-hidden border border-slate-200 bg-white py-1 text-sm shadow-lg dark:border-slate-800 dark:bg-[#1f1f1f]">
           <a href="/api" class="block px-4 py-2 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">API</a>
-          <a href="/mcp" class="block px-4 py-2 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">MCP</a>
+          <a href="/mcp-server" class="block px-4 py-2 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">MCP</a>
           <a href="https://github.com/mnfst/modelparams.dev" target="_blank" rel="noopener noreferrer" class="block px-4 py-2 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">GitHub</a>
           <div class="my-1 border-t border-slate-200 dark:border-slate-800"></div>
           <p class="px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">Providers</p>

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -39,6 +39,12 @@
           API
         </a>
         <a
+          href="/api#mcp"
+          class="rounded-md px-3 py-1.5 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white"
+        >
+          MCP
+        </a>
+        <a
           href="/glossary"
           class="rounded-md px-3 py-1.5 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white"
         >
@@ -96,6 +102,7 @@
         </summary>
         <div class="absolute right-0 top-full z-30 mt-2 w-56 overflow-hidden border border-slate-200 bg-white py-1 text-sm shadow-lg dark:border-slate-800 dark:bg-[#1f1f1f]">
           <a href="/api" class="block px-4 py-2 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">API</a>
+          <a href="/api#mcp" class="block px-4 py-2 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">MCP</a>
           <a href="https://github.com/mnfst/modelparams.dev" target="_blank" rel="noopener noreferrer" class="block px-4 py-2 text-slate-600 hover:bg-warm-hover hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">GitHub</a>
           <div class="my-1 border-t border-slate-200 dark:border-slate-800"></div>
           <p class="px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">Providers</p>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,7 +11,7 @@ import type { Config } from "tailwindcss";
  */
 
 const config: Config = {
-  content: ["./src/views/**/*.ejs", "./src/client/**/*.ts"],
+  content: ["./src/views/**/*.ejs", "./src/client/**/*.ts", "./src/build/**/*.ts"],
   darkMode: "class",
   theme: {
     extend: {


### PR DESCRIPTION
### What changed
- **Dedicated MCP page** at `/mcp`, served via content negotiation: MCP clients get the protocol, browsers get the docs page. One canonical URL.
- Page shows per-client install commands behind a picker (Claude Code, Codex, OpenCode, Claude Desktop/Cursor/Windsurf/Zed) with copy buttons, and each tool's input schema + example output.
- Header nav + mobile menu "MCP" link, footer "MCP server" link, homepage hero mention + CTA — all pointing to `/mcp`.
- API page's MCP section is now a one-line pointer to `/mcp`.
- Endpoint stays at `/mcp` (reverted the earlier move to `/api/mcp`).

### Why
The MCP server was buried in the API page. This gives it its own page, matching how hosted MCP servers advertise, while keeping the conventional `/mcp` endpoint URL.

### Implementation note
The page is self-contained (inline CSS/JS, no ejs/fs) so the Vercel function that serves `/mcp` can return it for browser GETs without touching the static build's filesystem.
