### PR TITLE
fix: match Z.AI parameter limits to provider docs

### DIFF
--- a/models/z-ai/glm-4.5-air-subscription.yaml
+++ b/models/z-ai/glm-4.5-air-subscription.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 98304
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-4.5-air.yaml
+++ b/models/z-ai/glm-4.5-air.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 98304
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-4.5-airx.yaml
+++ b/models/z-ai/glm-4.5-airx.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 98304
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-4.5-flash.yaml
+++ b/models/z-ai/glm-4.5-flash.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 98304
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-4.5-subscription.yaml
+++ b/models/z-ai/glm-4.5-subscription.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 98304
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-4.5-x.yaml
+++ b/models/z-ai/glm-4.5-x.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 98304
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-4.5.yaml
+++ b/models/z-ai/glm-4.5.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 98304
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-4.6-subscription.yaml
+++ b/models/z-ai/glm-4.6-subscription.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 131072
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-4.6.yaml
+++ b/models/z-ai/glm-4.6.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 131072
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-4.7-flash.yaml
+++ b/models/z-ai/glm-4.7-flash.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 131072
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-4.7-flashx.yaml
+++ b/models/z-ai/glm-4.7-flashx.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 131072
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-4.7-subscription.yaml
+++ b/models/z-ai/glm-4.7-subscription.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 131072
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-4.7.yaml
+++ b/models/z-ai/glm-4.7.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 131072
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-5-subscription.yaml
+++ b/models/z-ai/glm-5-subscription.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 131072
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-5-turbo-subscription.yaml
+++ b/models/z-ai/glm-5-turbo-subscription.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 131072
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-5-turbo.yaml
+++ b/models/z-ai/glm-5-turbo.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 131072
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-5.1-subscription.yaml
+++ b/models/z-ai/glm-5.1-subscription.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 131072
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-5.1.yaml
+++ b/models/z-ai/glm-5.1.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 131072
     group: generation_length
   - path: temperature
     type: number

--- a/models/z-ai/glm-5.3.yaml
+++ b/models/z-ai/glm-5.3.yaml
@@ -47,29 +47,21 @@ params:
   - path: thinking.type
     type: enum
     label: Thinking mode
-    description: Toggles the model's extended reasoning before it produces the final answer.
+    description: GLM-5.3 always engages in extended reasoning; thinking cannot be disabled.
     default: enabled
     values:
       - enabled
-      - disabled
     group: reasoning
   - path: reasoning_effort
     type: enum
     label: Reasoning effort
-    description: Controls how much reasoning effort GLM-5.2 spends when thinking is enabled.
+    description: Controls how much reasoning effort GLM-5.3 spends on its always-on thinking.
     default: max
     values:
-      - none
-      - minimal
       - low
-      - medium
       - high
-      - xhigh
       - max
     group: reasoning
-    applicability:
-      only:
-        thinking.type: enabled
   - path: response_format.type
     type: enum
     label: Response format

--- a/models/z-ai/glm-5.yaml
+++ b/models/z-ai/glm-5.yaml
@@ -8,8 +8,10 @@ params:
     type: integer
     label: Max tokens
     description: Maximum number of tokens to generate in the response.
+    default: 65536
     range:
       min: 1
+      max: 131072
     group: generation_length
   - path: temperature
     type: number

--- a/packages/modelparams-python/src/modelparams/_generated/catalog.json
+++ b/packages/modelparams-python/src/modelparams/_generated/catalog.json
@@ -27742,8 +27742,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -27828,8 +27830,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -27914,8 +27918,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -28000,8 +28006,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -28086,8 +28094,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -28172,8 +28182,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -28258,8 +28270,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -28344,8 +28358,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28430,8 +28446,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28516,8 +28534,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28602,8 +28622,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28688,8 +28710,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28774,8 +28798,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28860,8 +28886,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28946,8 +28974,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -29032,8 +29062,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -29118,8 +29150,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -29204,8 +29238,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -29290,8 +29326,10 @@
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -29648,34 +29686,24 @@
       {
         "path": "thinking.type",
         "label": "Thinking mode",
-        "description": "Toggles the model's extended reasoning before it produces the final answer.",
+        "description": "GLM-5.3 always engages in extended reasoning; thinking cannot be disabled.",
         "group": "reasoning",
         "type": "enum",
         "default": "enabled",
         "values": [
-          "enabled",
-          "disabled"
+          "enabled"
         ]
       },
       {
         "path": "reasoning_effort",
         "label": "Reasoning effort",
-        "description": "Controls how much reasoning effort GLM-5.2 spends when thinking is enabled.",
+        "description": "Controls how much reasoning effort GLM-5.3 spends on its always-on thinking.",
         "group": "reasoning",
-        "applicability": {
-          "only": {
-            "thinking.type": "enabled"
-          }
-        },
         "type": "enum",
         "default": "max",
         "values": [
-          "none",
-          "minimal",
           "low",
-          "medium",
           "high",
-          "xhigh",
           "max"
         ]
       },

--- a/packages/modelparams-python/src/modelparams/types/z_ai.py
+++ b/packages/modelparams-python/src/modelparams/types/z_ai.py
@@ -13,7 +13,7 @@ _PARAMS_CONFIG = ConfigDict(strict=True, extra="forbid")
 Glm_4_5Params = TypedDict(
     "Glm_4_5Params",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=98304)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -27,7 +27,7 @@ setattr(Glm_4_5Params, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_4_5_AirParams = TypedDict(
     "Glm_4_5_AirParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=98304)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -41,7 +41,7 @@ setattr(Glm_4_5_AirParams, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_4_5_Air_SubscriptionParams = TypedDict(
     "Glm_4_5_Air_SubscriptionParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=98304)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -55,7 +55,7 @@ setattr(Glm_4_5_Air_SubscriptionParams, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_4_5_AirxParams = TypedDict(
     "Glm_4_5_AirxParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=98304)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -69,7 +69,7 @@ setattr(Glm_4_5_AirxParams, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_4_5_FlashParams = TypedDict(
     "Glm_4_5_FlashParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=98304)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -83,7 +83,7 @@ setattr(Glm_4_5_FlashParams, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_4_5_SubscriptionParams = TypedDict(
     "Glm_4_5_SubscriptionParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=98304)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -97,7 +97,7 @@ setattr(Glm_4_5_SubscriptionParams, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_4_5_XParams = TypedDict(
     "Glm_4_5_XParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=98304)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -111,7 +111,7 @@ setattr(Glm_4_5_XParams, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_4_6Params = TypedDict(
     "Glm_4_6Params",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=131072)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -125,7 +125,7 @@ setattr(Glm_4_6Params, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_4_6_SubscriptionParams = TypedDict(
     "Glm_4_6_SubscriptionParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=131072)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -139,7 +139,7 @@ setattr(Glm_4_6_SubscriptionParams, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_4_7Params = TypedDict(
     "Glm_4_7Params",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=131072)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -153,7 +153,7 @@ setattr(Glm_4_7Params, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_4_7_FlashParams = TypedDict(
     "Glm_4_7_FlashParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=131072)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -167,7 +167,7 @@ setattr(Glm_4_7_FlashParams, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_4_7_FlashxParams = TypedDict(
     "Glm_4_7_FlashxParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=131072)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -181,7 +181,7 @@ setattr(Glm_4_7_FlashxParams, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_4_7_SubscriptionParams = TypedDict(
     "Glm_4_7_SubscriptionParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=131072)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -195,7 +195,7 @@ setattr(Glm_4_7_SubscriptionParams, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_5Params = TypedDict(
     "Glm_5Params",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=131072)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -209,7 +209,7 @@ setattr(Glm_5Params, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_5_SubscriptionParams = TypedDict(
     "Glm_5_SubscriptionParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=131072)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -223,7 +223,7 @@ setattr(Glm_5_SubscriptionParams, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_5_TurboParams = TypedDict(
     "Glm_5_TurboParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=131072)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -237,7 +237,7 @@ setattr(Glm_5_TurboParams, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_5_Turbo_SubscriptionParams = TypedDict(
     "Glm_5_Turbo_SubscriptionParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=131072)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -251,7 +251,7 @@ setattr(Glm_5_Turbo_SubscriptionParams, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_5_1Params = TypedDict(
     "Glm_5_1Params",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=131072)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -265,7 +265,7 @@ setattr(Glm_5_1Params, "__pydantic_config__", _PARAMS_CONFIG)
 Glm_5_1_SubscriptionParams = TypedDict(
     "Glm_5_1_SubscriptionParams",
     {
-        "max_tokens": Annotated[int, Field(ge=1)],
+        "max_tokens": Annotated[int, Field(ge=1, le=131072)],
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
@@ -313,8 +313,8 @@ Glm_5_3Params = TypedDict(
         "temperature": Annotated[float, Field(ge=0, le=1)],
         "top_p": Annotated[float, Field(ge=0.01, le=1)],
         "do_sample": bool,
-        "thinking.type": Literal["enabled", "disabled"],
-        "reasoning_effort": Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+        "thinking.type": Literal["enabled"],
+        "reasoning_effort": Literal["low", "high", "max"],
         "response_format.type": Literal["text", "json_object"],
     },
     total=False,

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -27747,8 +27747,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -27833,8 +27835,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -27919,8 +27923,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -28005,8 +28011,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -28091,8 +28099,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -28177,8 +28187,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -28263,8 +28275,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 98304
         }
       },
       {
@@ -28349,8 +28363,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28435,8 +28451,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28521,8 +28539,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28607,8 +28627,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28693,8 +28715,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28779,8 +28803,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28865,8 +28891,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -28951,8 +28979,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -29037,8 +29067,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -29123,8 +29155,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -29209,8 +29243,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -29295,8 +29331,10 @@ const GENERATED_CATALOG = [
         "description": "Maximum number of tokens to generate in the response.",
         "group": "generation_length",
         "type": "integer",
+        "default": 65536,
         "range": {
-          "min": 1
+          "min": 1,
+          "max": 131072
         }
       },
       {
@@ -29653,34 +29691,24 @@ const GENERATED_CATALOG = [
       {
         "path": "thinking.type",
         "label": "Thinking mode",
-        "description": "Toggles the model's extended reasoning before it produces the final answer.",
+        "description": "GLM-5.3 always engages in extended reasoning; thinking cannot be disabled.",
         "group": "reasoning",
         "type": "enum",
         "default": "enabled",
         "values": [
-          "enabled",
-          "disabled"
+          "enabled"
         ]
       },
       {
         "path": "reasoning_effort",
         "label": "Reasoning effort",
-        "description": "Controls how much reasoning effort GLM-5.2 spends when thinking is enabled.",
+        "description": "Controls how much reasoning effort GLM-5.3 spends on its always-on thinking.",
         "group": "reasoning",
-        "applicability": {
-          "only": {
-            "thinking.type": "enabled"
-          }
-        },
         "type": "enum",
         "default": "max",
         "values": [
-          "none",
-          "minimal",
           "low",
-          "medium",
           "high",
-          "xhigh",
           "max"
         ]
       },

--- a/packages/modelparams/src/generated/defaults.ts
+++ b/packages/modelparams/src/generated/defaults.ts
@@ -1816,6 +1816,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-4.5": {
+    max_tokens: 65536,
     temperature: 0.6,
     top_p: 0.95,
     do_sample: true,
@@ -1823,6 +1824,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-4.5-air": {
+    max_tokens: 65536,
     temperature: 0.6,
     top_p: 0.95,
     do_sample: true,
@@ -1830,6 +1832,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-4.5-air-subscription": {
+    max_tokens: 65536,
     temperature: 0.6,
     top_p: 0.95,
     do_sample: true,
@@ -1837,6 +1840,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-4.5-airx": {
+    max_tokens: 65536,
     temperature: 0.6,
     top_p: 0.95,
     do_sample: true,
@@ -1844,6 +1848,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-4.5-flash": {
+    max_tokens: 65536,
     temperature: 0.6,
     top_p: 0.95,
     do_sample: true,
@@ -1851,6 +1856,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-4.5-subscription": {
+    max_tokens: 65536,
     temperature: 0.6,
     top_p: 0.95,
     do_sample: true,
@@ -1858,6 +1864,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-4.5-x": {
+    max_tokens: 65536,
     temperature: 0.6,
     top_p: 0.95,
     do_sample: true,
@@ -1865,6 +1872,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-4.6": {
+    max_tokens: 65536,
     temperature: 1,
     top_p: 0.95,
     do_sample: true,
@@ -1872,6 +1880,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-4.6-subscription": {
+    max_tokens: 65536,
     temperature: 1,
     top_p: 0.95,
     do_sample: true,
@@ -1879,6 +1888,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-4.7": {
+    max_tokens: 65536,
     temperature: 1,
     top_p: 0.95,
     do_sample: true,
@@ -1886,6 +1896,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-4.7-flash": {
+    max_tokens: 65536,
     temperature: 1,
     top_p: 0.95,
     do_sample: true,
@@ -1893,6 +1904,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-4.7-flashx": {
+    max_tokens: 65536,
     temperature: 1,
     top_p: 0.95,
     do_sample: true,
@@ -1900,6 +1912,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-4.7-subscription": {
+    max_tokens: 65536,
     temperature: 1,
     top_p: 0.95,
     do_sample: true,
@@ -1907,6 +1920,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-5": {
+    max_tokens: 65536,
     temperature: 1,
     top_p: 0.95,
     do_sample: true,
@@ -1914,6 +1928,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-5-subscription": {
+    max_tokens: 65536,
     temperature: 1,
     top_p: 0.95,
     do_sample: true,
@@ -1921,6 +1936,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-5-turbo": {
+    max_tokens: 65536,
     temperature: 1,
     top_p: 0.95,
     do_sample: true,
@@ -1928,6 +1944,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-5-turbo-subscription": {
+    max_tokens: 65536,
     temperature: 1,
     top_p: 0.95,
     do_sample: true,
@@ -1935,6 +1952,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-5.1": {
+    max_tokens: 65536,
     temperature: 1,
     top_p: 0.95,
     do_sample: true,
@@ -1942,6 +1960,7 @@ export const DEFAULTS = {
     "response_format.type": "text",
   },
   "z-ai/glm-5.1-subscription": {
+    max_tokens: 65536,
     temperature: 1,
     top_p: 0.95,
     do_sample: true,

--- a/packages/modelparams/src/generated/params-by-id.ts
+++ b/packages/modelparams/src/generated/params-by-id.ts
@@ -2988,8 +2988,8 @@ export type ParamsById = {
     temperature: number;
     top_p: number;
     do_sample: boolean;
-    "thinking.type": "enabled" | "disabled";
-    reasoning_effort: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+    "thinking.type": "enabled";
+    reasoning_effort: "low" | "high" | "max";
     "response_format.type": "text" | "json_object";
   };
 };


### PR DESCRIPTION
### 💭 Why
Audit against https://docs.z.ai/guides/overview/concept-param showed our Z.AI entries were missing max_tokens bounds and glm-5.3 carried options the API rejects. Every change was verified against the live Z.AI API.

### ✨ What changed
- max_tokens gets default 65536 plus max 131072 (GLM-5/5.1/5-turbo/4.7/4.6) or 98304 (GLM-4.5 family) on 19 entries.
- glm-5.3 reasoning_effort trimmed to low/high/max (API rejects the rest with error 1210).
- glm-5.3 thinking can no longer be disabled ("This model always engages in thinking"), enum reduced to enabled.
- Regenerated npm package data.

### 📝 Notes
- Live API quirk: the gateway accepts max_tokens up to 131072 for glm-4.5 and glm-4.5-x, but the docs cap all GLM-4.5 output at 98304 (96K) and the air/airx/flash siblings validate at 98304. Kept the documented value.
- glm-4.7-flash/flashx are absent from the doc table; their 131072 limit comes from the API validation error.
- glm-4.7 still accepts thinking disabled (tested), only glm-5.3 forces it.