### PR TITLE
feat: scope model params by API surface

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,13 @@ You don't need to know the schema to file one. A link to the official docs is th
    # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
    ```
 
-3. **Required top-level fields:** `provider`, `authType` (`api_key` or `subscription`), `model`, `params`.
+3. **Required top-level fields:** `provider`, `authType` (`api_key` or `subscription`),
+   `apiSurface`, `model`, `params`.
+
+   `apiSurface` names the API or SDK request family that accepts these paths.
+   Use one of the values in the [schema convention](docs/model-parameters-schema.md#catalog-entry).
+   Do not mix Chat Completions and Responses fields, or any other two surfaces,
+   in one entry.
 
    Optional lifecycle fields are `status` (`active`, `deprecated`, or
    `retired`), `replacement` (a provider-qualified model id), and `shutdownOn`
@@ -83,6 +89,7 @@ You don't need to know the schema to file one. A link to the official docs is th
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-sonnet-4-6
 params:
   - path: max_tokens

--- a/README.md
+++ b/README.md
@@ -146,20 +146,21 @@ The same model accepts different parameters on each host that serves it. The cat
 
 ## API surfaces
 
-One entry documents one wire format.
+Every catalog entry declares an `apiSurface`. It scopes the parameter paths to
+one request and SDK family, independently of provider, model, and auth type.
 
 | Surface                                                                                               | Status |
 | ----------------------------------------------------------------------------------------------------- | ------ |
 | OpenAI Chat Completions — openai, deepseek, xai, mistral, moonshot, alibaba, z-ai, groq, fireworks, … | ✅     |
+| OpenAI Responses — OpenAI subscription entries and xAI multi-agent models                             | ✅     |
 | Anthropic Messages                                                                                    | ✅     |
 | Google `generateContent`                                                                              | ✅     |
 | Amazon Bedrock `Converse` — every `bedrock/*` entry                                                   | ✅     |
 | Vertex AI `generateContent` — every `vertex/*` entry                                                  | ✅     |
-| Subscription plans (`-subscription` entries)                                                          | ✅     |
+| Cohere Chat                                                                                           | ✅     |
 | Amazon Bedrock `InvokeModel` (native per-vendor bodies)                                               | ❌     |
 | Vertex AI `rawPredict` (Anthropic, Meta, Mistral on Vertex)                                           | ❌     |
 | MiniMax native endpoint                                                                               | ❌     |
-| OpenAI Responses API                                                                                  | ❌     |
 | Google Interactions API                                                                               | ❌     |
 | xAI native SDK                                                                                        | ❌     |
 

--- a/api/v1/validate.ts
+++ b/api/v1/validate.ts
@@ -190,6 +190,7 @@ export default {
       model: resolved.id,
       provider: entry.provider,
       authType: entry.authType,
+      apiSurface: entry.apiSurface,
       // The exact string to put in the API request when the host's wire id
       // differs from the catalog slug (fireworks, groq).
       ...("wireId" in entry ? { wireId: entry.wireId } : {}),

--- a/docs/model-parameters-schema.md
+++ b/docs/model-parameters-schema.md
@@ -2,7 +2,7 @@
 
 The Model Parameters Schema (MPS) convention is the JSON/YAML shape used by
 modelparams.dev to describe the request parameters available for a specific
-provider, auth type, and model.
+provider, model, auth type, and API/SDK surface.
 
 This catalog is metadata. It describes knobs a consumer can put into an outbound
 model request, such as `temperature`, `top_p`, `max_tokens`,
@@ -17,13 +17,14 @@ The public runtime sources are:
 
 ## Catalog Entry
 
-Each entry describes exactly one provider/auth/model tuple and its available
+Each entry describes exactly one provider/model/auth/API-surface tuple and its available
 parameters.
 
 ```json
 {
   "provider": "anthropic",
   "authType": "api_key",
+  "apiSurface": "anthropic-messages",
   "model": "claude-haiku-4-5",
   "status": "active",
   "params": [
@@ -45,16 +46,12 @@ parameters.
 
 Conventions:
 
-- `provider`, `authType`, and `model` identify exactly one model route.
+- `provider`, `model`, `authType`, and `apiSurface` scope one parameter set.
 - `model` reuses the slug the catalog already uses for that model elsewhere,
   when the vendor publishes it first-party. `bedrock/claude-sonnet-4-5` matches
   `anthropic/claude-sonnet-4-5` on purpose: the provider axis only means
   something if the same model carries the same slug on every host.
-- `provider` is a kebab-case slug. It also fixes the wire format the entry
-  documents: every `params` path must belong to that one surface. Where a host
-  serves two (Bedrock's `Converse` and `InvokeModel`), the catalog documents the
-  one listed in the README's API surfaces table and omits the other rather than
-  mixing both vocabularies in one entry.
+- `provider` is a kebab-case slug.
 - `model` is the provider-native model id without path separators. Preserve
   upstream casing; it may contain dots or colons when the upstream model id does.
 - `wireId` is optional: the exact string to put in the request's own `model`
@@ -67,6 +64,14 @@ Conventions:
   go stale the next time the host adds a region. Availability per region is
   account state and is deliberately not recorded here.
 - `authType` is `api_key` or `subscription`.
+- `apiSurface` identifies the request and SDK family whose field names appear in
+  `params`. For example, OpenAI Chat Completions uses
+  `max_completion_tokens`, while OpenAI Responses uses
+  `max_output_tokens`. Do not combine fields from two surfaces in one entry.
+  Supported values are `openai-chat-completions`, `openai-responses`,
+  `anthropic-messages`, `google-generate-content`,
+  `amazon-bedrock-converse`, `google-vertex-generate-content`, and
+  `cohere-chat`.
 - `status` is `active`, `deprecated`, or `retired`. Omit it when lifecycle
   status has not been tracked; generated catalog data preserves the omission.
 - `replacement` is an optional provider-qualified model id, such as
@@ -105,7 +110,7 @@ up the target directly.
 ## Parameter Scope
 
 MPS entries should describe only parameters the user or consumer can configure
-for the selected provider/auth/model tuple.
+for the selected provider/model/auth/API-surface tuple.
 
 For `authType: api_key`, list parameters from the official provider API
 reference. Do not invent request fields the upstream API does not accept.

--- a/models/alibaba/deepseek-v3.2.yaml
+++ b/models/alibaba/deepseek-v3.2.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: deepseek-v3.2
 params:
   - path: max_completion_tokens

--- a/models/alibaba/deepseek-v4-flash-0731.yaml
+++ b/models/alibaba/deepseek-v4-flash-0731.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: deepseek-v4-flash-0731
 params:
   - path: max_completion_tokens

--- a/models/alibaba/deepseek-v4-flash.yaml
+++ b/models/alibaba/deepseek-v4-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: deepseek-v4-flash
 params:
   - path: max_completion_tokens

--- a/models/alibaba/deepseek-v4-pro-0813.yaml
+++ b/models/alibaba/deepseek-v4-pro-0813.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: deepseek-v4-pro-0813
 params:
   - path: max_completion_tokens

--- a/models/alibaba/deepseek-v4-pro.yaml
+++ b/models/alibaba/deepseek-v4-pro.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: deepseek-v4-pro
 params:
   - path: max_completion_tokens

--- a/models/alibaba/glm-5.1.yaml
+++ b/models/alibaba/glm-5.1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-5.1
 params:
   - path: max_completion_tokens

--- a/models/alibaba/glm-5.2.yaml
+++ b/models/alibaba/glm-5.2.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-5.2
 params:
   - path: max_completion_tokens

--- a/models/alibaba/kimi-k2.7-code.yaml
+++ b/models/alibaba/kimi-k2.7-code.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: kimi-k2.7-code
 params:
   - path: max_completion_tokens

--- a/models/alibaba/qwen-flash.yaml
+++ b/models/alibaba/qwen-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen-flash
 params:
   - path: max_tokens

--- a/models/alibaba/qwen-max.yaml
+++ b/models/alibaba/qwen-max.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen-max
 params:
   - path: max_tokens

--- a/models/alibaba/qwen-plus.yaml
+++ b/models/alibaba/qwen-plus.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen-plus
 params:
   - path: max_tokens

--- a/models/alibaba/qwen-turbo.yaml
+++ b/models/alibaba/qwen-turbo.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen-turbo
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3-235b-a22b-thinking-2507.yaml
+++ b/models/alibaba/qwen3-235b-a22b-thinking-2507.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3-235b-a22b-thinking-2507
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3-30b-a3b-instruct-2507.yaml
+++ b/models/alibaba/qwen3-30b-a3b-instruct-2507.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3-30b-a3b-instruct-2507
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3-30b-a3b-thinking-2507.yaml
+++ b/models/alibaba/qwen3-30b-a3b-thinking-2507.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3-30b-a3b-thinking-2507
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3-coder-flash.yaml
+++ b/models/alibaba/qwen3-coder-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3-coder-flash
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3-coder-next.yaml
+++ b/models/alibaba/qwen3-coder-next.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3-coder-next
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3-coder-plus.yaml
+++ b/models/alibaba/qwen3-coder-plus.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3-coder-plus
 status: deprecated
 replacement: alibaba/qwen3.7-plus

--- a/models/alibaba/qwen3-max.yaml
+++ b/models/alibaba/qwen3-max.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3-max
 status: active
 params:

--- a/models/alibaba/qwen3-next-80b-a3b-instruct.yaml
+++ b/models/alibaba/qwen3-next-80b-a3b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3-next-80b-a3b-instruct
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3-next-80b-a3b-thinking.yaml
+++ b/models/alibaba/qwen3-next-80b-a3b-thinking.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3-next-80b-a3b-thinking
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3-vl-235b-a22b-instruct.yaml
+++ b/models/alibaba/qwen3-vl-235b-a22b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3-vl-235b-a22b-instruct
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3-vl-235b-a22b-thinking.yaml
+++ b/models/alibaba/qwen3-vl-235b-a22b-thinking.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3-vl-235b-a22b-thinking
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3.5-122b-a10b.yaml
+++ b/models/alibaba/qwen3.5-122b-a10b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.5-122b-a10b
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3.5-27b.yaml
+++ b/models/alibaba/qwen3.5-27b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.5-27b
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3.5-35b-a3b.yaml
+++ b/models/alibaba/qwen3.5-35b-a3b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.5-35b-a3b
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3.5-397b-a17b.yaml
+++ b/models/alibaba/qwen3.5-397b-a17b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.5-397b-a17b
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3.5-flash.yaml
+++ b/models/alibaba/qwen3.5-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.5-flash
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3.5.yaml
+++ b/models/alibaba/qwen3.5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.5
 params:
   - path: max_tokens

--- a/models/alibaba/qwen3.6-27b.yaml
+++ b/models/alibaba/qwen3.6-27b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.6-27b
 params:
   - path: max_completion_tokens

--- a/models/alibaba/qwen3.6-35b-a3b.yaml
+++ b/models/alibaba/qwen3.6-35b-a3b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.6-35b-a3b
 params:
   - path: max_completion_tokens

--- a/models/alibaba/qwen3.6-flash.yaml
+++ b/models/alibaba/qwen3.6-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.6-flash
 status: active
 params:

--- a/models/alibaba/qwen3.6-max-preview.yaml
+++ b/models/alibaba/qwen3.6-max-preview.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.6-max-preview
 status: deprecated
 replacement: alibaba/qwen3.7-max

--- a/models/alibaba/qwen3.6-plus.yaml
+++ b/models/alibaba/qwen3.6-plus.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.6-plus
 params:
   - path: max_completion_tokens

--- a/models/alibaba/qwen3.7-flash.yaml
+++ b/models/alibaba/qwen3.7-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.7-flash
 params:
   - path: max_completion_tokens

--- a/models/alibaba/qwen3.7-max.yaml
+++ b/models/alibaba/qwen3.7-max.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.7-max
 status: active
 params:

--- a/models/alibaba/qwen3.7-plus.yaml
+++ b/models/alibaba/qwen3.7-plus.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.7-plus
 status: active
 params:

--- a/models/alibaba/qwen3.8-2.4t-a95b.yaml
+++ b/models/alibaba/qwen3.8-2.4t-a95b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.8-2.4t-a95b
 params:
   - path: max_completion_tokens

--- a/models/alibaba/qwen3.8-27b.yaml
+++ b/models/alibaba/qwen3.8-27b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.8-27b
 params:
   - path: max_completion_tokens

--- a/models/alibaba/qwen3.8-max.yaml
+++ b/models/alibaba/qwen3.8-max.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.8-max
 params:
   - path: max_completion_tokens

--- a/models/alibaba/qwq-plus.yaml
+++ b/models/alibaba/qwq-plus.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: alibaba
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwq-plus
 params:
   - path: max_tokens

--- a/models/anthropic/claude-3-5-haiku-20241022.yaml
+++ b/models/anthropic/claude-3-5-haiku-20241022.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-3-5-haiku-20241022
 status: retired
 replacement: anthropic/claude-haiku-4-5-20251001

--- a/models/anthropic/claude-3-5-haiku-latest.yaml
+++ b/models/anthropic/claude-3-5-haiku-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-3-5-haiku-latest
 status: retired
 replacement: anthropic/claude-haiku-4-5-20251001

--- a/models/anthropic/claude-3-5-sonnet-20241022.yaml
+++ b/models/anthropic/claude-3-5-sonnet-20241022.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-3-5-sonnet-20241022
 status: retired
 replacement: anthropic/claude-sonnet-4-6

--- a/models/anthropic/claude-3-5-sonnet-latest.yaml
+++ b/models/anthropic/claude-3-5-sonnet-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-3-5-sonnet-latest
 status: retired
 replacement: anthropic/claude-sonnet-4-6

--- a/models/anthropic/claude-3-7-sonnet-20250219.yaml
+++ b/models/anthropic/claude-3-7-sonnet-20250219.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-3-7-sonnet-20250219
 status: retired
 replacement: anthropic/claude-sonnet-4-6

--- a/models/anthropic/claude-3-7-sonnet-latest.yaml
+++ b/models/anthropic/claude-3-7-sonnet-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-3-7-sonnet-latest
 status: retired
 replacement: anthropic/claude-sonnet-4-6

--- a/models/anthropic/claude-3-opus-20240229.yaml
+++ b/models/anthropic/claude-3-opus-20240229.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-3-opus-20240229
 status: retired
 replacement: anthropic/claude-opus-4-8

--- a/models/anthropic/claude-3-opus-latest.yaml
+++ b/models/anthropic/claude-3-opus-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-3-opus-latest
 params:
   - path: max_tokens

--- a/models/anthropic/claude-fable-5-subscription.yaml
+++ b/models/anthropic/claude-fable-5-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-fable-5
 status: active
 params:

--- a/models/anthropic/claude-fable-5.yaml
+++ b/models/anthropic/claude-fable-5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-fable-5
 status: active
 params:

--- a/models/anthropic/claude-haiku-4-5-20251001-subscription.yaml
+++ b/models/anthropic/claude-haiku-4-5-20251001-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-haiku-4-5-20251001
 status: active
 params:

--- a/models/anthropic/claude-haiku-4-5-20251001.yaml
+++ b/models/anthropic/claude-haiku-4-5-20251001.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-haiku-4-5-20251001
 status: active
 params:

--- a/models/anthropic/claude-haiku-4-5-subscription.yaml
+++ b/models/anthropic/claude-haiku-4-5-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-haiku-4-5
 status: active
 params:

--- a/models/anthropic/claude-haiku-4-5.yaml
+++ b/models/anthropic/claude-haiku-4-5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-haiku-4-5
 status: active
 params:

--- a/models/anthropic/claude-haiku-4-subscription.yaml
+++ b/models/anthropic/claude-haiku-4-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-haiku-4
 params:
   - path: max_tokens

--- a/models/anthropic/claude-haiku-4.yaml
+++ b/models/anthropic/claude-haiku-4.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-haiku-4
 params:
   - path: max_tokens

--- a/models/anthropic/claude-opus-4-1-20250805-subscription.yaml
+++ b/models/anthropic/claude-opus-4-1-20250805-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-opus-4-1-20250805
 status: deprecated
 replacement: anthropic/claude-opus-4-8

--- a/models/anthropic/claude-opus-4-1-20250805.yaml
+++ b/models/anthropic/claude-opus-4-1-20250805.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-opus-4-1-20250805
 status: deprecated
 replacement: anthropic/claude-opus-4-8

--- a/models/anthropic/claude-opus-4-20250514-subscription.yaml
+++ b/models/anthropic/claude-opus-4-20250514-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-opus-4-20250514
 status: retired
 replacement: anthropic/claude-opus-4-8

--- a/models/anthropic/claude-opus-4-20250514.yaml
+++ b/models/anthropic/claude-opus-4-20250514.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-opus-4-20250514
 status: retired
 replacement: anthropic/claude-opus-4-8

--- a/models/anthropic/claude-opus-4-5-20251101-subscription.yaml
+++ b/models/anthropic/claude-opus-4-5-20251101-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-opus-4-5-20251101
 status: active
 params:

--- a/models/anthropic/claude-opus-4-5-20251101.yaml
+++ b/models/anthropic/claude-opus-4-5-20251101.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-opus-4-5-20251101
 status: active
 params:

--- a/models/anthropic/claude-opus-4-6-subscription.yaml
+++ b/models/anthropic/claude-opus-4-6-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-opus-4-6
 status: active
 params:

--- a/models/anthropic/claude-opus-4-6.yaml
+++ b/models/anthropic/claude-opus-4-6.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-opus-4-6
 status: active
 params:

--- a/models/anthropic/claude-opus-4-7-subscription.yaml
+++ b/models/anthropic/claude-opus-4-7-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-opus-4-7
 status: active
 params:

--- a/models/anthropic/claude-opus-4-7.yaml
+++ b/models/anthropic/claude-opus-4-7.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-opus-4-7
 status: active
 params:

--- a/models/anthropic/claude-opus-4-8-subscription.yaml
+++ b/models/anthropic/claude-opus-4-8-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-opus-4-8
 status: active
 params:

--- a/models/anthropic/claude-opus-4-8.yaml
+++ b/models/anthropic/claude-opus-4-8.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-opus-4-8
 status: active
 params:

--- a/models/anthropic/claude-opus-4-subscription.yaml
+++ b/models/anthropic/claude-opus-4-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-opus-4
 params:
   - path: max_tokens

--- a/models/anthropic/claude-opus-5-subscription.yaml
+++ b/models/anthropic/claude-opus-5-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-opus-5
 status: active
 params:

--- a/models/anthropic/claude-opus-5.yaml
+++ b/models/anthropic/claude-opus-5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-opus-5
 status: active
 params:

--- a/models/anthropic/claude-sonnet-4-20250514-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-20250514-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-sonnet-4-20250514
 status: retired
 replacement: anthropic/claude-sonnet-4-6

--- a/models/anthropic/claude-sonnet-4-20250514.yaml
+++ b/models/anthropic/claude-sonnet-4-20250514.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-sonnet-4-20250514
 status: retired
 replacement: anthropic/claude-sonnet-4-6

--- a/models/anthropic/claude-sonnet-4-5-20250929-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-5-20250929-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-sonnet-4-5-20250929
 status: active
 params:

--- a/models/anthropic/claude-sonnet-4-5-20250929.yaml
+++ b/models/anthropic/claude-sonnet-4-5-20250929.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-sonnet-4-5-20250929
 status: active
 params:

--- a/models/anthropic/claude-sonnet-4-5-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-5-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-sonnet-4-5
 status: active
 params:

--- a/models/anthropic/claude-sonnet-4-5.yaml
+++ b/models/anthropic/claude-sonnet-4-5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-sonnet-4-5
 status: active
 params:

--- a/models/anthropic/claude-sonnet-4-6-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-6-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-sonnet-4-6
 status: active
 params:

--- a/models/anthropic/claude-sonnet-4-6.yaml
+++ b/models/anthropic/claude-sonnet-4-6.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-sonnet-4-6
 status: active
 params:

--- a/models/anthropic/claude-sonnet-4-subscription.yaml
+++ b/models/anthropic/claude-sonnet-4-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-sonnet-4
 params:
   - path: max_tokens

--- a/models/anthropic/claude-sonnet-5-subscription.yaml
+++ b/models/anthropic/claude-sonnet-5-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-sonnet-5
 status: active
 params:

--- a/models/anthropic/claude-sonnet-5.yaml
+++ b/models/anthropic/claude-sonnet-5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-sonnet-5
 status: active
 params:

--- a/models/bedrock/claude-haiku-4-5.yaml
+++ b/models/bedrock/claude-haiku-4-5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: claude-haiku-4-5
 wireId: "{scope}.anthropic.claude-haiku-4-5-20251001-v1:0"
 params:

--- a/models/bedrock/claude-opus-4-5-20251101.yaml
+++ b/models/bedrock/claude-opus-4-5-20251101.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: claude-opus-4-5-20251101
 wireId: "{scope}.anthropic.claude-opus-4-5-20251101-v1:0"
 params:

--- a/models/bedrock/claude-opus-4-6.yaml
+++ b/models/bedrock/claude-opus-4-6.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: claude-opus-4-6
 wireId: "{scope}.anthropic.claude-opus-4-6-v1"
 params:

--- a/models/bedrock/claude-sonnet-4-5.yaml
+++ b/models/bedrock/claude-sonnet-4-5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: claude-sonnet-4-5
 wireId: "{scope}.anthropic.claude-sonnet-4-5-20250929-v1:0"
 params:

--- a/models/bedrock/claude-sonnet-4-6.yaml
+++ b/models/bedrock/claude-sonnet-4-6.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: claude-sonnet-4-6
 wireId: "{scope}.anthropic.claude-sonnet-4-6"
 params:

--- a/models/bedrock/deepseek-r1.yaml
+++ b/models/bedrock/deepseek-r1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: deepseek-r1
 wireId: "{scope}.deepseek.r1-v1:0"
 params:

--- a/models/bedrock/deepseek-v3.2.yaml
+++ b/models/bedrock/deepseek-v3.2.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: deepseek-v3.2
 wireId: deepseek.v3.2
 params:

--- a/models/bedrock/devstral-2-123b.yaml
+++ b/models/bedrock/devstral-2-123b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: devstral-2-123b
 wireId: mistral.devstral-2-123b
 params:

--- a/models/bedrock/gemma-3-12b-it.yaml
+++ b/models/bedrock/gemma-3-12b-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: gemma-3-12b-it
 wireId: google.gemma-3-12b-it
 params:

--- a/models/bedrock/gemma-3-27b-it.yaml
+++ b/models/bedrock/gemma-3-27b-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: gemma-3-27b-it
 wireId: google.gemma-3-27b-it
 params:

--- a/models/bedrock/gemma-3-4b-it.yaml
+++ b/models/bedrock/gemma-3-4b-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: gemma-3-4b-it
 wireId: google.gemma-3-4b-it
 params:

--- a/models/bedrock/glm-4.7-flash.yaml
+++ b/models/bedrock/glm-4.7-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: glm-4.7-flash
 wireId: zai.glm-4.7-flash
 params:

--- a/models/bedrock/glm-4.7.yaml
+++ b/models/bedrock/glm-4.7.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: glm-4.7
 wireId: zai.glm-4.7
 params:

--- a/models/bedrock/glm-5.yaml
+++ b/models/bedrock/glm-5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: glm-5
 wireId: zai.glm-5
 params:

--- a/models/bedrock/gpt-oss-120b.yaml
+++ b/models/bedrock/gpt-oss-120b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: gpt-oss-120b
 wireId: openai.gpt-oss-120b-1:0
 params:

--- a/models/bedrock/gpt-oss-20b.yaml
+++ b/models/bedrock/gpt-oss-20b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: gpt-oss-20b
 wireId: openai.gpt-oss-20b-1:0
 params:

--- a/models/bedrock/gpt-oss-safeguard-120b.yaml
+++ b/models/bedrock/gpt-oss-safeguard-120b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: gpt-oss-safeguard-120b
 wireId: openai.gpt-oss-safeguard-120b
 params:

--- a/models/bedrock/gpt-oss-safeguard-20b.yaml
+++ b/models/bedrock/gpt-oss-safeguard-20b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: gpt-oss-safeguard-20b
 wireId: openai.gpt-oss-safeguard-20b
 params:

--- a/models/bedrock/kimi-k2-thinking.yaml
+++ b/models/bedrock/kimi-k2-thinking.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: kimi-k2-thinking
 wireId: moonshot.kimi-k2-thinking
 params:

--- a/models/bedrock/kimi-k2.5.yaml
+++ b/models/bedrock/kimi-k2.5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: kimi-k2.5
 wireId: moonshotai.kimi-k2.5
 params:

--- a/models/bedrock/llama3-1-70b-instruct.yaml
+++ b/models/bedrock/llama3-1-70b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: llama3-1-70b-instruct
 wireId: "{scope}.meta.llama3-1-70b-instruct-v1:0"
 params:

--- a/models/bedrock/llama3-1-8b-instruct.yaml
+++ b/models/bedrock/llama3-1-8b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: llama3-1-8b-instruct
 wireId: "{scope}.meta.llama3-1-8b-instruct-v1:0"
 params:

--- a/models/bedrock/llama3-3-70b-instruct.yaml
+++ b/models/bedrock/llama3-3-70b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: llama3-3-70b-instruct
 wireId: "{scope}.meta.llama3-3-70b-instruct-v1:0"
 params:

--- a/models/bedrock/llama3-70b-instruct.yaml
+++ b/models/bedrock/llama3-70b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: llama3-70b-instruct
 wireId: meta.llama3-70b-instruct-v1:0
 params:

--- a/models/bedrock/llama3-8b-instruct.yaml
+++ b/models/bedrock/llama3-8b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: llama3-8b-instruct
 wireId: meta.llama3-8b-instruct-v1:0
 params:

--- a/models/bedrock/magistral-small-2509.yaml
+++ b/models/bedrock/magistral-small-2509.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: magistral-small-2509
 wireId: mistral.magistral-small-2509
 params:

--- a/models/bedrock/minimax-m2.1.yaml
+++ b/models/bedrock/minimax-m2.1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: minimax-m2.1
 wireId: minimax.minimax-m2.1
 params:

--- a/models/bedrock/minimax-m2.5.yaml
+++ b/models/bedrock/minimax-m2.5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: minimax-m2.5
 wireId: minimax.minimax-m2.5
 params:

--- a/models/bedrock/minimax-m2.yaml
+++ b/models/bedrock/minimax-m2.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: minimax-m2
 wireId: minimax.minimax-m2
 params:

--- a/models/bedrock/ministral-3-14b-instruct.yaml
+++ b/models/bedrock/ministral-3-14b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: ministral-3-14b-instruct
 wireId: mistral.ministral-3-14b-instruct
 params:

--- a/models/bedrock/ministral-3-3b-instruct.yaml
+++ b/models/bedrock/ministral-3-3b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: ministral-3-3b-instruct
 wireId: mistral.ministral-3-3b-instruct
 params:

--- a/models/bedrock/ministral-3-8b-instruct.yaml
+++ b/models/bedrock/ministral-3-8b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: ministral-3-8b-instruct
 wireId: mistral.ministral-3-8b-instruct
 params:

--- a/models/bedrock/mistral-7b-instruct.yaml
+++ b/models/bedrock/mistral-7b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: mistral-7b-instruct
 wireId: mistral.mistral-7b-instruct-v0:2
 params:

--- a/models/bedrock/mistral-large-2402.yaml
+++ b/models/bedrock/mistral-large-2402.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: mistral-large-2402
 wireId: mistral.mistral-large-2402-v1:0
 params:

--- a/models/bedrock/mistral-large-3-675b-instruct.yaml
+++ b/models/bedrock/mistral-large-3-675b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: mistral-large-3-675b-instruct
 wireId: mistral.mistral-large-3-675b-instruct
 params:

--- a/models/bedrock/mistral-small-2402.yaml
+++ b/models/bedrock/mistral-small-2402.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: mistral-small-2402
 wireId: mistral.mistral-small-2402-v1:0
 params:

--- a/models/bedrock/mixtral-8x7b-instruct.yaml
+++ b/models/bedrock/mixtral-8x7b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: mixtral-8x7b-instruct
 wireId: mistral.mixtral-8x7b-instruct-v0:1
 params:

--- a/models/bedrock/nemotron-nano-12b.yaml
+++ b/models/bedrock/nemotron-nano-12b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: nemotron-nano-12b
 wireId: nvidia.nemotron-nano-12b-v2
 params:

--- a/models/bedrock/nemotron-nano-3-30b.yaml
+++ b/models/bedrock/nemotron-nano-3-30b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: nemotron-nano-3-30b
 wireId: nvidia.nemotron-nano-3-30b
 params:

--- a/models/bedrock/nemotron-nano-9b.yaml
+++ b/models/bedrock/nemotron-nano-9b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: nemotron-nano-9b
 wireId: nvidia.nemotron-nano-9b-v2
 params:

--- a/models/bedrock/nemotron-super-3-120b.yaml
+++ b/models/bedrock/nemotron-super-3-120b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: nemotron-super-3-120b
 wireId: nvidia.nemotron-super-3-120b
 params:

--- a/models/bedrock/nova-2-lite.yaml
+++ b/models/bedrock/nova-2-lite.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: nova-2-lite
 wireId: "{scope}.amazon.nova-2-lite-v1:0"
 params:

--- a/models/bedrock/nova-lite.yaml
+++ b/models/bedrock/nova-lite.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: nova-lite
 status: active
 wireId: amazon.nova-lite-v1:0

--- a/models/bedrock/nova-micro.yaml
+++ b/models/bedrock/nova-micro.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: nova-micro
 status: active
 wireId: amazon.nova-micro-v1:0

--- a/models/bedrock/nova-pro.yaml
+++ b/models/bedrock/nova-pro.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: nova-pro
 status: active
 wireId: amazon.nova-pro-v1:0

--- a/models/bedrock/palmyra-vision-7b.yaml
+++ b/models/bedrock/palmyra-vision-7b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: palmyra-vision-7b
 wireId: writer.palmyra-vision-7b
 params:

--- a/models/bedrock/palmyra-x4.yaml
+++ b/models/bedrock/palmyra-x4.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: palmyra-x4
 wireId: "{scope}.writer.palmyra-x4-v1:0"
 params:

--- a/models/bedrock/palmyra-x5.yaml
+++ b/models/bedrock/palmyra-x5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: palmyra-x5
 wireId: "{scope}.writer.palmyra-x5-v1:0"
 params:

--- a/models/bedrock/pixtral-large-2502.yaml
+++ b/models/bedrock/pixtral-large-2502.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: pixtral-large-2502
 wireId: "{scope}.mistral.pixtral-large-2502-v1:0"
 params:

--- a/models/bedrock/qwen3-32b.yaml
+++ b/models/bedrock/qwen3-32b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: qwen3-32b
 wireId: qwen.qwen3-32b-v1:0
 params:

--- a/models/bedrock/qwen3-coder-30b-a3b.yaml
+++ b/models/bedrock/qwen3-coder-30b-a3b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: qwen3-coder-30b-a3b
 wireId: qwen.qwen3-coder-30b-a3b-v1:0
 params:

--- a/models/bedrock/qwen3-coder-next.yaml
+++ b/models/bedrock/qwen3-coder-next.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: qwen3-coder-next
 wireId: qwen.qwen3-coder-next
 params:

--- a/models/bedrock/qwen3-next-80b-a3b.yaml
+++ b/models/bedrock/qwen3-next-80b-a3b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: qwen3-next-80b-a3b
 wireId: qwen.qwen3-next-80b-a3b
 params:

--- a/models/bedrock/qwen3-vl-235b-a22b.yaml
+++ b/models/bedrock/qwen3-vl-235b-a22b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: qwen3-vl-235b-a22b
 wireId: qwen.qwen3-vl-235b-a22b
 params:

--- a/models/bedrock/voxtral-mini-3b-2507.yaml
+++ b/models/bedrock/voxtral-mini-3b-2507.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: voxtral-mini-3b-2507
 wireId: mistral.voxtral-mini-3b-2507
 params:

--- a/models/bedrock/voxtral-small-24b-2507.yaml
+++ b/models/bedrock/voxtral-small-24b-2507.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: bedrock
 authType: api_key
+apiSurface: amazon-bedrock-converse
 model: voxtral-small-24b-2507
 wireId: mistral.voxtral-small-24b-2507
 params:

--- a/models/cerebras/zai-glm-4.7.yaml
+++ b/models/cerebras/zai-glm-4.7.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: cerebras
 authType: api_key
+apiSurface: openai-chat-completions
 model: zai-glm-4.7
 params:
   - path: max_completion_tokens

--- a/models/cohere/command-a-03-2025.yaml
+++ b/models/cohere/command-a-03-2025.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: cohere
 authType: api_key
+apiSurface: cohere-chat
 model: command-a-03-2025
 status: active
 params:

--- a/models/cohere/command-a-plus-05-2026.yaml
+++ b/models/cohere/command-a-plus-05-2026.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: cohere
 authType: api_key
+apiSurface: cohere-chat
 model: command-a-plus-05-2026
 status: active
 params:

--- a/models/cohere/command-a-reasoning-08-2025.yaml
+++ b/models/cohere/command-a-reasoning-08-2025.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: cohere
 authType: api_key
+apiSurface: cohere-chat
 model: command-a-reasoning-08-2025
 status: active
 params:

--- a/models/cohere/command-a-translate-08-2025.yaml
+++ b/models/cohere/command-a-translate-08-2025.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: cohere
 authType: api_key
+apiSurface: cohere-chat
 model: command-a-translate-08-2025
 status: active
 params:

--- a/models/cohere/command-a-vision-07-2025.yaml
+++ b/models/cohere/command-a-vision-07-2025.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: cohere
 authType: api_key
+apiSurface: cohere-chat
 model: command-a-vision-07-2025
 status: active
 params:

--- a/models/cohere/command-r-08-2024.yaml
+++ b/models/cohere/command-r-08-2024.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: cohere
 authType: api_key
+apiSurface: cohere-chat
 model: command-r-08-2024
 status: active
 params:

--- a/models/cohere/command-r-plus-08-2024.yaml
+++ b/models/cohere/command-r-plus-08-2024.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: cohere
 authType: api_key
+apiSurface: cohere-chat
 model: command-r-plus-08-2024
 status: active
 params:

--- a/models/cohere/command-r7b-12-2024.yaml
+++ b/models/cohere/command-r7b-12-2024.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: cohere
 authType: api_key
+apiSurface: cohere-chat
 model: command-r7b-12-2024
 status: active
 params:

--- a/models/deepseek/deepseek-chat.yaml
+++ b/models/deepseek/deepseek-chat.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: deepseek
 authType: api_key
+apiSurface: openai-chat-completions
 model: deepseek-chat
 status: retired
 replacement: deepseek/deepseek-v4-flash

--- a/models/deepseek/deepseek-reasoner.yaml
+++ b/models/deepseek/deepseek-reasoner.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: deepseek
 authType: api_key
+apiSurface: openai-chat-completions
 model: deepseek-reasoner
 status: retired
 replacement: deepseek/deepseek-v4-flash

--- a/models/deepseek/deepseek-v4-flash.yaml
+++ b/models/deepseek/deepseek-v4-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: deepseek
 authType: api_key
+apiSurface: openai-chat-completions
 model: deepseek-v4-flash
 status: active
 params:

--- a/models/deepseek/deepseek-v4-pro.yaml
+++ b/models/deepseek/deepseek-v4-pro.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: deepseek
 authType: api_key
+apiSurface: openai-chat-completions
 model: deepseek-v4-pro
 status: active
 params:

--- a/models/fireworks/deepseek-v4-flash-0731.yaml
+++ b/models/fireworks/deepseek-v4-flash-0731.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: deepseek-v4-flash-0731
 wireId: accounts/fireworks/models/deepseek-v4-flash-0731
 params:

--- a/models/fireworks/deepseek-v4-pro-0813.yaml
+++ b/models/fireworks/deepseek-v4-pro-0813.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: deepseek-v4-pro-0813
 wireId: accounts/fireworks/models/deepseek-v4-pro-0813
 params:

--- a/models/fireworks/deepseek-v4-pro.yaml
+++ b/models/fireworks/deepseek-v4-pro.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: deepseek-v4-pro
 wireId: accounts/fireworks/models/deepseek-v4-pro
 params:

--- a/models/fireworks/glm-5p2.yaml
+++ b/models/fireworks/glm-5p2.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-5p2
 wireId: accounts/fireworks/models/glm-5p2
 params:

--- a/models/fireworks/gpt-oss-120b.yaml
+++ b/models/fireworks/gpt-oss-120b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-oss-120b
 wireId: accounts/fireworks/models/gpt-oss-120b
 params:

--- a/models/fireworks/gpt-oss-20b.yaml
+++ b/models/fireworks/gpt-oss-20b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-oss-20b
 wireId: accounts/fireworks/models/gpt-oss-20b
 params:

--- a/models/fireworks/inkling.yaml
+++ b/models/fireworks/inkling.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: inkling
 wireId: accounts/fireworks/models/inkling
 params:

--- a/models/fireworks/kimi-k2p6.yaml
+++ b/models/fireworks/kimi-k2p6.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: kimi-k2p6
 wireId: accounts/fireworks/models/kimi-k2p6
 params:

--- a/models/fireworks/kimi-k2p7-code.yaml
+++ b/models/fireworks/kimi-k2p7-code.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: kimi-k2p7-code
 wireId: accounts/fireworks/models/kimi-k2p7-code
 params:

--- a/models/fireworks/kimi-k3.yaml
+++ b/models/fireworks/kimi-k3.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: kimi-k3
 wireId: accounts/fireworks/models/kimi-k3
 params:

--- a/models/fireworks/minimax-m2p7.yaml
+++ b/models/fireworks/minimax-m2p7.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: minimax-m2p7
 wireId: accounts/fireworks/models/minimax-m2p7
 params:

--- a/models/fireworks/minimax-m3.yaml
+++ b/models/fireworks/minimax-m3.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: minimax-m3
 wireId: accounts/fireworks/models/minimax-m3
 params:

--- a/models/fireworks/muse-glimmer-30b.yaml
+++ b/models/fireworks/muse-glimmer-30b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: muse-glimmer-30b
 wireId: accounts/fireworks/models/muse-glimmer-30b
 params:

--- a/models/fireworks/qwen3p7-plus.yaml
+++ b/models/fireworks/qwen3p7-plus.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3p7-plus
 wireId: accounts/fireworks/models/qwen3p7-plus
 params:

--- a/models/fireworks/qwen3p8-2p4t-a95b.yaml
+++ b/models/fireworks/qwen3p8-2p4t-a95b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3p8-2p4t-a95b
 wireId: accounts/fireworks/models/qwen3p8-2p4t-a95b
 params:

--- a/models/fireworks/qwen3p8-max.yaml
+++ b/models/fireworks/qwen3p8-max.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: fireworks
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3p8-max
 wireId: accounts/fireworks/models/qwen3p8-max
 params:

--- a/models/google/gemini-2.5-flash-lite-subscription.yaml
+++ b/models/google/gemini-2.5-flash-lite-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: subscription
+apiSurface: google-generate-content
 model: gemini-2.5-flash-lite
 status: active
 replacement: google/gemini-3.1-flash-lite

--- a/models/google/gemini-2.5-flash-lite.yaml
+++ b/models/google/gemini-2.5-flash-lite.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemini-2.5-flash-lite
 status: active
 replacement: google/gemini-3.1-flash-lite

--- a/models/google/gemini-2.5-flash-subscription.yaml
+++ b/models/google/gemini-2.5-flash-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: subscription
+apiSurface: google-generate-content
 model: gemini-2.5-flash
 status: active
 replacement: google/gemini-3.6-flash

--- a/models/google/gemini-2.5-flash.yaml
+++ b/models/google/gemini-2.5-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemini-2.5-flash
 status: active
 replacement: google/gemini-3.6-flash

--- a/models/google/gemini-2.5-pro-subscription.yaml
+++ b/models/google/gemini-2.5-pro-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: subscription
+apiSurface: google-generate-content
 model: gemini-2.5-pro
 status: active
 replacement: google/gemini-3.1-pro-preview

--- a/models/google/gemini-2.5-pro.yaml
+++ b/models/google/gemini-2.5-pro.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemini-2.5-pro
 status: active
 replacement: google/gemini-3.1-pro-preview

--- a/models/google/gemini-3-flash-preview-subscription.yaml
+++ b/models/google/gemini-3-flash-preview-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: subscription
+apiSurface: google-generate-content
 model: gemini-3-flash-preview
 status: active
 replacement: google/gemini-3.6-flash

--- a/models/google/gemini-3-flash-preview.yaml
+++ b/models/google/gemini-3-flash-preview.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemini-3-flash-preview
 status: active
 replacement: google/gemini-3.6-flash

--- a/models/google/gemini-3.1-flash-lite-preview-subscription.yaml
+++ b/models/google/gemini-3.1-flash-lite-preview-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: subscription
+apiSurface: google-generate-content
 model: gemini-3.1-flash-lite-preview
 status: retired
 replacement: google/gemini-3.1-flash-lite

--- a/models/google/gemini-3.1-flash-lite-preview.yaml
+++ b/models/google/gemini-3.1-flash-lite-preview.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemini-3.1-flash-lite-preview
 status: retired
 replacement: google/gemini-3.1-flash-lite

--- a/models/google/gemini-3.1-flash-lite-subscription.yaml
+++ b/models/google/gemini-3.1-flash-lite-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: subscription
+apiSurface: google-generate-content
 model: gemini-3.1-flash-lite
 status: active
 replacement: google/gemini-3.5-flash-lite

--- a/models/google/gemini-3.1-flash-lite.yaml
+++ b/models/google/gemini-3.1-flash-lite.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemini-3.1-flash-lite
 status: active
 replacement: google/gemini-3.5-flash-lite

--- a/models/google/gemini-3.1-pro-preview-customtools.yaml
+++ b/models/google/gemini-3.1-pro-preview-customtools.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemini-3.1-pro-preview-customtools
 params:
   - path: generationConfig.maxOutputTokens

--- a/models/google/gemini-3.1-pro-preview-subscription.yaml
+++ b/models/google/gemini-3.1-pro-preview-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: subscription
+apiSurface: google-generate-content
 model: gemini-3.1-pro-preview
 status: active
 params:

--- a/models/google/gemini-3.1-pro-preview.yaml
+++ b/models/google/gemini-3.1-pro-preview.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemini-3.1-pro-preview
 status: active
 params:

--- a/models/google/gemini-3.5-flash-lite.yaml
+++ b/models/google/gemini-3.5-flash-lite.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemini-3.5-flash-lite
 status: active
 params:

--- a/models/google/gemini-3.5-flash.yaml
+++ b/models/google/gemini-3.5-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemini-3.5-flash
 status: active
 params:

--- a/models/google/gemini-3.6-flash.yaml
+++ b/models/google/gemini-3.6-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemini-3.6-flash
 status: active
 params:

--- a/models/google/gemini-3.7-flash.yaml
+++ b/models/google/gemini-3.7-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemini-3.7-flash
 params:
   - path: generationConfig.maxOutputTokens

--- a/models/google/gemini-flash-latest.yaml
+++ b/models/google/gemini-flash-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemini-flash-latest
 params:
   - path: generationConfig.maxOutputTokens

--- a/models/google/gemma-3-12b-it.yaml
+++ b/models/google/gemma-3-12b-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemma-3-12b-it
 params:
   - path: max_completion_tokens

--- a/models/google/gemma-3-1b-it.yaml
+++ b/models/google/gemma-3-1b-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemma-3-1b-it
 params:
   - path: max_completion_tokens

--- a/models/google/gemma-3-27b-it.yaml
+++ b/models/google/gemma-3-27b-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemma-3-27b-it
 params:
   - path: max_completion_tokens

--- a/models/google/gemma-3-4b-it.yaml
+++ b/models/google/gemma-3-4b-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemma-3-4b-it
 params:
   - path: max_completion_tokens

--- a/models/google/gemma-3n-E2B-it.yaml
+++ b/models/google/gemma-3n-E2B-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemma-3n-E2B-it
 params:
   - path: max_completion_tokens

--- a/models/google/gemma-3n-E4B-it.yaml
+++ b/models/google/gemma-3n-E4B-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemma-3n-E4B-it
 params:
   - path: max_completion_tokens

--- a/models/google/gemma-4-12B-it.yaml
+++ b/models/google/gemma-4-12B-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemma-4-12B-it
 params:
   - path: max_completion_tokens

--- a/models/google/gemma-4-26b-a4b-it.yaml
+++ b/models/google/gemma-4-26b-a4b-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemma-4-26b-a4b-it
 params:
   - path: generationConfig.maxOutputTokens

--- a/models/google/gemma-4-31b-it.yaml
+++ b/models/google/gemma-4-31b-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemma-4-31b-it
 params:
   - path: generationConfig.maxOutputTokens

--- a/models/google/gemma-4-E2B-it.yaml
+++ b/models/google/gemma-4-E2B-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemma-4-E2B-it
 params:
   - path: max_completion_tokens

--- a/models/google/gemma-4-E4B-it.yaml
+++ b/models/google/gemma-4-E4B-it.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: google
 authType: api_key
+apiSurface: google-generate-content
 model: gemma-4-E4B-it
 params:
   - path: max_completion_tokens

--- a/models/groq/gpt-oss-120b.yaml
+++ b/models/groq/gpt-oss-120b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: groq
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-oss-120b
 wireId: openai/gpt-oss-120b
 params:

--- a/models/groq/gpt-oss-20b.yaml
+++ b/models/groq/gpt-oss-20b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: groq
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-oss-20b
 wireId: openai/gpt-oss-20b
 params:

--- a/models/groq/gpt-oss-safeguard-20b.yaml
+++ b/models/groq/gpt-oss-safeguard-20b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: groq
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-oss-safeguard-20b
 wireId: openai/gpt-oss-safeguard-20b
 params:

--- a/models/groq/qwen3-32b.yaml
+++ b/models/groq/qwen3-32b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: groq
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3-32b
 params:
   - path: max_completion_tokens

--- a/models/groq/qwen3.6-27b.yaml
+++ b/models/groq/qwen3.6-27b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: groq
 authType: api_key
+apiSurface: openai-chat-completions
 model: qwen3.6-27b
 wireId: qwen/qwen3.6-27b
 params:

--- a/models/meta/Llama-3.3-70B-Instruct.yaml
+++ b/models/meta/Llama-3.3-70B-Instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: meta
 authType: api_key
+apiSurface: openai-chat-completions
 model: Llama-3.3-70B-Instruct
 params:
   - path: max_completion_tokens

--- a/models/meta/Llama-3.3-8B-Instruct.yaml
+++ b/models/meta/Llama-3.3-8B-Instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: meta
 authType: api_key
+apiSurface: openai-chat-completions
 model: Llama-3.3-8B-Instruct
 params:
   - path: max_completion_tokens

--- a/models/meta/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+++ b/models/meta/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: meta
 authType: api_key
+apiSurface: openai-chat-completions
 model: Llama-4-Maverick-17B-128E-Instruct-FP8
 params:
   - path: max_completion_tokens

--- a/models/meta/Llama-4-Scout-17B-16E-Instruct-FP8.yaml
+++ b/models/meta/Llama-4-Scout-17B-16E-Instruct-FP8.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: meta
 authType: api_key
+apiSurface: openai-chat-completions
 model: Llama-4-Scout-17B-16E-Instruct-FP8
 params:
   - path: max_completion_tokens

--- a/models/meta/muse-spark-1.1.yaml
+++ b/models/meta/muse-spark-1.1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: meta
 authType: api_key
+apiSurface: openai-chat-completions
 model: muse-spark-1.1
 params:
   - path: max_completion_tokens

--- a/models/meta/muse-spark-1.2-contributor.yaml
+++ b/models/meta/muse-spark-1.2-contributor.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: meta
 authType: api_key
+apiSurface: openai-chat-completions
 model: muse-spark-1.2-contributor
 params:
   - path: max_completion_tokens

--- a/models/minimax/MiniMax-M2-subscription.yaml
+++ b/models/minimax/MiniMax-M2-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: subscription
+apiSurface: openai-chat-completions
 model: MiniMax-M2
 status: active
 params:

--- a/models/minimax/MiniMax-M2.1-highspeed-subscription.yaml
+++ b/models/minimax/MiniMax-M2.1-highspeed-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: subscription
+apiSurface: openai-chat-completions
 model: MiniMax-M2.1-highspeed
 status: active
 params:

--- a/models/minimax/MiniMax-M2.1-subscription.yaml
+++ b/models/minimax/MiniMax-M2.1-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: subscription
+apiSurface: openai-chat-completions
 model: MiniMax-M2.1
 status: active
 params:

--- a/models/minimax/MiniMax-M2.5-highspeed-subscription.yaml
+++ b/models/minimax/MiniMax-M2.5-highspeed-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: subscription
+apiSurface: openai-chat-completions
 model: MiniMax-M2.5-highspeed
 status: active
 params:

--- a/models/minimax/MiniMax-M2.5-subscription.yaml
+++ b/models/minimax/MiniMax-M2.5-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: subscription
+apiSurface: openai-chat-completions
 model: MiniMax-M2.5
 status: active
 params:

--- a/models/minimax/MiniMax-M2.7-highspeed-subscription.yaml
+++ b/models/minimax/MiniMax-M2.7-highspeed-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: subscription
+apiSurface: openai-chat-completions
 model: MiniMax-M2.7-highspeed
 status: active
 params:

--- a/models/minimax/MiniMax-M2.7-subscription.yaml
+++ b/models/minimax/MiniMax-M2.7-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: subscription
+apiSurface: openai-chat-completions
 model: MiniMax-M2.7
 status: active
 params:

--- a/models/minimax/MiniMax-M3-subscription.yaml
+++ b/models/minimax/MiniMax-M3-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: subscription
+apiSurface: openai-chat-completions
 model: MiniMax-M3
 status: active
 params:

--- a/models/minimax/minimax-m2.1-highspeed.yaml
+++ b/models/minimax/minimax-m2.1-highspeed.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: api_key
+apiSurface: openai-chat-completions
 model: minimax-m2.1-highspeed
 params:
   - path: max_completion_tokens

--- a/models/minimax/minimax-m2.1.yaml
+++ b/models/minimax/minimax-m2.1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: api_key
+apiSurface: openai-chat-completions
 model: minimax-m2.1
 params:
   - path: max_completion_tokens

--- a/models/minimax/minimax-m2.5-highspeed.yaml
+++ b/models/minimax/minimax-m2.5-highspeed.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: api_key
+apiSurface: openai-chat-completions
 model: minimax-m2.5-highspeed
 params:
   - path: max_completion_tokens

--- a/models/minimax/minimax-m2.5.yaml
+++ b/models/minimax/minimax-m2.5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: api_key
+apiSurface: openai-chat-completions
 model: minimax-m2.5
 params:
   - path: max_completion_tokens

--- a/models/minimax/minimax-m2.7-highspeed.yaml
+++ b/models/minimax/minimax-m2.7-highspeed.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: api_key
+apiSurface: openai-chat-completions
 model: minimax-m2.7-highspeed
 params:
   - path: max_completion_tokens

--- a/models/minimax/minimax-m2.7.yaml
+++ b/models/minimax/minimax-m2.7.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: api_key
+apiSurface: openai-chat-completions
 model: minimax-m2.7
 params:
   - path: max_completion_tokens

--- a/models/minimax/minimax-m2.yaml
+++ b/models/minimax/minimax-m2.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: api_key
+apiSurface: openai-chat-completions
 model: minimax-m2
 params:
   - path: max_completion_tokens

--- a/models/minimax/minimax-m3.yaml
+++ b/models/minimax/minimax-m3.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: minimax
 authType: api_key
+apiSurface: openai-chat-completions
 model: minimax-m3
 params:
   - path: max_completion_tokens

--- a/models/mistral/codestral-2508.yaml
+++ b/models/mistral/codestral-2508.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: codestral-2508
 params:
   - path: max_tokens

--- a/models/mistral/codestral-latest.yaml
+++ b/models/mistral/codestral-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: codestral-latest
 params:
   - path: max_tokens

--- a/models/mistral/devstral-2512.yaml
+++ b/models/mistral/devstral-2512.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: devstral-2512
 status: retired
 replacement: mistral/mistral-medium-3-5-26-04

--- a/models/mistral/devstral-latest.yaml
+++ b/models/mistral/devstral-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: devstral-latest
 params:
   - path: max_tokens

--- a/models/mistral/magistral-medium-latest.yaml
+++ b/models/mistral/magistral-medium-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: magistral-medium-latest
 params:
   - path: max_tokens

--- a/models/mistral/magistral-small-latest.yaml
+++ b/models/mistral/magistral-small-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: magistral-small-latest
 params:
   - path: max_tokens

--- a/models/mistral/ministral-14b-2512.yaml
+++ b/models/mistral/ministral-14b-2512.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: ministral-14b-2512
 params:
   - path: max_tokens

--- a/models/mistral/ministral-14b-latest.yaml
+++ b/models/mistral/ministral-14b-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: ministral-14b-latest
 params:
   - path: max_tokens

--- a/models/mistral/ministral-3b-2512.yaml
+++ b/models/mistral/ministral-3b-2512.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: ministral-3b-2512
 params:
   - path: max_tokens

--- a/models/mistral/ministral-3b-latest.yaml
+++ b/models/mistral/ministral-3b-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: ministral-3b-latest
 params:
   - path: max_tokens

--- a/models/mistral/ministral-8b-2512.yaml
+++ b/models/mistral/ministral-8b-2512.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: ministral-8b-2512
 params:
   - path: max_tokens

--- a/models/mistral/ministral-8b-latest.yaml
+++ b/models/mistral/ministral-8b-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: ministral-8b-latest
 params:
   - path: max_tokens

--- a/models/mistral/mistral-large-2512.yaml
+++ b/models/mistral/mistral-large-2512.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: mistral-large-2512
 params:
   - path: max_tokens

--- a/models/mistral/mistral-large-latest.yaml
+++ b/models/mistral/mistral-large-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: mistral-large-latest
 params:
   - path: max_tokens

--- a/models/mistral/mistral-medium-3.5.yaml
+++ b/models/mistral/mistral-medium-3.5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: mistral-medium-3.5
 params:
   - path: max_tokens

--- a/models/mistral/mistral-medium-3.yaml
+++ b/models/mistral/mistral-medium-3.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: mistral-medium-3
 params:
   - path: max_tokens

--- a/models/mistral/mistral-medium-latest.yaml
+++ b/models/mistral/mistral-medium-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: mistral-medium-latest
 params:
   - path: max_tokens

--- a/models/mistral/mistral-small-2603.yaml
+++ b/models/mistral/mistral-small-2603.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: mistral-small-2603
 params:
   - path: max_tokens

--- a/models/mistral/mistral-small-latest.yaml
+++ b/models/mistral/mistral-small-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: mistral-small-latest
 params:
   - path: max_tokens

--- a/models/mistral/open-mistral-nemo.yaml
+++ b/models/mistral/open-mistral-nemo.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: mistral
 authType: api_key
+apiSurface: openai-chat-completions
 model: open-mistral-nemo
 status: deprecated
 params:

--- a/models/moonshot/kimi-k2.5.yaml
+++ b/models/moonshot/kimi-k2.5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: moonshot
 authType: api_key
+apiSurface: openai-chat-completions
 model: kimi-k2.5
 status: deprecated
 replacement: moonshot/kimi-k2.6

--- a/models/moonshot/kimi-k2.6-subscription.yaml
+++ b/models/moonshot/kimi-k2.6-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: moonshot
 authType: subscription
+apiSurface: openai-chat-completions
 model: kimi-k2.6
 status: active
 params:

--- a/models/moonshot/kimi-k2.6.yaml
+++ b/models/moonshot/kimi-k2.6.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: moonshot
 authType: api_key
+apiSurface: openai-chat-completions
 model: kimi-k2.6
 status: active
 params:

--- a/models/moonshot/kimi-k2.7-code-highspeed-subscription.yaml
+++ b/models/moonshot/kimi-k2.7-code-highspeed-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: moonshot
 authType: subscription
+apiSurface: openai-chat-completions
 model: kimi-k2.7-code-highspeed
 status: active
 params:

--- a/models/moonshot/kimi-k2.7-code-highspeed.yaml
+++ b/models/moonshot/kimi-k2.7-code-highspeed.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: moonshot
 authType: api_key
+apiSurface: openai-chat-completions
 model: kimi-k2.7-code-highspeed
 status: active
 params:

--- a/models/moonshot/kimi-k2.7-code-subscription.yaml
+++ b/models/moonshot/kimi-k2.7-code-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: moonshot
 authType: subscription
+apiSurface: openai-chat-completions
 model: kimi-k2.7-code
 status: active
 params:

--- a/models/moonshot/kimi-k2.7-code.yaml
+++ b/models/moonshot/kimi-k2.7-code.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: moonshot
 authType: api_key
+apiSurface: openai-chat-completions
 model: kimi-k2.7-code
 status: active
 params:

--- a/models/moonshot/kimi-k3.yaml
+++ b/models/moonshot/kimi-k3.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: moonshot
 authType: api_key
+apiSurface: openai-chat-completions
 model: kimi-k3
 status: active
 params:

--- a/models/moonshot/moonshot-v1-128k.yaml
+++ b/models/moonshot/moonshot-v1-128k.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: moonshot
 authType: api_key
+apiSurface: openai-chat-completions
 model: moonshot-v1-128k
 status: deprecated
 replacement: moonshot/kimi-k2.6

--- a/models/moonshot/moonshot-v1-32k.yaml
+++ b/models/moonshot/moonshot-v1-32k.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: moonshot
 authType: api_key
+apiSurface: openai-chat-completions
 model: moonshot-v1-32k
 status: deprecated
 replacement: moonshot/kimi-k2.6

--- a/models/moonshot/moonshot-v1-8k.yaml
+++ b/models/moonshot/moonshot-v1-8k.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: moonshot
 authType: api_key
+apiSurface: openai-chat-completions
 model: moonshot-v1-8k
 status: deprecated
 replacement: moonshot/kimi-k2.6

--- a/models/nvidia/deepseek-v4-flash-0731.yaml
+++ b/models/nvidia/deepseek-v4-flash-0731.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: deepseek-v4-flash-0731
 wireId: deepseek-ai/deepseek-v4-flash-0731
 params:

--- a/models/nvidia/gliner-pii.yaml
+++ b/models/nvidia/gliner-pii.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: gliner-pii
 params:
   - path: threshold

--- a/models/nvidia/llama-3.1-nemoguard-8b-topic-control.yaml
+++ b/models/nvidia/llama-3.1-nemoguard-8b-topic-control.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: llama-3.1-nemoguard-8b-topic-control
 params:
   - path: temperature

--- a/models/nvidia/llama-3.1-nemotron-nano-8b-v1.yaml
+++ b/models/nvidia/llama-3.1-nemotron-nano-8b-v1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: llama-3.1-nemotron-nano-8b-v1
 params:
   - path: temperature

--- a/models/nvidia/llama-3.1-nemotron-safety-guard-8b-v3.yaml
+++ b/models/nvidia/llama-3.1-nemotron-safety-guard-8b-v3.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: llama-3.1-nemotron-safety-guard-8b-v3
 params:
   - path: temperature

--- a/models/nvidia/llama-3.1-nemotron-ultra-253b-v1.yaml
+++ b/models/nvidia/llama-3.1-nemotron-ultra-253b-v1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: llama-3.1-nemotron-ultra-253b-v1
 params:
   - path: temperature

--- a/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.yaml
+++ b/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: llama-3.3-nemotron-super-49b-v1.5
 params:
   - path: temperature

--- a/models/nvidia/llama-3.3-nemotron-super-49b-v1.yaml
+++ b/models/nvidia/llama-3.3-nemotron-super-49b-v1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: llama-3.3-nemotron-super-49b-v1
 params:
   - path: temperature

--- a/models/nvidia/nemoguard-jailbreak-detect.yaml
+++ b/models/nvidia/nemoguard-jailbreak-detect.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: nemoguard-jailbreak-detect
 params: []

--- a/models/nvidia/nemotron-3-nano-30b-a3b.yaml
+++ b/models/nvidia/nemotron-3-nano-30b-a3b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: nemotron-3-nano-30b-a3b
 params:
   - path: temperature

--- a/models/nvidia/nemotron-3-super-120b-a12b.yaml
+++ b/models/nvidia/nemotron-3-super-120b-a12b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: nemotron-3-super-120b-a12b
 params:
   - path: temperature

--- a/models/nvidia/nemotron-3-ultra-550b-a55b.yaml
+++ b/models/nvidia/nemotron-3-ultra-550b-a55b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: nemotron-3-ultra-550b-a55b
 params:
   - path: temperature

--- a/models/nvidia/nemotron-3-ultra-subscription.yaml
+++ b/models/nvidia/nemotron-3-ultra-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: subscription
+apiSurface: openai-chat-completions
 model: nemotron-3-ultra
 params:
   - path: temperature

--- a/models/nvidia/nemotron-content-safety-reasoning-4b.yaml
+++ b/models/nvidia/nemotron-content-safety-reasoning-4b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: nemotron-content-safety-reasoning-4b
 params:
   - path: temperature

--- a/models/nvidia/nemotron-mini-4b-instruct.yaml
+++ b/models/nvidia/nemotron-mini-4b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: nemotron-mini-4b-instruct
 params:
   - path: temperature

--- a/models/nvidia/riva-translate-4b-instruct-v1.1.yaml
+++ b/models/nvidia/riva-translate-4b-instruct-v1.1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: riva-translate-4b-instruct-v1.1
 params:
   - path: temperature

--- a/models/nvidia/usdcode-llama-3.1-70b-instruct.yaml
+++ b/models/nvidia/usdcode-llama-3.1-70b-instruct.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: nvidia
 authType: api_key
+apiSurface: openai-chat-completions
 model: usdcode-llama-3.1-70b-instruct
 params:
   - path: temperature

--- a/models/openai/chatgpt-4o-latest.yaml
+++ b/models/openai/chatgpt-4o-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: chatgpt-4o-latest
 status: retired
 replacement: openai/gpt-5.1-chat-latest

--- a/models/openai/gpt-3.5-turbo-16k.yaml
+++ b/models/openai/gpt-3.5-turbo-16k.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-3.5-turbo-16k
 params:
   - path: max_tokens

--- a/models/openai/gpt-3.5-turbo.yaml
+++ b/models/openai/gpt-3.5-turbo.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-3.5-turbo
 status: deprecated
 replacement: openai/gpt-5.6-terra

--- a/models/openai/gpt-4-0613.yaml
+++ b/models/openai/gpt-4-0613.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-4-0613
 status: deprecated
 replacement: openai/gpt-5.6-sol

--- a/models/openai/gpt-4-turbo-2024-04-09.yaml
+++ b/models/openai/gpt-4-turbo-2024-04-09.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-4-turbo-2024-04-09
 status: deprecated
 replacement: openai/gpt-5.6-sol

--- a/models/openai/gpt-4-turbo.yaml
+++ b/models/openai/gpt-4-turbo.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-4-turbo
 status: deprecated
 replacement: openai/gpt-5.6-sol

--- a/models/openai/gpt-4.1-mini.yaml
+++ b/models/openai/gpt-4.1-mini.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-4.1-mini
 status: active
 params:

--- a/models/openai/gpt-4.1-nano.yaml
+++ b/models/openai/gpt-4.1-nano.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-4.1-nano
 status: deprecated
 replacement: openai/gpt-5.6-luna

--- a/models/openai/gpt-4.1.yaml
+++ b/models/openai/gpt-4.1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-4.1
 status: active
 params:

--- a/models/openai/gpt-4.yaml
+++ b/models/openai/gpt-4.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-4
 status: deprecated
 replacement: openai/gpt-5.6-sol

--- a/models/openai/gpt-4o-2024-11-20.yaml
+++ b/models/openai/gpt-4o-2024-11-20.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-4o-2024-11-20
 params:
   - path: max_tokens

--- a/models/openai/gpt-4o-mini.yaml
+++ b/models/openai/gpt-4o-mini.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-4o-mini
 status: active
 params:

--- a/models/openai/gpt-4o.yaml
+++ b/models/openai/gpt-4o.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-4o
 status: active
 params:

--- a/models/openai/gpt-5-chat-latest.yaml
+++ b/models/openai/gpt-5-chat-latest.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5-chat-latest
 status: retired
 replacement: openai/gpt-5.6-sol

--- a/models/openai/gpt-5-mini.yaml
+++ b/models/openai/gpt-5-mini.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5-mini
 status: deprecated
 replacement: openai/gpt-5.6-terra

--- a/models/openai/gpt-5-nano.yaml
+++ b/models/openai/gpt-5-nano.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5-nano
 status: deprecated
 replacement: openai/gpt-5.6-luna

--- a/models/openai/gpt-5.1-codex-max-subscription.yaml
+++ b/models/openai/gpt-5.1-codex-max-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.1-codex-max
 status: retired
 replacement: openai/gpt-5.3-codex

--- a/models/openai/gpt-5.1-codex-subscription.yaml
+++ b/models/openai/gpt-5.1-codex-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.1-codex
 status: retired
 replacement: openai/gpt-5.3-codex

--- a/models/openai/gpt-5.1.yaml
+++ b/models/openai/gpt-5.1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5.1
 params:
   - path: max_completion_tokens

--- a/models/openai/gpt-5.2-codex-subscription.yaml
+++ b/models/openai/gpt-5.2-codex-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.2-codex
 status: retired
 replacement: openai/gpt-5.3-codex

--- a/models/openai/gpt-5.2-subscription.yaml
+++ b/models/openai/gpt-5.2-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.2
 params:
   - path: reasoning.effort

--- a/models/openai/gpt-5.2.yaml
+++ b/models/openai/gpt-5.2.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5.2
 params:
   - path: max_completion_tokens

--- a/models/openai/gpt-5.3-codex-spark-subscription.yaml
+++ b/models/openai/gpt-5.3-codex-spark-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.3-codex-spark
 status: active
 params:

--- a/models/openai/gpt-5.3-codex-subscription.yaml
+++ b/models/openai/gpt-5.3-codex-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.3-codex
 status: active
 params:

--- a/models/openai/gpt-5.3-codex.yaml
+++ b/models/openai/gpt-5.3-codex.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5.3-codex
 status: active
 params:

--- a/models/openai/gpt-5.4-mini-subscription.yaml
+++ b/models/openai/gpt-5.4-mini-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.4-mini
 status: active
 params:

--- a/models/openai/gpt-5.4-mini.yaml
+++ b/models/openai/gpt-5.4-mini.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5.4-mini
 status: active
 params:

--- a/models/openai/gpt-5.4-nano.yaml
+++ b/models/openai/gpt-5.4-nano.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5.4-nano
 status: active
 params:

--- a/models/openai/gpt-5.4-pro-subscription.yaml
+++ b/models/openai/gpt-5.4-pro-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.4-pro
 status: active
 params:

--- a/models/openai/gpt-5.4-pro.yaml
+++ b/models/openai/gpt-5.4-pro.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5.4-pro
 status: active
 params:

--- a/models/openai/gpt-5.4-subscription.yaml
+++ b/models/openai/gpt-5.4-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.4
 status: active
 params:

--- a/models/openai/gpt-5.4.yaml
+++ b/models/openai/gpt-5.4.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5.4
 status: active
 params:

--- a/models/openai/gpt-5.5-pro-subscription.yaml
+++ b/models/openai/gpt-5.5-pro-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.5-pro
 status: active
 params:

--- a/models/openai/gpt-5.5-pro.yaml
+++ b/models/openai/gpt-5.5-pro.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5.5-pro
 status: active
 params:

--- a/models/openai/gpt-5.5-subscription.yaml
+++ b/models/openai/gpt-5.5-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.5
 status: active
 params:

--- a/models/openai/gpt-5.5.yaml
+++ b/models/openai/gpt-5.5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5.5
 status: active
 params:

--- a/models/openai/gpt-5.6-luna-subscription.yaml
+++ b/models/openai/gpt-5.6-luna-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.6-luna
 status: active
 params:

--- a/models/openai/gpt-5.6-luna.yaml
+++ b/models/openai/gpt-5.6-luna.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5.6-luna
 status: active
 params:

--- a/models/openai/gpt-5.6-sol-subscription.yaml
+++ b/models/openai/gpt-5.6-sol-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.6-sol
 status: active
 params:

--- a/models/openai/gpt-5.6-sol.yaml
+++ b/models/openai/gpt-5.6-sol.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5.6-sol
 status: active
 params:

--- a/models/openai/gpt-5.6-terra-subscription.yaml
+++ b/models/openai/gpt-5.6-terra-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: subscription
+apiSurface: openai-responses
 model: gpt-5.6-terra
 status: active
 params:

--- a/models/openai/gpt-5.6-terra.yaml
+++ b/models/openai/gpt-5.6-terra.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5.6-terra
 status: active
 params:

--- a/models/openai/gpt-5.6.yaml
+++ b/models/openai/gpt-5.6.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5.6
 params:
   - path: max_completion_tokens

--- a/models/openai/gpt-5.yaml
+++ b/models/openai/gpt-5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-5
 status: deprecated
 replacement: openai/gpt-5.6-sol

--- a/models/openai/gpt-oss-120b.yaml
+++ b/models/openai/gpt-oss-120b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-oss-120b
 status: active
 params:

--- a/models/openai/gpt-oss-20b.yaml
+++ b/models/openai/gpt-oss-20b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-oss-20b
 status: active
 params:

--- a/models/openai/gpt-oss-safeguard-120b.yaml
+++ b/models/openai/gpt-oss-safeguard-120b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-oss-safeguard-120b
 params:
   - path: max_completion_tokens

--- a/models/openai/gpt-oss-safeguard-20b.yaml
+++ b/models/openai/gpt-oss-safeguard-20b.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: gpt-oss-safeguard-20b
 params:
   - path: max_completion_tokens

--- a/models/openai/o1-mini.yaml
+++ b/models/openai/o1-mini.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: o1-mini
 status: retired
 replacement: openai/o4-mini

--- a/models/openai/o1-preview.yaml
+++ b/models/openai/o1-preview.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: o1-preview
 status: retired
 replacement: openai/o3

--- a/models/openai/o1.yaml
+++ b/models/openai/o1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: o1
 status: deprecated
 replacement: openai/gpt-5.6-sol

--- a/models/openai/o3-mini.yaml
+++ b/models/openai/o3-mini.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: o3-mini
 status: deprecated
 replacement: openai/gpt-5.6-sol

--- a/models/openai/o3-pro.yaml
+++ b/models/openai/o3-pro.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: o3-pro
 status: deprecated
 replacement: openai/gpt-5.6-sol

--- a/models/openai/o3.yaml
+++ b/models/openai/o3.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: o3
 status: deprecated
 replacement: openai/gpt-5.6-sol

--- a/models/openai/o4-mini.yaml
+++ b/models/openai/o4-mini.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: openai
 authType: api_key
+apiSurface: openai-chat-completions
 model: o4-mini
 status: deprecated
 replacement: openai/gpt-5.6-terra

--- a/models/perplexity/sonar-deep-research.yaml
+++ b/models/perplexity/sonar-deep-research.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: perplexity
 authType: api_key
+apiSurface: openai-chat-completions
 model: sonar-deep-research
 params:
   - path: max_tokens

--- a/models/perplexity/sonar-pro.yaml
+++ b/models/perplexity/sonar-pro.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: perplexity
 authType: api_key
+apiSurface: openai-chat-completions
 model: sonar-pro
 params:
   - path: max_tokens

--- a/models/perplexity/sonar-reasoning-pro.yaml
+++ b/models/perplexity/sonar-reasoning-pro.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: perplexity
 authType: api_key
+apiSurface: openai-chat-completions
 model: sonar-reasoning-pro
 params:
   - path: max_tokens

--- a/models/perplexity/sonar.yaml
+++ b/models/perplexity/sonar.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: perplexity
 authType: api_key
+apiSurface: openai-chat-completions
 model: sonar
 params:
   - path: max_tokens

--- a/models/thinking-machines/Inkling.yaml
+++ b/models/thinking-machines/Inkling.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: thinking-machines
 authType: api_key
+apiSurface: openai-chat-completions
 model: Inkling
 params:
   - path: max_tokens

--- a/models/vertex/gemini-2.5-flash-lite.yaml
+++ b/models/vertex/gemini-2.5-flash-lite.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: vertex
 authType: api_key
+apiSurface: google-vertex-generate-content
 model: gemini-2.5-flash-lite
 status: deprecated
 replacement: vertex/gemini-3.1-flash-lite

--- a/models/vertex/gemini-2.5-flash.yaml
+++ b/models/vertex/gemini-2.5-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: vertex
 authType: api_key
+apiSurface: google-vertex-generate-content
 model: gemini-2.5-flash
 status: deprecated
 replacement: vertex/gemini-3.5-flash-lite

--- a/models/vertex/gemini-2.5-pro.yaml
+++ b/models/vertex/gemini-2.5-pro.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: vertex
 authType: api_key
+apiSurface: google-vertex-generate-content
 model: gemini-2.5-pro
 status: deprecated
 replacement: vertex/gemini-3.5-flash

--- a/models/vertex/gemini-3-flash-preview.yaml
+++ b/models/vertex/gemini-3-flash-preview.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: vertex
 authType: api_key
+apiSurface: google-vertex-generate-content
 model: gemini-3-flash-preview
 params:
   - path: generationConfig.maxOutputTokens

--- a/models/vertex/gemini-3.1-flash-lite.yaml
+++ b/models/vertex/gemini-3.1-flash-lite.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: vertex
 authType: api_key
+apiSurface: google-vertex-generate-content
 model: gemini-3.1-flash-lite
 status: active
 params:

--- a/models/vertex/gemini-3.1-pro-preview-customtools.yaml
+++ b/models/vertex/gemini-3.1-pro-preview-customtools.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: vertex
 authType: api_key
+apiSurface: google-vertex-generate-content
 model: gemini-3.1-pro-preview-customtools
 params:
   - path: generationConfig.maxOutputTokens

--- a/models/vertex/gemini-3.1-pro-preview.yaml
+++ b/models/vertex/gemini-3.1-pro-preview.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: vertex
 authType: api_key
+apiSurface: google-vertex-generate-content
 model: gemini-3.1-pro-preview
 params:
   - path: generationConfig.maxOutputTokens

--- a/models/vertex/gemini-3.5-flash-lite.yaml
+++ b/models/vertex/gemini-3.5-flash-lite.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: vertex
 authType: api_key
+apiSurface: google-vertex-generate-content
 model: gemini-3.5-flash-lite
 status: active
 params:

--- a/models/vertex/gemini-3.5-flash.yaml
+++ b/models/vertex/gemini-3.5-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: vertex
 authType: api_key
+apiSurface: google-vertex-generate-content
 model: gemini-3.5-flash
 status: active
 params:

--- a/models/vertex/gemini-3.6-flash.yaml
+++ b/models/vertex/gemini-3.6-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: vertex
 authType: api_key
+apiSurface: google-vertex-generate-content
 model: gemini-3.6-flash
 status: active
 params:

--- a/models/vertex/gemini-3.7-flash.yaml
+++ b/models/vertex/gemini-3.7-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: vertex
 authType: api_key
+apiSurface: google-vertex-generate-content
 model: gemini-3.7-flash
 status: active
 params:

--- a/models/xai/grok-4.20-0309-non-reasoning-subscription.yaml
+++ b/models/xai/grok-4.20-0309-non-reasoning-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xai
 authType: subscription
+apiSurface: openai-chat-completions
 model: grok-4.20-0309-non-reasoning
 status: active
 params:

--- a/models/xai/grok-4.20-0309-non-reasoning.yaml
+++ b/models/xai/grok-4.20-0309-non-reasoning.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xai
 authType: api_key
+apiSurface: openai-chat-completions
 model: grok-4.20-0309-non-reasoning
 status: active
 params:

--- a/models/xai/grok-4.20-0309-reasoning-subscription.yaml
+++ b/models/xai/grok-4.20-0309-reasoning-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xai
 authType: subscription
+apiSurface: openai-chat-completions
 model: grok-4.20-0309-reasoning
 status: active
 params:

--- a/models/xai/grok-4.20-0309-reasoning.yaml
+++ b/models/xai/grok-4.20-0309-reasoning.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xai
 authType: api_key
+apiSurface: openai-chat-completions
 model: grok-4.20-0309-reasoning
 status: active
 params:

--- a/models/xai/grok-4.20-multi-agent-0309.yaml
+++ b/models/xai/grok-4.20-multi-agent-0309.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xai
 authType: api_key
+apiSurface: openai-responses
 model: grok-4.20-multi-agent-0309
 status: active
 params:

--- a/models/xai/grok-4.3-subscription.yaml
+++ b/models/xai/grok-4.3-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xai
 authType: subscription
+apiSurface: openai-chat-completions
 model: grok-4.3
 status: active
 params:

--- a/models/xai/grok-4.3.yaml
+++ b/models/xai/grok-4.3.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xai
 authType: api_key
+apiSurface: openai-chat-completions
 model: grok-4.3
 status: active
 params:

--- a/models/xai/grok-4.5-subscription.yaml
+++ b/models/xai/grok-4.5-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xai
 authType: subscription
+apiSurface: openai-chat-completions
 model: grok-4.5
 status: active
 params:

--- a/models/xai/grok-4.5.yaml
+++ b/models/xai/grok-4.5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xai
 authType: api_key
+apiSurface: openai-chat-completions
 model: grok-4.5
 status: active
 params:

--- a/models/xai/grok-4.6.yaml
+++ b/models/xai/grok-4.6.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xai
 authType: api_key
+apiSurface: openai-chat-completions
 model: grok-4.6
 params:
   - path: max_completion_tokens

--- a/models/xai/grok-build-0.1-subscription.yaml
+++ b/models/xai/grok-build-0.1-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xai
 authType: subscription
+apiSurface: openai-chat-completions
 model: grok-build-0.1
 status: active
 params:

--- a/models/xai/grok-build-0.1.yaml
+++ b/models/xai/grok-build-0.1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xai
 authType: api_key
+apiSurface: openai-chat-completions
 model: grok-build-0.1
 status: active
 params:

--- a/models/xiaomi/mimo-v2.5-pro.yaml
+++ b/models/xiaomi/mimo-v2.5-pro.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xiaomi
 authType: api_key
+apiSurface: openai-chat-completions
 model: mimo-v2.5-pro
 status: active
 params:

--- a/models/xiaomi/mimo-v2.5-subscription.yaml
+++ b/models/xiaomi/mimo-v2.5-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xiaomi
 authType: subscription
+apiSurface: openai-chat-completions
 model: mimo-v2.5
 status: active
 params:

--- a/models/xiaomi/mimo-v2.5.yaml
+++ b/models/xiaomi/mimo-v2.5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: xiaomi
 authType: api_key
+apiSurface: openai-chat-completions
 model: mimo-v2.5
 status: active
 params:

--- a/models/z-ai/glm-4.5-air-subscription.yaml
+++ b/models/z-ai/glm-4.5-air-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: subscription
+apiSurface: openai-chat-completions
 model: glm-4.5-air
 status: active
 params:

--- a/models/z-ai/glm-4.5-air.yaml
+++ b/models/z-ai/glm-4.5-air.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-4.5-air
 status: active
 params:

--- a/models/z-ai/glm-4.5-airx.yaml
+++ b/models/z-ai/glm-4.5-airx.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-4.5-airx
 status: active
 params:

--- a/models/z-ai/glm-4.5-flash.yaml
+++ b/models/z-ai/glm-4.5-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-4.5-flash
 status: active
 params:

--- a/models/z-ai/glm-4.5-subscription.yaml
+++ b/models/z-ai/glm-4.5-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: subscription
+apiSurface: openai-chat-completions
 model: glm-4.5
 status: active
 params:

--- a/models/z-ai/glm-4.5-x.yaml
+++ b/models/z-ai/glm-4.5-x.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-4.5-x
 status: active
 params:

--- a/models/z-ai/glm-4.5.yaml
+++ b/models/z-ai/glm-4.5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-4.5
 status: active
 params:

--- a/models/z-ai/glm-4.6-subscription.yaml
+++ b/models/z-ai/glm-4.6-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: subscription
+apiSurface: openai-chat-completions
 model: glm-4.6
 status: active
 params:

--- a/models/z-ai/glm-4.6.yaml
+++ b/models/z-ai/glm-4.6.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-4.6
 status: active
 params:

--- a/models/z-ai/glm-4.7-flash.yaml
+++ b/models/z-ai/glm-4.7-flash.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-4.7-flash
 status: active
 params:

--- a/models/z-ai/glm-4.7-flashx.yaml
+++ b/models/z-ai/glm-4.7-flashx.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-4.7-flashx
 status: active
 params:

--- a/models/z-ai/glm-4.7-subscription.yaml
+++ b/models/z-ai/glm-4.7-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: subscription
+apiSurface: openai-chat-completions
 model: glm-4.7
 status: active
 params:

--- a/models/z-ai/glm-4.7.yaml
+++ b/models/z-ai/glm-4.7.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-4.7
 status: active
 params:

--- a/models/z-ai/glm-5-subscription.yaml
+++ b/models/z-ai/glm-5-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: subscription
+apiSurface: openai-chat-completions
 model: glm-5
 status: active
 params:

--- a/models/z-ai/glm-5-turbo-subscription.yaml
+++ b/models/z-ai/glm-5-turbo-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: subscription
+apiSurface: openai-chat-completions
 model: glm-5-turbo
 status: active
 params:

--- a/models/z-ai/glm-5-turbo.yaml
+++ b/models/z-ai/glm-5-turbo.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-5-turbo
 status: active
 params:

--- a/models/z-ai/glm-5.1-subscription.yaml
+++ b/models/z-ai/glm-5.1-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: subscription
+apiSurface: openai-chat-completions
 model: glm-5.1
 status: active
 params:

--- a/models/z-ai/glm-5.1.yaml
+++ b/models/z-ai/glm-5.1.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-5.1
 status: active
 params:

--- a/models/z-ai/glm-5.2-subscription.yaml
+++ b/models/z-ai/glm-5.2-subscription.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: subscription
+apiSurface: openai-chat-completions
 model: glm-5.2
 status: active
 params:

--- a/models/z-ai/glm-5.2.yaml
+++ b/models/z-ai/glm-5.2.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-5.2
 status: active
 params:

--- a/models/z-ai/glm-5.3.yaml
+++ b/models/z-ai/glm-5.3.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-5.3
 params:
   - path: max_tokens

--- a/models/z-ai/glm-5.yaml
+++ b/models/z-ai/glm-5.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: z-ai
 authType: api_key
+apiSurface: openai-chat-completions
 model: glm-5
 status: active
 params:

--- a/packages/modelparams-mcp/README.md
+++ b/packages/modelparams-mcp/README.md
@@ -85,7 +85,7 @@ Model ids, filtered by provider or substring. Use it to resolve the exact catalo
 
 ### `list_provider_models`
 
-Everything one provider serves, in one call: its models, the `wireId` each one needs, their lifecycle status, and the parameter surfaces they expose. For picking a model *and* configuring it in the same step — the question you have when a provider is fixed and the model isn't, which is the normal state of affairs on Bedrock and Vertex.
+Everything one provider serves, in one call: its models, the `wireId` each one needs, their lifecycle status, and the parameter surfaces they expose. For picking a model _and_ configuring it in the same step — the question you have when a provider is fixed and the model isn't, which is the normal state of affairs on Bedrock and Vertex.
 
 Models are grouped by parameter surface rather than listed one by one, because a provider's models are far less varied than their count suggests — Bedrock's 56 models are four distinct surfaces, since Converse normalises most of them:
 
@@ -113,6 +113,7 @@ Models are grouped by parameter surface rather than listed one by one, because a
     {
       "model": "bedrock/claude-opus-4-6",
       "authType": "api_key",
+      "apiSurface": "amazon-bedrock-converse",
       "wireId": "{scope}.anthropic.claude-opus-4-6-v1",
       "profile": "p2"
     }
@@ -133,7 +134,7 @@ A `wireId` containing `{scope}` needs one substitution before you send it. Bedro
 
 ## Wire formats
 
-One entry documents one wire format, so `validate_model_params` answers for the surface that entry describes and no other. This matters when a host serves two: `bedrock/*` documents Amazon Bedrock's `Converse` API — `inferenceConfig.maxTokens`, vendor extras under `additionalModelRequestFields` — which is what `ConverseCommand` in `@aws-sdk/client-bedrock-runtime` sends. It does **not** describe `InvokeModel` with native per-vendor bodies (`max_tokens`, top-level `thinking`), which is what `AnthropicBedrock` from `@anthropic-ai/bedrock-sdk` sends. Validate against the surface your code actually calls; the full support table is in the [catalog README](https://github.com/mnfst/modelparams.dev#api-surfaces).
+One entry documents one wire format and returns its machine-readable `apiSurface`, so `validate_model_params` answers for that surface and no other. This matters when a host serves two: `bedrock/*` declares `amazon-bedrock-converse` and documents Amazon Bedrock's `Converse` API — `inferenceConfig.maxTokens`, vendor extras under `additionalModelRequestFields` — which is what `ConverseCommand` in `@aws-sdk/client-bedrock-runtime` sends. It does **not** describe `InvokeModel` with native per-vendor bodies (`max_tokens`, top-level `thinking`), which is what `AnthropicBedrock` from `@anthropic-ai/bedrock-sdk` sends. Validate against the surface your code actually calls; the full support table is in the [catalog README](https://github.com/mnfst/modelparams.dev#api-surfaces).
 
 ## Related
 

--- a/packages/modelparams-mcp/src/tools.ts
+++ b/packages/modelparams-mcp/src/tools.ts
@@ -110,6 +110,7 @@ export function validateModelParams(input: {
     model: resolved.id,
     provider: entry.provider,
     authType: entry.authType,
+    apiSurface: entry.apiSurface,
     ...("wireId" in entry ? { wireId: entry.wireId } : {}),
     valid: dropped.length === 0,
     summary:
@@ -140,6 +141,7 @@ export function getModelParams(input: { model: string; baseUrl?: string }): Tool
     model: resolved.id,
     provider: entry.provider,
     authType: entry.authType,
+    apiSurface: entry.apiSurface,
     ...("wireId" in entry ? { wireId: entry.wireId } : {}),
     ...(entry.status !== undefined ? { status: entry.status } : {}),
     ...(entry.replacement !== undefined ? { replacement: entry.replacement } : {}),
@@ -243,6 +245,7 @@ export function listProviderModels(input: {
     return {
       model: id,
       authType: entry.authType,
+      apiSurface: entry.apiSurface,
       ...("wireId" in entry ? { wireId: entry.wireId } : {}),
       // Lifecycle travels with the row: a tool whose whole job is helping an
       // agent choose a model must not hand back a retired one unmarked.

--- a/packages/modelparams-mcp/tests/server.test.ts
+++ b/packages/modelparams-mcp/tests/server.test.ts
@@ -16,6 +16,7 @@ interface ParamInfo {
 interface ValidateResult {
   model: string;
   provider: string;
+  apiSurface: string;
   valid: boolean;
   summary: string;
   issues: { path: string; code: string; message: string; conflictsWith?: string[] }[];
@@ -26,6 +27,7 @@ interface ValidateResult {
 
 interface ModelParamsResult {
   model: string;
+  apiSurface: string;
   status?: "active" | "deprecated" | "retired";
   replacement?: string;
   shutdownOn?: string;
@@ -57,6 +59,7 @@ interface ProviderModelsResult {
   models: {
     model: string;
     authType: string;
+    apiSurface: string;
     wireId?: string;
     profile: string;
     status?: string;
@@ -119,6 +122,7 @@ describe("validate_model_params", () => {
       params: { max_tokens: 1024, temperature: 1 },
     });
     expect(out.valid).toBe(true);
+    expect(out.apiSurface).toBe("anthropic-messages");
     expect(out.issues).toEqual([]);
   });
 
@@ -153,6 +157,7 @@ describe("validate_model_params", () => {
       params: {},
     });
     expect(out.model).toBe("openai/gpt-5.5");
+    expect(out.apiSurface).toBe("openai-chat-completions");
     expect(out.valid).toBe(true);
   });
 
@@ -264,6 +269,7 @@ describe("list_provider_models", () => {
     expect(out.total).toBeGreaterThan(10);
     expect(out.truncated).toBe(false);
     expect(out.models).toHaveLength(out.total);
+    expect(out.models.every((model) => model.apiSurface === "amazon-bedrock-converse")).toBe(true);
     expect(out.baseUrls.length).toBeGreaterThan(0);
   });
 

--- a/packages/modelparams-python/README.md
+++ b/packages/modelparams-python/README.md
@@ -72,3 +72,6 @@ uv run --project packages/modelparams-python pytest packages/modelparams-python/
 
 Generated catalog and type files are committed and verified in CI. Python releases use independent
 `modelparams-py@x.y.z` tags and publish to PyPI through the repository's trusted-publisher workflow.
+
+Catalog entries expose `api_surface` as a typed value, so callers can distinguish request families
+such as `openai-chat-completions` and `openai-responses` before using a parameter set.

--- a/packages/modelparams-python/src/modelparams/__init__.py
+++ b/packages/modelparams-python/src/modelparams/__init__.py
@@ -12,6 +12,7 @@ from .catalog import (
     list_models,
 )
 from .models import (
+    ApiSurface,
     Applicability,
     ApplicabilityCondition,
     CatalogEntry,
@@ -42,6 +43,7 @@ __all__ = [
     "PROVIDERS",
     "Applicability",
     "ApplicabilityCondition",
+    "ApiSurface",
     "CatalogEntry",
     "JsonPrimitive",
     "LifecycleStatus",

--- a/packages/modelparams-python/src/modelparams/_generated/catalog.json
+++ b/packages/modelparams-python/src/modelparams/_generated/catalog.json
@@ -2,6 +2,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v3.2",
     "params": [
       {
@@ -77,6 +78,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-flash",
     "params": [
       {
@@ -152,6 +154,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-flash-0731",
     "params": [
       {
@@ -227,6 +230,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-pro",
     "params": [
       {
@@ -302,6 +306,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-pro-0813",
     "params": [
       {
@@ -377,6 +382,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.1",
     "params": [
       {
@@ -452,6 +458,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.2",
     "params": [
       {
@@ -527,6 +534,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.7-code",
     "params": [
       {
@@ -602,6 +610,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen-flash",
     "params": [
       {
@@ -662,6 +671,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen-max",
     "params": [
       {
@@ -722,6 +732,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen-plus",
     "params": [
       {
@@ -782,6 +793,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen-turbo",
     "params": [
       {
@@ -842,6 +854,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-235b-a22b-thinking-2507",
     "params": [
       {
@@ -902,6 +915,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-30b-a3b-instruct-2507",
     "params": [
       {
@@ -962,6 +976,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-30b-a3b-thinking-2507",
     "params": [
       {
@@ -1022,6 +1037,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-coder-flash",
     "params": [
       {
@@ -1074,6 +1090,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-coder-next",
     "params": [
       {
@@ -1126,6 +1143,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-coder-plus",
     "status": "deprecated",
     "replacement": "alibaba/qwen3.7-plus",
@@ -1181,6 +1199,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-max",
     "status": "active",
     "params": [
@@ -1242,6 +1261,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-next-80b-a3b-instruct",
     "params": [
       {
@@ -1302,6 +1322,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-next-80b-a3b-thinking",
     "params": [
       {
@@ -1362,6 +1383,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-vl-235b-a22b-instruct",
     "params": [
       {
@@ -1422,6 +1444,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-vl-235b-a22b-thinking",
     "params": [
       {
@@ -1482,6 +1505,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.5",
     "params": [
       {
@@ -1542,6 +1566,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.5-122b-a10b",
     "params": [
       {
@@ -1602,6 +1627,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.5-27b",
     "params": [
       {
@@ -1662,6 +1688,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.5-35b-a3b",
     "params": [
       {
@@ -1722,6 +1749,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.5-397b-a17b",
     "params": [
       {
@@ -1782,6 +1810,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.5-flash",
     "params": [
       {
@@ -1842,6 +1871,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.6-27b",
     "params": [
       {
@@ -1917,6 +1947,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.6-35b-a3b",
     "params": [
       {
@@ -1992,6 +2023,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.6-flash",
     "status": "active",
     "params": [
@@ -2068,6 +2100,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.6-max-preview",
     "status": "deprecated",
     "replacement": "alibaba/qwen3.7-max",
@@ -2146,6 +2179,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.6-plus",
     "params": [
       {
@@ -2221,6 +2255,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.7-flash",
     "params": [
       {
@@ -2296,6 +2331,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.7-max",
     "status": "active",
     "params": [
@@ -2372,6 +2408,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.7-plus",
     "status": "active",
     "params": [
@@ -2448,6 +2485,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.8-2.4t-a95b",
     "params": [
       {
@@ -2523,6 +2561,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.8-27b",
     "params": [
       {
@@ -2598,6 +2637,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.8-max",
     "params": [
       {
@@ -2673,6 +2713,7 @@
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwq-plus",
     "params": [
       {
@@ -2725,6 +2766,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-5-haiku-20241022",
     "status": "retired",
     "replacement": "anthropic/claude-haiku-4-5-20251001",
@@ -2814,6 +2856,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-5-haiku-latest",
     "status": "retired",
     "replacement": "anthropic/claude-haiku-4-5-20251001",
@@ -2903,6 +2946,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-5-sonnet-20241022",
     "status": "retired",
     "replacement": "anthropic/claude-sonnet-4-6",
@@ -2992,6 +3036,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-5-sonnet-latest",
     "status": "retired",
     "replacement": "anthropic/claude-sonnet-4-6",
@@ -3081,6 +3126,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-7-sonnet-20250219",
     "status": "retired",
     "replacement": "anthropic/claude-sonnet-4-6",
@@ -3198,6 +3244,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-7-sonnet-latest",
     "status": "retired",
     "replacement": "anthropic/claude-sonnet-4-6",
@@ -3315,6 +3362,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-opus-20240229",
     "status": "retired",
     "replacement": "anthropic/claude-opus-4-8",
@@ -3404,6 +3452,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-opus-latest",
     "params": [
       {
@@ -3490,6 +3539,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-fable-5",
     "status": "active",
     "params": [
@@ -3553,6 +3603,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-fable-5",
     "status": "active",
     "params": [
@@ -3616,6 +3667,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-haiku-4",
     "params": [
       {
@@ -3730,6 +3782,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-haiku-4-5",
     "status": "active",
     "params": [
@@ -3845,6 +3898,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-haiku-4-5-20251001",
     "status": "active",
     "params": [
@@ -3964,6 +4018,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-haiku-4-5-20251001",
     "status": "active",
     "params": [
@@ -4083,6 +4138,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-haiku-4-5",
     "status": "active",
     "params": [
@@ -4198,6 +4254,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-haiku-4",
     "params": [
       {
@@ -4312,6 +4369,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-1-20250805",
     "status": "deprecated",
     "replacement": "anthropic/claude-opus-4-8",
@@ -4452,6 +4510,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-1-20250805",
     "status": "deprecated",
     "replacement": "anthropic/claude-opus-4-8",
@@ -4592,6 +4651,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-20250514",
     "status": "retired",
     "replacement": "anthropic/claude-opus-4-8",
@@ -4722,6 +4782,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-20250514",
     "status": "retired",
     "replacement": "anthropic/claude-opus-4-8",
@@ -4852,6 +4913,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-5-20251101",
     "status": "active",
     "params": [
@@ -5003,6 +5065,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-5-20251101",
     "status": "active",
     "params": [
@@ -5154,6 +5217,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-6",
     "status": "active",
     "params": [
@@ -5311,6 +5375,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-6",
     "status": "active",
     "params": [
@@ -5468,6 +5533,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-7",
     "status": "active",
     "params": [
@@ -5533,6 +5599,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-7",
     "status": "active",
     "params": [
@@ -5598,6 +5665,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-8",
     "status": "active",
     "params": [
@@ -5663,6 +5731,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-8",
     "status": "active",
     "params": [
@@ -5728,6 +5797,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4",
     "params": [
       {
@@ -5843,6 +5913,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-5",
     "status": "active",
     "params": [
@@ -5916,6 +5987,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-5",
     "status": "active",
     "params": [
@@ -5989,6 +6061,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-20250514",
     "status": "retired",
     "replacement": "anthropic/claude-sonnet-4-6",
@@ -6119,6 +6192,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-20250514",
     "status": "retired",
     "replacement": "anthropic/claude-sonnet-4-6",
@@ -6249,6 +6323,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-5",
     "status": "active",
     "params": [
@@ -6365,6 +6440,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-5-20250929",
     "status": "active",
     "params": [
@@ -6484,6 +6560,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-5-20250929",
     "status": "active",
     "params": [
@@ -6603,6 +6680,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-5",
     "status": "active",
     "params": [
@@ -6719,6 +6797,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-6",
     "status": "active",
     "params": [
@@ -6876,6 +6955,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-6",
     "status": "active",
     "params": [
@@ -7033,6 +7113,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4",
     "params": [
       {
@@ -7148,6 +7229,7 @@
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-5",
     "status": "active",
     "params": [
@@ -7213,6 +7295,7 @@
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-5",
     "status": "active",
     "params": [
@@ -7278,6 +7361,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "claude-haiku-4-5",
     "wireId": "{scope}.anthropic.claude-haiku-4-5-20251001-v1:0",
     "params": [
@@ -7364,6 +7448,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "claude-opus-4-5-20251101",
     "wireId": "{scope}.anthropic.claude-opus-4-5-20251101-v1:0",
     "params": [
@@ -7450,6 +7535,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "claude-opus-4-6",
     "wireId": "{scope}.anthropic.claude-opus-4-6-v1",
     "params": [
@@ -7536,6 +7622,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "claude-sonnet-4-5",
     "wireId": "{scope}.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "params": [
@@ -7622,6 +7709,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "claude-sonnet-4-6",
     "wireId": "{scope}.anthropic.claude-sonnet-4-6",
     "params": [
@@ -7708,6 +7796,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "deepseek-r1",
     "wireId": "{scope}.deepseek.r1-v1:0",
     "params": [
@@ -7757,6 +7846,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "deepseek-v3.2",
     "wireId": "deepseek.v3.2",
     "params": [
@@ -7806,6 +7896,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "devstral-2-123b",
     "wireId": "mistral.devstral-2-123b",
     "params": [
@@ -7855,6 +7946,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gemma-3-12b-it",
     "wireId": "google.gemma-3-12b-it",
     "params": [
@@ -7904,6 +7996,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gemma-3-27b-it",
     "wireId": "google.gemma-3-27b-it",
     "params": [
@@ -7953,6 +8046,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gemma-3-4b-it",
     "wireId": "google.gemma-3-4b-it",
     "params": [
@@ -8002,6 +8096,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "glm-4.7",
     "wireId": "zai.glm-4.7",
     "params": [
@@ -8051,6 +8146,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "glm-4.7-flash",
     "wireId": "zai.glm-4.7-flash",
     "params": [
@@ -8100,6 +8196,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "glm-5",
     "wireId": "zai.glm-5",
     "params": [
@@ -8149,6 +8246,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gpt-oss-120b",
     "wireId": "openai.gpt-oss-120b-1:0",
     "params": [
@@ -8198,6 +8296,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gpt-oss-20b",
     "wireId": "openai.gpt-oss-20b-1:0",
     "params": [
@@ -8247,6 +8346,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gpt-oss-safeguard-120b",
     "wireId": "openai.gpt-oss-safeguard-120b",
     "params": [
@@ -8296,6 +8396,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gpt-oss-safeguard-20b",
     "wireId": "openai.gpt-oss-safeguard-20b",
     "params": [
@@ -8345,6 +8446,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "kimi-k2-thinking",
     "wireId": "moonshot.kimi-k2-thinking",
     "params": [
@@ -8394,6 +8496,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "kimi-k2.5",
     "wireId": "moonshotai.kimi-k2.5",
     "params": [
@@ -8443,6 +8546,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "llama3-1-70b-instruct",
     "wireId": "{scope}.meta.llama3-1-70b-instruct-v1:0",
     "params": [
@@ -8492,6 +8596,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "llama3-1-8b-instruct",
     "wireId": "{scope}.meta.llama3-1-8b-instruct-v1:0",
     "params": [
@@ -8541,6 +8646,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "llama3-3-70b-instruct",
     "wireId": "{scope}.meta.llama3-3-70b-instruct-v1:0",
     "params": [
@@ -8590,6 +8696,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "llama3-70b-instruct",
     "wireId": "meta.llama3-70b-instruct-v1:0",
     "params": [
@@ -8639,6 +8746,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "llama3-8b-instruct",
     "wireId": "meta.llama3-8b-instruct-v1:0",
     "params": [
@@ -8688,6 +8796,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "magistral-small-2509",
     "wireId": "mistral.magistral-small-2509",
     "params": [
@@ -8737,6 +8846,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "minimax-m2",
     "wireId": "minimax.minimax-m2",
     "params": [
@@ -8823,6 +8933,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "minimax-m2.1",
     "wireId": "minimax.minimax-m2.1",
     "params": [
@@ -8872,6 +8983,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "minimax-m2.5",
     "wireId": "minimax.minimax-m2.5",
     "params": [
@@ -8921,6 +9033,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "ministral-3-14b-instruct",
     "wireId": "mistral.ministral-3-14b-instruct",
     "params": [
@@ -9007,6 +9120,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "ministral-3-3b-instruct",
     "wireId": "mistral.ministral-3-3b-instruct",
     "params": [
@@ -9056,6 +9170,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "ministral-3-8b-instruct",
     "wireId": "mistral.ministral-3-8b-instruct",
     "params": [
@@ -9105,6 +9220,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "mistral-7b-instruct",
     "wireId": "mistral.mistral-7b-instruct-v0:2",
     "params": [
@@ -9164,6 +9280,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "mistral-large-2402",
     "wireId": "mistral.mistral-large-2402-v1:0",
     "params": [
@@ -9223,6 +9340,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "mistral-large-3-675b-instruct",
     "wireId": "mistral.mistral-large-3-675b-instruct",
     "params": [
@@ -9272,6 +9390,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "mistral-small-2402",
     "wireId": "mistral.mistral-small-2402-v1:0",
     "params": [
@@ -9331,6 +9450,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "mixtral-8x7b-instruct",
     "wireId": "mistral.mixtral-8x7b-instruct-v0:1",
     "params": [
@@ -9390,6 +9510,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nemotron-nano-12b",
     "wireId": "nvidia.nemotron-nano-12b-v2",
     "params": [
@@ -9439,6 +9560,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nemotron-nano-3-30b",
     "wireId": "nvidia.nemotron-nano-3-30b",
     "params": [
@@ -9488,6 +9610,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nemotron-nano-9b",
     "wireId": "nvidia.nemotron-nano-9b-v2",
     "params": [
@@ -9537,6 +9660,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nemotron-super-3-120b",
     "wireId": "nvidia.nemotron-super-3-120b",
     "params": [
@@ -9586,6 +9710,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nova-2-lite",
     "wireId": "{scope}.amazon.nova-2-lite-v1:0",
     "params": [
@@ -9645,6 +9770,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nova-lite",
     "wireId": "amazon.nova-lite-v1:0",
     "status": "active",
@@ -9705,6 +9831,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nova-micro",
     "wireId": "amazon.nova-micro-v1:0",
     "status": "active",
@@ -9765,6 +9892,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nova-pro",
     "wireId": "amazon.nova-pro-v1:0",
     "status": "active",
@@ -9825,6 +9953,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "palmyra-vision-7b",
     "wireId": "writer.palmyra-vision-7b",
     "params": [
@@ -9874,6 +10003,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "palmyra-x4",
     "wireId": "{scope}.writer.palmyra-x4-v1:0",
     "params": [
@@ -9923,6 +10053,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "palmyra-x5",
     "wireId": "{scope}.writer.palmyra-x5-v1:0",
     "params": [
@@ -9972,6 +10103,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "pixtral-large-2502",
     "wireId": "{scope}.mistral.pixtral-large-2502-v1:0",
     "params": [
@@ -10021,6 +10153,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "qwen3-32b",
     "wireId": "qwen.qwen3-32b-v1:0",
     "params": [
@@ -10070,6 +10203,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "qwen3-coder-30b-a3b",
     "wireId": "qwen.qwen3-coder-30b-a3b-v1:0",
     "params": [
@@ -10119,6 +10253,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "qwen3-coder-next",
     "wireId": "qwen.qwen3-coder-next",
     "params": [
@@ -10168,6 +10303,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "qwen3-next-80b-a3b",
     "wireId": "qwen.qwen3-next-80b-a3b",
     "params": [
@@ -10217,6 +10353,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "qwen3-vl-235b-a22b",
     "wireId": "qwen.qwen3-vl-235b-a22b",
     "params": [
@@ -10266,6 +10403,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "voxtral-mini-3b-2507",
     "wireId": "mistral.voxtral-mini-3b-2507",
     "params": [
@@ -10315,6 +10453,7 @@
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "voxtral-small-24b-2507",
     "wireId": "mistral.voxtral-small-24b-2507",
     "params": [
@@ -10364,6 +10503,7 @@
   {
     "provider": "cerebras",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "zai-glm-4.7",
     "params": [
       {
@@ -10478,6 +10618,7 @@
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-a-03-2025",
     "status": "active",
     "params": [
@@ -10616,6 +10757,7 @@
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-a-plus-05-2026",
     "status": "active",
     "params": [
@@ -10754,6 +10896,7 @@
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-a-reasoning-08-2025",
     "status": "active",
     "params": [
@@ -10919,6 +11062,7 @@
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-a-translate-08-2025",
     "status": "active",
     "params": [
@@ -11057,6 +11201,7 @@
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-a-vision-07-2025",
     "status": "active",
     "params": [
@@ -11195,6 +11340,7 @@
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-r-08-2024",
     "status": "active",
     "params": [
@@ -11323,6 +11469,7 @@
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-r-plus-08-2024",
     "status": "active",
     "params": [
@@ -11451,6 +11598,7 @@
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-r7b-12-2024",
     "status": "active",
     "params": [
@@ -11589,6 +11737,7 @@
   {
     "provider": "deepseek",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-chat",
     "status": "retired",
     "replacement": "deepseek/deepseek-v4-flash",
@@ -11662,6 +11811,7 @@
   {
     "provider": "deepseek",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-reasoner",
     "status": "retired",
     "replacement": "deepseek/deepseek-v4-flash",
@@ -11752,6 +11902,7 @@
   {
     "provider": "deepseek",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-flash",
     "status": "active",
     "params": [
@@ -11840,6 +11991,7 @@
   {
     "provider": "deepseek",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-pro",
     "status": "active",
     "params": [
@@ -11928,6 +12080,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-flash-0731",
     "wireId": "accounts/fireworks/models/deepseek-v4-flash-0731",
     "params": [
@@ -12016,6 +12169,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-pro",
     "wireId": "accounts/fireworks/models/deepseek-v4-pro",
     "params": [
@@ -12104,6 +12258,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-pro-0813",
     "wireId": "accounts/fireworks/models/deepseek-v4-pro-0813",
     "params": [
@@ -12192,6 +12347,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5p2",
     "wireId": "accounts/fireworks/models/glm-5p2",
     "params": [
@@ -12280,6 +12436,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-120b",
     "wireId": "accounts/fireworks/models/gpt-oss-120b",
     "params": [
@@ -12368,6 +12525,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-20b",
     "wireId": "accounts/fireworks/models/gpt-oss-20b",
     "params": [
@@ -12456,6 +12614,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "inkling",
     "wireId": "accounts/fireworks/models/inkling",
     "params": [
@@ -12544,6 +12703,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2p6",
     "wireId": "accounts/fireworks/models/kimi-k2p6",
     "params": [
@@ -12632,6 +12792,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2p7-code",
     "wireId": "accounts/fireworks/models/kimi-k2p7-code",
     "params": [
@@ -12720,6 +12881,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k3",
     "wireId": "accounts/fireworks/models/kimi-k3",
     "params": [
@@ -12808,6 +12970,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2p7",
     "wireId": "accounts/fireworks/models/minimax-m2p7",
     "params": [
@@ -12896,6 +13059,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m3",
     "wireId": "accounts/fireworks/models/minimax-m3",
     "params": [
@@ -12984,6 +13148,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "muse-glimmer-30b",
     "wireId": "accounts/fireworks/models/muse-glimmer-30b",
     "params": [
@@ -13072,6 +13237,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3p7-plus",
     "wireId": "accounts/fireworks/models/qwen3p7-plus",
     "params": [
@@ -13160,6 +13326,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3p8-2p4t-a95b",
     "wireId": "accounts/fireworks/models/qwen3p8-2p4t-a95b",
     "params": [
@@ -13248,6 +13415,7 @@
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3p8-max",
     "wireId": "accounts/fireworks/models/qwen3p8-max",
     "params": [
@@ -13336,6 +13504,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-2.5-flash",
     "status": "active",
     "replacement": "google/gemini-3.6-flash",
@@ -13432,6 +13601,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-2.5-flash-lite",
     "status": "active",
     "replacement": "google/gemini-3.1-flash-lite",
@@ -13524,6 +13694,7 @@
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-2.5-flash-lite",
     "status": "active",
     "replacement": "google/gemini-3.1-flash-lite",
@@ -13616,6 +13787,7 @@
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-2.5-flash",
     "status": "active",
     "replacement": "google/gemini-3.6-flash",
@@ -13712,6 +13884,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-2.5-pro",
     "status": "active",
     "replacement": "google/gemini-3.1-pro-preview",
@@ -13807,6 +13980,7 @@
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-2.5-pro",
     "status": "active",
     "replacement": "google/gemini-3.1-pro-preview",
@@ -13902,6 +14076,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3-flash-preview",
     "status": "active",
     "replacement": "google/gemini-3.6-flash",
@@ -14000,6 +14175,7 @@
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3-flash-preview",
     "status": "active",
     "replacement": "google/gemini-3.6-flash",
@@ -14098,6 +14274,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-flash-lite",
     "status": "active",
     "replacement": "google/gemini-3.5-flash-lite",
@@ -14196,6 +14373,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-flash-lite-preview",
     "status": "retired",
     "replacement": "google/gemini-3.1-flash-lite",
@@ -14295,6 +14473,7 @@
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-flash-lite-preview",
     "status": "retired",
     "replacement": "google/gemini-3.1-flash-lite",
@@ -14394,6 +14573,7 @@
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-flash-lite",
     "status": "active",
     "replacement": "google/gemini-3.5-flash-lite",
@@ -14492,6 +14672,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-pro-preview",
     "status": "active",
     "params": [
@@ -14589,6 +14770,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-pro-preview-customtools",
     "params": [
       {
@@ -14685,6 +14867,7 @@
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-pro-preview",
     "status": "active",
     "params": [
@@ -14780,6 +14963,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.5-flash",
     "status": "active",
     "params": [
@@ -14877,6 +15061,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.5-flash-lite",
     "status": "active",
     "params": [
@@ -14974,6 +15159,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.6-flash",
     "status": "active",
     "params": [
@@ -15071,6 +15257,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.7-flash",
     "params": [
       {
@@ -15167,6 +15354,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-flash-latest",
     "params": [
       {
@@ -15257,6 +15445,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-3-12b-it",
     "params": [
       {
@@ -15306,6 +15495,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-3-1b-it",
     "params": [
       {
@@ -15355,6 +15545,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-3-27b-it",
     "params": [
       {
@@ -15404,6 +15595,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-3-4b-it",
     "params": [
       {
@@ -15453,6 +15645,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-3n-E2B-it",
     "params": [
       {
@@ -15502,6 +15695,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-3n-E4B-it",
     "params": [
       {
@@ -15551,6 +15745,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-4-12B-it",
     "params": [
       {
@@ -15599,6 +15794,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-4-26b-a4b-it",
     "params": [
       {
@@ -15700,6 +15896,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-4-31b-it",
     "params": [
       {
@@ -15801,6 +15998,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-4-E2B-it",
     "params": [
       {
@@ -15849,6 +16047,7 @@
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-4-E4B-it",
     "params": [
       {
@@ -15897,6 +16096,7 @@
   {
     "provider": "groq",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-120b",
     "wireId": "openai/gpt-oss-120b",
     "params": [
@@ -16017,6 +16217,7 @@
   {
     "provider": "groq",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-20b",
     "wireId": "openai/gpt-oss-20b",
     "params": [
@@ -16137,6 +16338,7 @@
   {
     "provider": "groq",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-safeguard-20b",
     "wireId": "openai/gpt-oss-safeguard-20b",
     "params": [
@@ -16257,6 +16459,7 @@
   {
     "provider": "groq",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-32b",
     "params": [
       {
@@ -16376,6 +16579,7 @@
   {
     "provider": "groq",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.6-27b",
     "wireId": "qwen/qwen3.6-27b",
     "params": [
@@ -16496,6 +16700,7 @@
   {
     "provider": "meta",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "Llama-3.3-70B-Instruct",
     "params": [
       {
@@ -16565,6 +16770,7 @@
   {
     "provider": "meta",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "Llama-3.3-8B-Instruct",
     "params": [
       {
@@ -16634,6 +16840,7 @@
   {
     "provider": "meta",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "Llama-4-Maverick-17B-128E-Instruct-FP8",
     "params": [
       {
@@ -16703,6 +16910,7 @@
   {
     "provider": "meta",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "Llama-4-Scout-17B-16E-Instruct-FP8",
     "params": [
       {
@@ -16772,6 +16980,7 @@
   {
     "provider": "meta",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "muse-spark-1.1",
     "params": [
       {
@@ -16900,6 +17109,7 @@
   {
     "provider": "meta",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "muse-spark-1.2-contributor",
     "params": [
       {
@@ -17028,6 +17238,7 @@
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2",
     "params": [
       {
@@ -17079,6 +17290,7 @@
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2",
     "status": "active",
     "params": [
@@ -17123,6 +17335,7 @@
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2.1",
     "params": [
       {
@@ -17174,6 +17387,7 @@
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2.1-highspeed",
     "params": [
       {
@@ -17225,6 +17439,7 @@
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2.1-highspeed",
     "status": "active",
     "params": [
@@ -17269,6 +17484,7 @@
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2.1",
     "status": "active",
     "params": [
@@ -17313,6 +17529,7 @@
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2.5",
     "params": [
       {
@@ -17364,6 +17581,7 @@
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2.5-highspeed",
     "params": [
       {
@@ -17415,6 +17633,7 @@
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2.5-highspeed",
     "status": "active",
     "params": [
@@ -17459,6 +17678,7 @@
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2.5",
     "status": "active",
     "params": [
@@ -17503,6 +17723,7 @@
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2.7",
     "params": [
       {
@@ -17554,6 +17775,7 @@
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2.7-highspeed",
     "params": [
       {
@@ -17605,6 +17827,7 @@
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2.7-highspeed",
     "status": "active",
     "params": [
@@ -17649,6 +17872,7 @@
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2.7",
     "status": "active",
     "params": [
@@ -17693,6 +17917,7 @@
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m3",
     "params": [
       {
@@ -17744,6 +17969,7 @@
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M3",
     "status": "active",
     "params": [
@@ -17788,6 +18014,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "codestral-2508",
     "params": [
       {
@@ -17894,6 +18121,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "codestral-latest",
     "params": [
       {
@@ -18000,6 +18228,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "devstral-2512",
     "status": "retired",
     "replacement": "mistral/mistral-medium-3-5-26-04",
@@ -18109,6 +18338,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "devstral-latest",
     "params": [
       {
@@ -18215,6 +18445,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "magistral-medium-latest",
     "params": [
       {
@@ -18331,6 +18562,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "magistral-small-latest",
     "params": [
       {
@@ -18447,6 +18679,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "ministral-14b-2512",
     "params": [
       {
@@ -18553,6 +18786,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "ministral-14b-latest",
     "params": [
       {
@@ -18659,6 +18893,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "ministral-3b-2512",
     "params": [
       {
@@ -18765,6 +19000,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "ministral-3b-latest",
     "params": [
       {
@@ -18871,6 +19107,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "ministral-8b-2512",
     "params": [
       {
@@ -18977,6 +19214,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "ministral-8b-latest",
     "params": [
       {
@@ -19083,6 +19321,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-large-2512",
     "params": [
       {
@@ -19189,6 +19428,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-large-latest",
     "params": [
       {
@@ -19295,6 +19535,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-medium-3",
     "params": [
       {
@@ -19401,6 +19642,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-medium-3.5",
     "params": [
       {
@@ -19507,6 +19749,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-medium-latest",
     "params": [
       {
@@ -19613,6 +19856,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-small-2603",
     "params": [
       {
@@ -19719,6 +19963,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-small-latest",
     "params": [
       {
@@ -19825,6 +20070,7 @@
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "open-mistral-nemo",
     "status": "deprecated",
     "params": [
@@ -19932,6 +20178,7 @@
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.5",
     "status": "deprecated",
     "replacement": "moonshot/kimi-k2.6",
@@ -20019,6 +20266,7 @@
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.6",
     "status": "active",
     "params": [
@@ -20116,6 +20364,7 @@
   {
     "provider": "moonshot",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.6",
     "status": "active",
     "params": [
@@ -20170,6 +20419,7 @@
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.7-code",
     "status": "active",
     "params": [
@@ -20256,6 +20506,7 @@
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.7-code-highspeed",
     "status": "active",
     "params": [
@@ -20342,6 +20593,7 @@
   {
     "provider": "moonshot",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.7-code-highspeed",
     "status": "active",
     "params": [
@@ -20383,6 +20635,7 @@
   {
     "provider": "moonshot",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.7-code",
     "status": "active",
     "params": [
@@ -20424,6 +20677,7 @@
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k3",
     "status": "active",
     "params": [
@@ -20499,6 +20753,7 @@
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "moonshot-v1-128k",
     "status": "deprecated",
     "replacement": "moonshot/kimi-k2.6",
@@ -20639,6 +20894,7 @@
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "moonshot-v1-32k",
     "status": "deprecated",
     "replacement": "moonshot/kimi-k2.6",
@@ -20779,6 +21035,7 @@
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "moonshot-v1-8k",
     "status": "deprecated",
     "replacement": "moonshot/kimi-k2.6",
@@ -20919,6 +21176,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-flash-0731",
     "wireId": "deepseek-ai/deepseek-v4-flash-0731",
     "params": [
@@ -21005,6 +21263,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gliner-pii",
     "params": [
       {
@@ -21056,6 +21315,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "llama-3.1-nemoguard-8b-topic-control",
     "params": [
       {
@@ -21128,6 +21388,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "llama-3.1-nemotron-nano-8b-v1",
     "params": [
       {
@@ -21213,6 +21474,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "llama-3.1-nemotron-safety-guard-8b-v3",
     "params": [
       {
@@ -21232,6 +21494,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "llama-3.1-nemotron-ultra-253b-v1",
     "params": [
       {
@@ -21317,6 +21580,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "llama-3.3-nemotron-super-49b-v1",
     "params": [
       {
@@ -21402,6 +21666,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "llama-3.3-nemotron-super-49b-v1.5",
     "params": [
       {
@@ -21487,12 +21752,14 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "nemoguard-jailbreak-detect",
     "params": []
   },
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "nemotron-3-nano-30b-a3b",
     "params": [
       {
@@ -21552,6 +21819,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "nemotron-3-super-120b-a12b",
     "params": [
       {
@@ -21636,6 +21904,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "nemotron-3-ultra-550b-a55b",
     "params": [
       {
@@ -21720,6 +21989,7 @@
   {
     "provider": "nvidia",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "nemotron-3-ultra",
     "params": [
       {
@@ -21793,6 +22063,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "nemotron-content-safety-reasoning-4b",
     "params": [
       {
@@ -21852,6 +22123,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "nemotron-mini-4b-instruct",
     "params": [
       {
@@ -21925,6 +22197,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "riva-translate-4b-instruct-v1.1",
     "params": [
       {
@@ -21998,6 +22271,7 @@
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "usdcode-llama-3.1-70b-instruct",
     "params": [
       {
@@ -22054,6 +22328,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "chatgpt-4o-latest",
     "status": "retired",
     "replacement": "openai/gpt-5.1-chat-latest",
@@ -22101,6 +22376,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-3.5-turbo",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-terra",
@@ -22148,6 +22424,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-3.5-turbo-16k",
     "params": [
       {
@@ -22192,6 +22469,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -22270,6 +22548,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4-0613",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -22317,6 +22596,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4-turbo",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -22364,6 +22644,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4-turbo-2024-04-09",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -22411,6 +22692,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4.1",
     "status": "active",
     "params": [
@@ -22456,6 +22738,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4.1-mini",
     "status": "active",
     "params": [
@@ -22501,6 +22784,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4.1-nano",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-luna",
@@ -22548,6 +22832,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4o",
     "status": "active",
     "params": [
@@ -22593,6 +22878,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4o-2024-11-20",
     "params": [
       {
@@ -22637,6 +22923,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4o-mini",
     "status": "active",
     "params": [
@@ -22682,6 +22969,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -22717,6 +23005,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5-chat-latest",
     "status": "retired",
     "replacement": "openai/gpt-5.6-sol",
@@ -22738,6 +23027,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5-mini",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-terra",
@@ -22773,6 +23063,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5-nano",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-luna",
@@ -22808,6 +23099,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.1",
     "params": [
       {
@@ -22840,6 +23132,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.1-codex-max",
     "status": "retired",
     "replacement": "openai/gpt-5.3-codex",
@@ -22892,6 +23185,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.1-codex",
     "status": "retired",
     "replacement": "openai/gpt-5.3-codex",
@@ -22943,6 +23237,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.2",
     "params": [
       {
@@ -22976,6 +23271,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.2-codex",
     "status": "retired",
     "replacement": "openai/gpt-5.3-codex",
@@ -23028,6 +23324,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.2",
     "params": [
       {
@@ -23077,6 +23374,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.3-codex",
     "status": "active",
     "params": [
@@ -23110,6 +23408,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.3-codex-spark",
     "status": "active",
     "params": [
@@ -23160,6 +23459,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.3-codex",
     "status": "active",
     "params": [
@@ -23210,6 +23510,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.4",
     "status": "active",
     "params": [
@@ -23244,6 +23545,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.4-mini",
     "status": "active",
     "params": [
@@ -23278,6 +23580,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.4-mini",
     "status": "active",
     "params": [
@@ -23328,6 +23631,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.4-nano",
     "status": "active",
     "params": [
@@ -23362,6 +23666,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.4-pro",
     "status": "active",
     "params": [
@@ -23394,6 +23699,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.4-pro",
     "status": "active",
     "params": [
@@ -23442,6 +23748,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.4",
     "status": "active",
     "params": [
@@ -23492,6 +23799,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.5",
     "status": "active",
     "params": [
@@ -23526,6 +23834,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.5-pro",
     "status": "active",
     "params": [
@@ -23558,6 +23867,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.5-pro",
     "status": "active",
     "params": [
@@ -23606,6 +23916,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.5",
     "status": "active",
     "params": [
@@ -23656,6 +23967,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.6",
     "params": [
       {
@@ -23689,6 +24001,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.6-luna",
     "status": "active",
     "params": [
@@ -23723,6 +24036,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.6-luna",
     "status": "active",
     "params": [
@@ -23773,6 +24087,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.6-sol",
     "status": "active",
     "params": [
@@ -23807,6 +24122,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.6-sol",
     "status": "active",
     "params": [
@@ -23857,6 +24173,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.6-terra",
     "status": "active",
     "params": [
@@ -23891,6 +24208,7 @@
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.6-terra",
     "status": "active",
     "params": [
@@ -23941,6 +24259,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-120b",
     "status": "active",
     "params": [
@@ -24017,6 +24336,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-20b",
     "status": "active",
     "params": [
@@ -24093,6 +24413,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-safeguard-120b",
     "params": [
       {
@@ -24144,6 +24465,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-safeguard-20b",
     "params": [
       {
@@ -24195,6 +24517,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o1",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -24230,6 +24553,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o1-mini",
     "status": "retired",
     "replacement": "openai/o4-mini",
@@ -24265,6 +24589,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o1-preview",
     "status": "retired",
     "replacement": "openai/o3",
@@ -24300,6 +24625,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o3",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -24335,6 +24661,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o3-mini",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -24370,6 +24697,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o3-pro",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -24405,6 +24733,7 @@
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o4-mini",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-terra",
@@ -24440,6 +24769,7 @@
   {
     "provider": "perplexity",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "sonar",
     "params": [
       {
@@ -24566,6 +24896,7 @@
   {
     "provider": "perplexity",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "sonar-deep-research",
     "params": [
       {
@@ -24697,6 +25028,7 @@
   {
     "provider": "perplexity",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "sonar-pro",
     "params": [
       {
@@ -24823,6 +25155,7 @@
   {
     "provider": "perplexity",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "sonar-reasoning-pro",
     "params": [
       {
@@ -24949,6 +25282,7 @@
   {
     "provider": "thinking-machines",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "Inkling",
     "params": [
       {
@@ -25010,6 +25344,7 @@
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-2.5-flash",
     "status": "deprecated",
     "replacement": "vertex/gemini-3.5-flash-lite",
@@ -25145,6 +25480,7 @@
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-2.5-flash-lite",
     "status": "deprecated",
     "replacement": "vertex/gemini-3.1-flash-lite",
@@ -25262,6 +25598,7 @@
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-2.5-pro",
     "status": "deprecated",
     "replacement": "vertex/gemini-3.5-flash",
@@ -25397,6 +25734,7 @@
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3-flash-preview",
     "params": [
       {
@@ -25557,6 +25895,7 @@
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.1-flash-lite",
     "status": "active",
     "params": [
@@ -25718,6 +26057,7 @@
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.1-pro-preview",
     "params": [
       {
@@ -25878,6 +26218,7 @@
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.1-pro-preview-customtools",
     "params": [
       {
@@ -26038,6 +26379,7 @@
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.5-flash",
     "status": "active",
     "params": [
@@ -26199,6 +26541,7 @@
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.5-flash-lite",
     "status": "active",
     "params": [
@@ -26338,6 +26681,7 @@
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.6-flash",
     "status": "active",
     "params": [
@@ -26477,6 +26821,7 @@
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.7-flash",
     "status": "active",
     "params": [
@@ -26616,6 +26961,7 @@
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.20-0309-non-reasoning",
     "status": "active",
     "params": [
@@ -26687,6 +27033,7 @@
   {
     "provider": "xai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.20-0309-non-reasoning",
     "status": "active",
     "params": [
@@ -26758,6 +27105,7 @@
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.20-0309-reasoning",
     "status": "active",
     "params": [
@@ -26822,6 +27170,7 @@
   {
     "provider": "xai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.20-0309-reasoning",
     "status": "active",
     "params": [
@@ -26886,6 +27235,7 @@
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-responses",
     "model": "grok-4.20-multi-agent-0309",
     "status": "active",
     "params": [
@@ -26956,6 +27306,7 @@
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.3",
     "status": "active",
     "params": [
@@ -27034,6 +27385,7 @@
   {
     "provider": "xai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.3",
     "status": "active",
     "params": [
@@ -27112,6 +27464,7 @@
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.5",
     "status": "active",
     "params": [
@@ -27190,6 +27543,7 @@
   {
     "provider": "xai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.5",
     "status": "active",
     "params": [
@@ -27268,6 +27622,7 @@
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.6",
     "params": [
       {
@@ -27338,6 +27693,7 @@
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-build-0.1",
     "status": "active",
     "params": [
@@ -27402,6 +27758,7 @@
   {
     "provider": "xai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-build-0.1",
     "status": "active",
     "params": [
@@ -27466,6 +27823,7 @@
   {
     "provider": "xiaomi",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mimo-v2.5",
     "status": "active",
     "params": [
@@ -27544,6 +27902,7 @@
   {
     "provider": "xiaomi",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mimo-v2.5-pro",
     "status": "active",
     "params": [
@@ -27655,6 +28014,7 @@
   {
     "provider": "xiaomi",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "mimo-v2.5",
     "status": "active",
     "params": [
@@ -27733,6 +28093,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5",
     "status": "active",
     "params": [
@@ -27821,6 +28182,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5-air",
     "status": "active",
     "params": [
@@ -27909,6 +28271,7 @@
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5-air",
     "status": "active",
     "params": [
@@ -27997,6 +28360,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5-airx",
     "status": "active",
     "params": [
@@ -28085,6 +28449,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5-flash",
     "status": "active",
     "params": [
@@ -28173,6 +28538,7 @@
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5",
     "status": "active",
     "params": [
@@ -28261,6 +28627,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5-x",
     "status": "active",
     "params": [
@@ -28349,6 +28716,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.6",
     "status": "active",
     "params": [
@@ -28437,6 +28805,7 @@
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.6",
     "status": "active",
     "params": [
@@ -28525,6 +28894,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.7",
     "status": "active",
     "params": [
@@ -28613,6 +28983,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.7-flash",
     "status": "active",
     "params": [
@@ -28701,6 +29072,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.7-flashx",
     "status": "active",
     "params": [
@@ -28789,6 +29161,7 @@
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.7",
     "status": "active",
     "params": [
@@ -28877,6 +29250,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5",
     "status": "active",
     "params": [
@@ -28965,6 +29339,7 @@
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5",
     "status": "active",
     "params": [
@@ -29053,6 +29428,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5-turbo",
     "status": "active",
     "params": [
@@ -29141,6 +29517,7 @@
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5-turbo",
     "status": "active",
     "params": [
@@ -29229,6 +29606,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.1",
     "status": "active",
     "params": [
@@ -29317,6 +29695,7 @@
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.1",
     "status": "active",
     "params": [
@@ -29405,6 +29784,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.2",
     "status": "active",
     "params": [
@@ -29515,6 +29895,7 @@
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.2",
     "status": "active",
     "params": [
@@ -29625,6 +30006,7 @@
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.3",
     "params": [
       {

--- a/packages/modelparams-python/src/modelparams/models.py
+++ b/packages/modelparams-python/src/modelparams/models.py
@@ -7,6 +7,15 @@ from pydantic import BaseModel, ConfigDict, Field
 JsonPrimitive: TypeAlias = str | int | float | bool | None
 JsonNumber: TypeAlias = int | float
 AuthType: TypeAlias = Literal["api_key", "subscription"]
+ApiSurface: TypeAlias = Literal[
+    "openai-chat-completions",
+    "openai-responses",
+    "anthropic-messages",
+    "google-generate-content",
+    "amazon-bedrock-converse",
+    "google-vertex-generate-content",
+    "cohere-chat",
+]
 LifecycleStatus: TypeAlias = Literal["active", "deprecated", "retired"]
 ParamType: TypeAlias = Literal["boolean", "enum", "integer", "number", "string"]
 ParamGroup: TypeAlias = Literal[
@@ -59,6 +68,7 @@ class Parameter(FrozenModel):
 class CatalogEntry(FrozenModel):
     provider: str
     auth_type: AuthType = Field(alias="authType")
+    api_surface: ApiSurface = Field(alias="apiSurface")
     model: str
     # Exact wire string when the host's native id differs from the catalog
     # slug (pathed ids: accounts/fireworks/models/kimi-k3, openai/gpt-oss-20b).

--- a/packages/modelparams-python/tests/test_catalog.py
+++ b/packages/modelparams-python/tests/test_catalog.py
@@ -44,6 +44,7 @@ def test_get_model_returns_frozen_pythonic_metadata() -> None:
     model = get_model(HAIKU)
     assert model.provider == "anthropic"
     assert model.auth_type == "api_key"
+    assert model.api_surface == "anthropic-messages"
     assert model.model == "claude-haiku-4-5-20251001"
     assert model.status == "active"
     assert model.params

--- a/packages/modelparams/README.md
+++ b/packages/modelparams/README.md
@@ -141,6 +141,7 @@ Each dropped entry carries a `code`: `unknown_parameter`, `invalid_value`, or `n
 | `StrictParamsOf<Id>` | Same shape, every field required.                                                                                     |
 | `ModelId`            | Union of all `"provider/model"` ids (including `-subscription` variants).                                             |
 | `Provider`           | Union of provider slugs (`"anthropic"`, `"openai"`, …).                                                               |
+| `ApiSurface`         | Union of request and SDK surfaces (`"openai-responses"`, `"anthropic-messages"`, …).                                  |
 | `ParamsById`         | Mapped type: `{ [Id in ModelId]: ParamsByIdMap[Id] }`.                                                                |
 | `CatalogEntry`       | The full catalog object for one model.                                                                                |
 | `Param`              | A parameter definition in a loose, iterable shape — `getModel(id).params` assigns to `readonly Param[]` with no cast. |

--- a/packages/modelparams/scripts/codegen.ts
+++ b/packages/modelparams/scripts/codegen.ts
@@ -104,6 +104,7 @@ async function main(): Promise<void> {
       `import type { ModelId } from "./model-ids.js";\n\n` +
       `const GENERATED_CATALOG = ${JSON.stringify(models, null, 2)} as const;\n\n` +
       `type GeneratedCatalogEntry = (typeof GENERATED_CATALOG)[number];\n` +
+      `export type ApiSurface = GeneratedCatalogEntry["apiSurface"];\n` +
       `export type LifecycleStatus = "active" | "deprecated" | "retired";\n` +
       `type WithLifecycle<T> = T extends unknown\n` +
       `  ? Omit<T, "status" | "replacement" | "shutdownOn"> & {\n` +

--- a/packages/modelparams/src/generated/data.ts
+++ b/packages/modelparams/src/generated/data.ts
@@ -7,6 +7,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v3.2",
     "params": [
       {
@@ -82,6 +83,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-flash",
     "params": [
       {
@@ -157,6 +159,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-flash-0731",
     "params": [
       {
@@ -232,6 +235,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-pro",
     "params": [
       {
@@ -307,6 +311,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-pro-0813",
     "params": [
       {
@@ -382,6 +387,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.1",
     "params": [
       {
@@ -457,6 +463,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.2",
     "params": [
       {
@@ -532,6 +539,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.7-code",
     "params": [
       {
@@ -607,6 +615,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen-flash",
     "params": [
       {
@@ -667,6 +676,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen-max",
     "params": [
       {
@@ -727,6 +737,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen-plus",
     "params": [
       {
@@ -787,6 +798,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen-turbo",
     "params": [
       {
@@ -847,6 +859,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-235b-a22b-thinking-2507",
     "params": [
       {
@@ -907,6 +920,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-30b-a3b-instruct-2507",
     "params": [
       {
@@ -967,6 +981,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-30b-a3b-thinking-2507",
     "params": [
       {
@@ -1027,6 +1042,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-coder-flash",
     "params": [
       {
@@ -1079,6 +1095,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-coder-next",
     "params": [
       {
@@ -1131,6 +1148,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-coder-plus",
     "status": "deprecated",
     "replacement": "alibaba/qwen3.7-plus",
@@ -1186,6 +1204,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-max",
     "status": "active",
     "params": [
@@ -1247,6 +1266,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-next-80b-a3b-instruct",
     "params": [
       {
@@ -1307,6 +1327,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-next-80b-a3b-thinking",
     "params": [
       {
@@ -1367,6 +1388,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-vl-235b-a22b-instruct",
     "params": [
       {
@@ -1427,6 +1449,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-vl-235b-a22b-thinking",
     "params": [
       {
@@ -1487,6 +1510,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.5",
     "params": [
       {
@@ -1547,6 +1571,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.5-122b-a10b",
     "params": [
       {
@@ -1607,6 +1632,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.5-27b",
     "params": [
       {
@@ -1667,6 +1693,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.5-35b-a3b",
     "params": [
       {
@@ -1727,6 +1754,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.5-397b-a17b",
     "params": [
       {
@@ -1787,6 +1815,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.5-flash",
     "params": [
       {
@@ -1847,6 +1876,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.6-27b",
     "params": [
       {
@@ -1922,6 +1952,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.6-35b-a3b",
     "params": [
       {
@@ -1997,6 +2028,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.6-flash",
     "status": "active",
     "params": [
@@ -2073,6 +2105,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.6-max-preview",
     "status": "deprecated",
     "replacement": "alibaba/qwen3.7-max",
@@ -2151,6 +2184,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.6-plus",
     "params": [
       {
@@ -2226,6 +2260,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.7-flash",
     "params": [
       {
@@ -2301,6 +2336,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.7-max",
     "status": "active",
     "params": [
@@ -2377,6 +2413,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.7-plus",
     "status": "active",
     "params": [
@@ -2453,6 +2490,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.8-2.4t-a95b",
     "params": [
       {
@@ -2528,6 +2566,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.8-27b",
     "params": [
       {
@@ -2603,6 +2642,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.8-max",
     "params": [
       {
@@ -2678,6 +2718,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "alibaba",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwq-plus",
     "params": [
       {
@@ -2730,6 +2771,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-5-haiku-20241022",
     "status": "retired",
     "replacement": "anthropic/claude-haiku-4-5-20251001",
@@ -2819,6 +2861,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-5-haiku-latest",
     "status": "retired",
     "replacement": "anthropic/claude-haiku-4-5-20251001",
@@ -2908,6 +2951,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-5-sonnet-20241022",
     "status": "retired",
     "replacement": "anthropic/claude-sonnet-4-6",
@@ -2997,6 +3041,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-5-sonnet-latest",
     "status": "retired",
     "replacement": "anthropic/claude-sonnet-4-6",
@@ -3086,6 +3131,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-7-sonnet-20250219",
     "status": "retired",
     "replacement": "anthropic/claude-sonnet-4-6",
@@ -3203,6 +3249,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-7-sonnet-latest",
     "status": "retired",
     "replacement": "anthropic/claude-sonnet-4-6",
@@ -3320,6 +3367,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-opus-20240229",
     "status": "retired",
     "replacement": "anthropic/claude-opus-4-8",
@@ -3409,6 +3457,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-3-opus-latest",
     "params": [
       {
@@ -3495,6 +3544,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-fable-5",
     "status": "active",
     "params": [
@@ -3558,6 +3608,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-fable-5",
     "status": "active",
     "params": [
@@ -3621,6 +3672,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-haiku-4",
     "params": [
       {
@@ -3735,6 +3787,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-haiku-4-5",
     "status": "active",
     "params": [
@@ -3850,6 +3903,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-haiku-4-5-20251001",
     "status": "active",
     "params": [
@@ -3969,6 +4023,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-haiku-4-5-20251001",
     "status": "active",
     "params": [
@@ -4088,6 +4143,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-haiku-4-5",
     "status": "active",
     "params": [
@@ -4203,6 +4259,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-haiku-4",
     "params": [
       {
@@ -4317,6 +4374,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-1-20250805",
     "status": "deprecated",
     "replacement": "anthropic/claude-opus-4-8",
@@ -4457,6 +4515,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-1-20250805",
     "status": "deprecated",
     "replacement": "anthropic/claude-opus-4-8",
@@ -4597,6 +4656,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-20250514",
     "status": "retired",
     "replacement": "anthropic/claude-opus-4-8",
@@ -4727,6 +4787,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-20250514",
     "status": "retired",
     "replacement": "anthropic/claude-opus-4-8",
@@ -4857,6 +4918,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-5-20251101",
     "status": "active",
     "params": [
@@ -5008,6 +5070,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-5-20251101",
     "status": "active",
     "params": [
@@ -5159,6 +5222,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-6",
     "status": "active",
     "params": [
@@ -5316,6 +5380,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-6",
     "status": "active",
     "params": [
@@ -5473,6 +5538,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-7",
     "status": "active",
     "params": [
@@ -5538,6 +5604,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-7",
     "status": "active",
     "params": [
@@ -5603,6 +5670,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-8",
     "status": "active",
     "params": [
@@ -5668,6 +5736,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4-8",
     "status": "active",
     "params": [
@@ -5733,6 +5802,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-4",
     "params": [
       {
@@ -5848,6 +5918,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-5",
     "status": "active",
     "params": [
@@ -5921,6 +5992,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-opus-5",
     "status": "active",
     "params": [
@@ -5994,6 +6066,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-20250514",
     "status": "retired",
     "replacement": "anthropic/claude-sonnet-4-6",
@@ -6124,6 +6197,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-20250514",
     "status": "retired",
     "replacement": "anthropic/claude-sonnet-4-6",
@@ -6254,6 +6328,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-5",
     "status": "active",
     "params": [
@@ -6370,6 +6445,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-5-20250929",
     "status": "active",
     "params": [
@@ -6489,6 +6565,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-5-20250929",
     "status": "active",
     "params": [
@@ -6608,6 +6685,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-5",
     "status": "active",
     "params": [
@@ -6724,6 +6802,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-6",
     "status": "active",
     "params": [
@@ -6881,6 +6960,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4-6",
     "status": "active",
     "params": [
@@ -7038,6 +7118,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-4",
     "params": [
       {
@@ -7153,6 +7234,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "api_key",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-5",
     "status": "active",
     "params": [
@@ -7218,6 +7300,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "anthropic",
     "authType": "subscription",
+    "apiSurface": "anthropic-messages",
     "model": "claude-sonnet-5",
     "status": "active",
     "params": [
@@ -7283,6 +7366,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "claude-haiku-4-5",
     "wireId": "{scope}.anthropic.claude-haiku-4-5-20251001-v1:0",
     "params": [
@@ -7369,6 +7453,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "claude-opus-4-5-20251101",
     "wireId": "{scope}.anthropic.claude-opus-4-5-20251101-v1:0",
     "params": [
@@ -7455,6 +7540,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "claude-opus-4-6",
     "wireId": "{scope}.anthropic.claude-opus-4-6-v1",
     "params": [
@@ -7541,6 +7627,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "claude-sonnet-4-5",
     "wireId": "{scope}.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "params": [
@@ -7627,6 +7714,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "claude-sonnet-4-6",
     "wireId": "{scope}.anthropic.claude-sonnet-4-6",
     "params": [
@@ -7713,6 +7801,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "deepseek-r1",
     "wireId": "{scope}.deepseek.r1-v1:0",
     "params": [
@@ -7762,6 +7851,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "deepseek-v3.2",
     "wireId": "deepseek.v3.2",
     "params": [
@@ -7811,6 +7901,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "devstral-2-123b",
     "wireId": "mistral.devstral-2-123b",
     "params": [
@@ -7860,6 +7951,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gemma-3-12b-it",
     "wireId": "google.gemma-3-12b-it",
     "params": [
@@ -7909,6 +8001,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gemma-3-27b-it",
     "wireId": "google.gemma-3-27b-it",
     "params": [
@@ -7958,6 +8051,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gemma-3-4b-it",
     "wireId": "google.gemma-3-4b-it",
     "params": [
@@ -8007,6 +8101,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "glm-4.7",
     "wireId": "zai.glm-4.7",
     "params": [
@@ -8056,6 +8151,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "glm-4.7-flash",
     "wireId": "zai.glm-4.7-flash",
     "params": [
@@ -8105,6 +8201,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "glm-5",
     "wireId": "zai.glm-5",
     "params": [
@@ -8154,6 +8251,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gpt-oss-120b",
     "wireId": "openai.gpt-oss-120b-1:0",
     "params": [
@@ -8203,6 +8301,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gpt-oss-20b",
     "wireId": "openai.gpt-oss-20b-1:0",
     "params": [
@@ -8252,6 +8351,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gpt-oss-safeguard-120b",
     "wireId": "openai.gpt-oss-safeguard-120b",
     "params": [
@@ -8301,6 +8401,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "gpt-oss-safeguard-20b",
     "wireId": "openai.gpt-oss-safeguard-20b",
     "params": [
@@ -8350,6 +8451,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "kimi-k2-thinking",
     "wireId": "moonshot.kimi-k2-thinking",
     "params": [
@@ -8399,6 +8501,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "kimi-k2.5",
     "wireId": "moonshotai.kimi-k2.5",
     "params": [
@@ -8448,6 +8551,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "llama3-1-70b-instruct",
     "wireId": "{scope}.meta.llama3-1-70b-instruct-v1:0",
     "params": [
@@ -8497,6 +8601,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "llama3-1-8b-instruct",
     "wireId": "{scope}.meta.llama3-1-8b-instruct-v1:0",
     "params": [
@@ -8546,6 +8651,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "llama3-3-70b-instruct",
     "wireId": "{scope}.meta.llama3-3-70b-instruct-v1:0",
     "params": [
@@ -8595,6 +8701,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "llama3-70b-instruct",
     "wireId": "meta.llama3-70b-instruct-v1:0",
     "params": [
@@ -8644,6 +8751,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "llama3-8b-instruct",
     "wireId": "meta.llama3-8b-instruct-v1:0",
     "params": [
@@ -8693,6 +8801,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "magistral-small-2509",
     "wireId": "mistral.magistral-small-2509",
     "params": [
@@ -8742,6 +8851,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "minimax-m2",
     "wireId": "minimax.minimax-m2",
     "params": [
@@ -8828,6 +8938,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "minimax-m2.1",
     "wireId": "minimax.minimax-m2.1",
     "params": [
@@ -8877,6 +8988,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "minimax-m2.5",
     "wireId": "minimax.minimax-m2.5",
     "params": [
@@ -8926,6 +9038,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "ministral-3-14b-instruct",
     "wireId": "mistral.ministral-3-14b-instruct",
     "params": [
@@ -9012,6 +9125,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "ministral-3-3b-instruct",
     "wireId": "mistral.ministral-3-3b-instruct",
     "params": [
@@ -9061,6 +9175,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "ministral-3-8b-instruct",
     "wireId": "mistral.ministral-3-8b-instruct",
     "params": [
@@ -9110,6 +9225,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "mistral-7b-instruct",
     "wireId": "mistral.mistral-7b-instruct-v0:2",
     "params": [
@@ -9169,6 +9285,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "mistral-large-2402",
     "wireId": "mistral.mistral-large-2402-v1:0",
     "params": [
@@ -9228,6 +9345,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "mistral-large-3-675b-instruct",
     "wireId": "mistral.mistral-large-3-675b-instruct",
     "params": [
@@ -9277,6 +9395,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "mistral-small-2402",
     "wireId": "mistral.mistral-small-2402-v1:0",
     "params": [
@@ -9336,6 +9455,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "mixtral-8x7b-instruct",
     "wireId": "mistral.mixtral-8x7b-instruct-v0:1",
     "params": [
@@ -9395,6 +9515,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nemotron-nano-12b",
     "wireId": "nvidia.nemotron-nano-12b-v2",
     "params": [
@@ -9444,6 +9565,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nemotron-nano-3-30b",
     "wireId": "nvidia.nemotron-nano-3-30b",
     "params": [
@@ -9493,6 +9615,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nemotron-nano-9b",
     "wireId": "nvidia.nemotron-nano-9b-v2",
     "params": [
@@ -9542,6 +9665,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nemotron-super-3-120b",
     "wireId": "nvidia.nemotron-super-3-120b",
     "params": [
@@ -9591,6 +9715,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nova-2-lite",
     "wireId": "{scope}.amazon.nova-2-lite-v1:0",
     "params": [
@@ -9650,6 +9775,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nova-lite",
     "wireId": "amazon.nova-lite-v1:0",
     "status": "active",
@@ -9710,6 +9836,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nova-micro",
     "wireId": "amazon.nova-micro-v1:0",
     "status": "active",
@@ -9770,6 +9897,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "nova-pro",
     "wireId": "amazon.nova-pro-v1:0",
     "status": "active",
@@ -9830,6 +9958,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "palmyra-vision-7b",
     "wireId": "writer.palmyra-vision-7b",
     "params": [
@@ -9879,6 +10008,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "palmyra-x4",
     "wireId": "{scope}.writer.palmyra-x4-v1:0",
     "params": [
@@ -9928,6 +10058,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "palmyra-x5",
     "wireId": "{scope}.writer.palmyra-x5-v1:0",
     "params": [
@@ -9977,6 +10108,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "pixtral-large-2502",
     "wireId": "{scope}.mistral.pixtral-large-2502-v1:0",
     "params": [
@@ -10026,6 +10158,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "qwen3-32b",
     "wireId": "qwen.qwen3-32b-v1:0",
     "params": [
@@ -10075,6 +10208,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "qwen3-coder-30b-a3b",
     "wireId": "qwen.qwen3-coder-30b-a3b-v1:0",
     "params": [
@@ -10124,6 +10258,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "qwen3-coder-next",
     "wireId": "qwen.qwen3-coder-next",
     "params": [
@@ -10173,6 +10308,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "qwen3-next-80b-a3b",
     "wireId": "qwen.qwen3-next-80b-a3b",
     "params": [
@@ -10222,6 +10358,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "qwen3-vl-235b-a22b",
     "wireId": "qwen.qwen3-vl-235b-a22b",
     "params": [
@@ -10271,6 +10408,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "voxtral-mini-3b-2507",
     "wireId": "mistral.voxtral-mini-3b-2507",
     "params": [
@@ -10320,6 +10458,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "bedrock",
     "authType": "api_key",
+    "apiSurface": "amazon-bedrock-converse",
     "model": "voxtral-small-24b-2507",
     "wireId": "mistral.voxtral-small-24b-2507",
     "params": [
@@ -10369,6 +10508,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "cerebras",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "zai-glm-4.7",
     "params": [
       {
@@ -10483,6 +10623,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-a-03-2025",
     "status": "active",
     "params": [
@@ -10621,6 +10762,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-a-plus-05-2026",
     "status": "active",
     "params": [
@@ -10759,6 +10901,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-a-reasoning-08-2025",
     "status": "active",
     "params": [
@@ -10924,6 +11067,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-a-translate-08-2025",
     "status": "active",
     "params": [
@@ -11062,6 +11206,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-a-vision-07-2025",
     "status": "active",
     "params": [
@@ -11200,6 +11345,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-r-08-2024",
     "status": "active",
     "params": [
@@ -11328,6 +11474,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-r-plus-08-2024",
     "status": "active",
     "params": [
@@ -11456,6 +11603,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "cohere",
     "authType": "api_key",
+    "apiSurface": "cohere-chat",
     "model": "command-r7b-12-2024",
     "status": "active",
     "params": [
@@ -11594,6 +11742,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "deepseek",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-chat",
     "status": "retired",
     "replacement": "deepseek/deepseek-v4-flash",
@@ -11667,6 +11816,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "deepseek",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-reasoner",
     "status": "retired",
     "replacement": "deepseek/deepseek-v4-flash",
@@ -11757,6 +11907,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "deepseek",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-flash",
     "status": "active",
     "params": [
@@ -11845,6 +11996,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "deepseek",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-pro",
     "status": "active",
     "params": [
@@ -11933,6 +12085,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-flash-0731",
     "wireId": "accounts/fireworks/models/deepseek-v4-flash-0731",
     "params": [
@@ -12021,6 +12174,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-pro",
     "wireId": "accounts/fireworks/models/deepseek-v4-pro",
     "params": [
@@ -12109,6 +12263,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-pro-0813",
     "wireId": "accounts/fireworks/models/deepseek-v4-pro-0813",
     "params": [
@@ -12197,6 +12352,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5p2",
     "wireId": "accounts/fireworks/models/glm-5p2",
     "params": [
@@ -12285,6 +12441,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-120b",
     "wireId": "accounts/fireworks/models/gpt-oss-120b",
     "params": [
@@ -12373,6 +12530,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-20b",
     "wireId": "accounts/fireworks/models/gpt-oss-20b",
     "params": [
@@ -12461,6 +12619,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "inkling",
     "wireId": "accounts/fireworks/models/inkling",
     "params": [
@@ -12549,6 +12708,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2p6",
     "wireId": "accounts/fireworks/models/kimi-k2p6",
     "params": [
@@ -12637,6 +12797,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2p7-code",
     "wireId": "accounts/fireworks/models/kimi-k2p7-code",
     "params": [
@@ -12725,6 +12886,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k3",
     "wireId": "accounts/fireworks/models/kimi-k3",
     "params": [
@@ -12813,6 +12975,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2p7",
     "wireId": "accounts/fireworks/models/minimax-m2p7",
     "params": [
@@ -12901,6 +13064,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m3",
     "wireId": "accounts/fireworks/models/minimax-m3",
     "params": [
@@ -12989,6 +13153,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "muse-glimmer-30b",
     "wireId": "accounts/fireworks/models/muse-glimmer-30b",
     "params": [
@@ -13077,6 +13242,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3p7-plus",
     "wireId": "accounts/fireworks/models/qwen3p7-plus",
     "params": [
@@ -13165,6 +13331,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3p8-2p4t-a95b",
     "wireId": "accounts/fireworks/models/qwen3p8-2p4t-a95b",
     "params": [
@@ -13253,6 +13420,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "fireworks",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3p8-max",
     "wireId": "accounts/fireworks/models/qwen3p8-max",
     "params": [
@@ -13341,6 +13509,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-2.5-flash",
     "status": "active",
     "replacement": "google/gemini-3.6-flash",
@@ -13437,6 +13606,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-2.5-flash-lite",
     "status": "active",
     "replacement": "google/gemini-3.1-flash-lite",
@@ -13529,6 +13699,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-2.5-flash-lite",
     "status": "active",
     "replacement": "google/gemini-3.1-flash-lite",
@@ -13621,6 +13792,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-2.5-flash",
     "status": "active",
     "replacement": "google/gemini-3.6-flash",
@@ -13717,6 +13889,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-2.5-pro",
     "status": "active",
     "replacement": "google/gemini-3.1-pro-preview",
@@ -13812,6 +13985,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-2.5-pro",
     "status": "active",
     "replacement": "google/gemini-3.1-pro-preview",
@@ -13907,6 +14081,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3-flash-preview",
     "status": "active",
     "replacement": "google/gemini-3.6-flash",
@@ -14005,6 +14180,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3-flash-preview",
     "status": "active",
     "replacement": "google/gemini-3.6-flash",
@@ -14103,6 +14279,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-flash-lite",
     "status": "active",
     "replacement": "google/gemini-3.5-flash-lite",
@@ -14201,6 +14378,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-flash-lite-preview",
     "status": "retired",
     "replacement": "google/gemini-3.1-flash-lite",
@@ -14300,6 +14478,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-flash-lite-preview",
     "status": "retired",
     "replacement": "google/gemini-3.1-flash-lite",
@@ -14399,6 +14578,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-flash-lite",
     "status": "active",
     "replacement": "google/gemini-3.5-flash-lite",
@@ -14497,6 +14677,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-pro-preview",
     "status": "active",
     "params": [
@@ -14594,6 +14775,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-pro-preview-customtools",
     "params": [
       {
@@ -14690,6 +14872,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "subscription",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.1-pro-preview",
     "status": "active",
     "params": [
@@ -14785,6 +14968,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.5-flash",
     "status": "active",
     "params": [
@@ -14882,6 +15066,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.5-flash-lite",
     "status": "active",
     "params": [
@@ -14979,6 +15164,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.6-flash",
     "status": "active",
     "params": [
@@ -15076,6 +15262,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-3.7-flash",
     "params": [
       {
@@ -15172,6 +15359,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemini-flash-latest",
     "params": [
       {
@@ -15262,6 +15450,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-3-12b-it",
     "params": [
       {
@@ -15311,6 +15500,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-3-1b-it",
     "params": [
       {
@@ -15360,6 +15550,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-3-27b-it",
     "params": [
       {
@@ -15409,6 +15600,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-3-4b-it",
     "params": [
       {
@@ -15458,6 +15650,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-3n-E2B-it",
     "params": [
       {
@@ -15507,6 +15700,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-3n-E4B-it",
     "params": [
       {
@@ -15556,6 +15750,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-4-12B-it",
     "params": [
       {
@@ -15604,6 +15799,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-4-26b-a4b-it",
     "params": [
       {
@@ -15705,6 +15901,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-4-31b-it",
     "params": [
       {
@@ -15806,6 +16003,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-4-E2B-it",
     "params": [
       {
@@ -15854,6 +16052,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "google",
     "authType": "api_key",
+    "apiSurface": "google-generate-content",
     "model": "gemma-4-E4B-it",
     "params": [
       {
@@ -15902,6 +16101,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "groq",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-120b",
     "wireId": "openai/gpt-oss-120b",
     "params": [
@@ -16022,6 +16222,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "groq",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-20b",
     "wireId": "openai/gpt-oss-20b",
     "params": [
@@ -16142,6 +16343,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "groq",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-safeguard-20b",
     "wireId": "openai/gpt-oss-safeguard-20b",
     "params": [
@@ -16262,6 +16464,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "groq",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3-32b",
     "params": [
       {
@@ -16381,6 +16584,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "groq",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "qwen3.6-27b",
     "wireId": "qwen/qwen3.6-27b",
     "params": [
@@ -16501,6 +16705,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "meta",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "Llama-3.3-70B-Instruct",
     "params": [
       {
@@ -16570,6 +16775,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "meta",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "Llama-3.3-8B-Instruct",
     "params": [
       {
@@ -16639,6 +16845,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "meta",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "Llama-4-Maverick-17B-128E-Instruct-FP8",
     "params": [
       {
@@ -16708,6 +16915,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "meta",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "Llama-4-Scout-17B-16E-Instruct-FP8",
     "params": [
       {
@@ -16777,6 +16985,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "meta",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "muse-spark-1.1",
     "params": [
       {
@@ -16905,6 +17114,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "meta",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "muse-spark-1.2-contributor",
     "params": [
       {
@@ -17033,6 +17243,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2",
     "params": [
       {
@@ -17084,6 +17295,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2",
     "status": "active",
     "params": [
@@ -17128,6 +17340,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2.1",
     "params": [
       {
@@ -17179,6 +17392,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2.1-highspeed",
     "params": [
       {
@@ -17230,6 +17444,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2.1-highspeed",
     "status": "active",
     "params": [
@@ -17274,6 +17489,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2.1",
     "status": "active",
     "params": [
@@ -17318,6 +17534,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2.5",
     "params": [
       {
@@ -17369,6 +17586,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2.5-highspeed",
     "params": [
       {
@@ -17420,6 +17638,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2.5-highspeed",
     "status": "active",
     "params": [
@@ -17464,6 +17683,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2.5",
     "status": "active",
     "params": [
@@ -17508,6 +17728,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2.7",
     "params": [
       {
@@ -17559,6 +17780,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m2.7-highspeed",
     "params": [
       {
@@ -17610,6 +17832,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2.7-highspeed",
     "status": "active",
     "params": [
@@ -17654,6 +17877,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M2.7",
     "status": "active",
     "params": [
@@ -17698,6 +17922,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "minimax-m3",
     "params": [
       {
@@ -17749,6 +17974,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "minimax",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "MiniMax-M3",
     "status": "active",
     "params": [
@@ -17793,6 +18019,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "codestral-2508",
     "params": [
       {
@@ -17899,6 +18126,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "codestral-latest",
     "params": [
       {
@@ -18005,6 +18233,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "devstral-2512",
     "status": "retired",
     "replacement": "mistral/mistral-medium-3-5-26-04",
@@ -18114,6 +18343,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "devstral-latest",
     "params": [
       {
@@ -18220,6 +18450,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "magistral-medium-latest",
     "params": [
       {
@@ -18336,6 +18567,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "magistral-small-latest",
     "params": [
       {
@@ -18452,6 +18684,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "ministral-14b-2512",
     "params": [
       {
@@ -18558,6 +18791,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "ministral-14b-latest",
     "params": [
       {
@@ -18664,6 +18898,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "ministral-3b-2512",
     "params": [
       {
@@ -18770,6 +19005,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "ministral-3b-latest",
     "params": [
       {
@@ -18876,6 +19112,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "ministral-8b-2512",
     "params": [
       {
@@ -18982,6 +19219,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "ministral-8b-latest",
     "params": [
       {
@@ -19088,6 +19326,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-large-2512",
     "params": [
       {
@@ -19194,6 +19433,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-large-latest",
     "params": [
       {
@@ -19300,6 +19540,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-medium-3",
     "params": [
       {
@@ -19406,6 +19647,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-medium-3.5",
     "params": [
       {
@@ -19512,6 +19754,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-medium-latest",
     "params": [
       {
@@ -19618,6 +19861,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-small-2603",
     "params": [
       {
@@ -19724,6 +19968,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mistral-small-latest",
     "params": [
       {
@@ -19830,6 +20075,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "mistral",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "open-mistral-nemo",
     "status": "deprecated",
     "params": [
@@ -19937,6 +20183,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.5",
     "status": "deprecated",
     "replacement": "moonshot/kimi-k2.6",
@@ -20024,6 +20271,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.6",
     "status": "active",
     "params": [
@@ -20121,6 +20369,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "moonshot",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.6",
     "status": "active",
     "params": [
@@ -20175,6 +20424,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.7-code",
     "status": "active",
     "params": [
@@ -20261,6 +20511,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.7-code-highspeed",
     "status": "active",
     "params": [
@@ -20347,6 +20598,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "moonshot",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.7-code-highspeed",
     "status": "active",
     "params": [
@@ -20388,6 +20640,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "moonshot",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k2.7-code",
     "status": "active",
     "params": [
@@ -20429,6 +20682,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "kimi-k3",
     "status": "active",
     "params": [
@@ -20504,6 +20758,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "moonshot-v1-128k",
     "status": "deprecated",
     "replacement": "moonshot/kimi-k2.6",
@@ -20644,6 +20899,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "moonshot-v1-32k",
     "status": "deprecated",
     "replacement": "moonshot/kimi-k2.6",
@@ -20784,6 +21040,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "moonshot",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "moonshot-v1-8k",
     "status": "deprecated",
     "replacement": "moonshot/kimi-k2.6",
@@ -20924,6 +21181,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "deepseek-v4-flash-0731",
     "wireId": "deepseek-ai/deepseek-v4-flash-0731",
     "params": [
@@ -21010,6 +21268,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gliner-pii",
     "params": [
       {
@@ -21061,6 +21320,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "llama-3.1-nemoguard-8b-topic-control",
     "params": [
       {
@@ -21133,6 +21393,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "llama-3.1-nemotron-nano-8b-v1",
     "params": [
       {
@@ -21218,6 +21479,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "llama-3.1-nemotron-safety-guard-8b-v3",
     "params": [
       {
@@ -21237,6 +21499,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "llama-3.1-nemotron-ultra-253b-v1",
     "params": [
       {
@@ -21322,6 +21585,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "llama-3.3-nemotron-super-49b-v1",
     "params": [
       {
@@ -21407,6 +21671,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "llama-3.3-nemotron-super-49b-v1.5",
     "params": [
       {
@@ -21492,12 +21757,14 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "nemoguard-jailbreak-detect",
     "params": []
   },
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "nemotron-3-nano-30b-a3b",
     "params": [
       {
@@ -21557,6 +21824,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "nemotron-3-super-120b-a12b",
     "params": [
       {
@@ -21641,6 +21909,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "nemotron-3-ultra-550b-a55b",
     "params": [
       {
@@ -21725,6 +21994,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "nemotron-3-ultra",
     "params": [
       {
@@ -21798,6 +22068,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "nemotron-content-safety-reasoning-4b",
     "params": [
       {
@@ -21857,6 +22128,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "nemotron-mini-4b-instruct",
     "params": [
       {
@@ -21930,6 +22202,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "riva-translate-4b-instruct-v1.1",
     "params": [
       {
@@ -22003,6 +22276,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "nvidia",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "usdcode-llama-3.1-70b-instruct",
     "params": [
       {
@@ -22059,6 +22333,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "chatgpt-4o-latest",
     "status": "retired",
     "replacement": "openai/gpt-5.1-chat-latest",
@@ -22106,6 +22381,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-3.5-turbo",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-terra",
@@ -22153,6 +22429,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-3.5-turbo-16k",
     "params": [
       {
@@ -22197,6 +22474,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -22275,6 +22553,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4-0613",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -22322,6 +22601,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4-turbo",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -22369,6 +22649,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4-turbo-2024-04-09",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -22416,6 +22697,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4.1",
     "status": "active",
     "params": [
@@ -22461,6 +22743,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4.1-mini",
     "status": "active",
     "params": [
@@ -22506,6 +22789,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4.1-nano",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-luna",
@@ -22553,6 +22837,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4o",
     "status": "active",
     "params": [
@@ -22598,6 +22883,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4o-2024-11-20",
     "params": [
       {
@@ -22642,6 +22928,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-4o-mini",
     "status": "active",
     "params": [
@@ -22687,6 +22974,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -22722,6 +23010,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5-chat-latest",
     "status": "retired",
     "replacement": "openai/gpt-5.6-sol",
@@ -22743,6 +23032,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5-mini",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-terra",
@@ -22778,6 +23068,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5-nano",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-luna",
@@ -22813,6 +23104,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.1",
     "params": [
       {
@@ -22845,6 +23137,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.1-codex-max",
     "status": "retired",
     "replacement": "openai/gpt-5.3-codex",
@@ -22897,6 +23190,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.1-codex",
     "status": "retired",
     "replacement": "openai/gpt-5.3-codex",
@@ -22948,6 +23242,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.2",
     "params": [
       {
@@ -22981,6 +23276,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.2-codex",
     "status": "retired",
     "replacement": "openai/gpt-5.3-codex",
@@ -23033,6 +23329,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.2",
     "params": [
       {
@@ -23082,6 +23379,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.3-codex",
     "status": "active",
     "params": [
@@ -23115,6 +23413,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.3-codex-spark",
     "status": "active",
     "params": [
@@ -23165,6 +23464,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.3-codex",
     "status": "active",
     "params": [
@@ -23215,6 +23515,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.4",
     "status": "active",
     "params": [
@@ -23249,6 +23550,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.4-mini",
     "status": "active",
     "params": [
@@ -23283,6 +23585,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.4-mini",
     "status": "active",
     "params": [
@@ -23333,6 +23636,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.4-nano",
     "status": "active",
     "params": [
@@ -23367,6 +23671,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.4-pro",
     "status": "active",
     "params": [
@@ -23399,6 +23704,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.4-pro",
     "status": "active",
     "params": [
@@ -23447,6 +23753,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.4",
     "status": "active",
     "params": [
@@ -23497,6 +23804,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.5",
     "status": "active",
     "params": [
@@ -23531,6 +23839,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.5-pro",
     "status": "active",
     "params": [
@@ -23563,6 +23872,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.5-pro",
     "status": "active",
     "params": [
@@ -23611,6 +23921,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.5",
     "status": "active",
     "params": [
@@ -23661,6 +23972,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.6",
     "params": [
       {
@@ -23694,6 +24006,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.6-luna",
     "status": "active",
     "params": [
@@ -23728,6 +24041,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.6-luna",
     "status": "active",
     "params": [
@@ -23778,6 +24092,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.6-sol",
     "status": "active",
     "params": [
@@ -23812,6 +24127,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.6-sol",
     "status": "active",
     "params": [
@@ -23862,6 +24178,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-5.6-terra",
     "status": "active",
     "params": [
@@ -23896,6 +24213,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "subscription",
+    "apiSurface": "openai-responses",
     "model": "gpt-5.6-terra",
     "status": "active",
     "params": [
@@ -23946,6 +24264,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-120b",
     "status": "active",
     "params": [
@@ -24022,6 +24341,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-20b",
     "status": "active",
     "params": [
@@ -24098,6 +24418,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-safeguard-120b",
     "params": [
       {
@@ -24149,6 +24470,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "gpt-oss-safeguard-20b",
     "params": [
       {
@@ -24200,6 +24522,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o1",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -24235,6 +24558,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o1-mini",
     "status": "retired",
     "replacement": "openai/o4-mini",
@@ -24270,6 +24594,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o1-preview",
     "status": "retired",
     "replacement": "openai/o3",
@@ -24305,6 +24630,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o3",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -24340,6 +24666,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o3-mini",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -24375,6 +24702,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o3-pro",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-sol",
@@ -24410,6 +24738,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "openai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "o4-mini",
     "status": "deprecated",
     "replacement": "openai/gpt-5.6-terra",
@@ -24445,6 +24774,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "perplexity",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "sonar",
     "params": [
       {
@@ -24571,6 +24901,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "perplexity",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "sonar-deep-research",
     "params": [
       {
@@ -24702,6 +25033,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "perplexity",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "sonar-pro",
     "params": [
       {
@@ -24828,6 +25160,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "perplexity",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "sonar-reasoning-pro",
     "params": [
       {
@@ -24954,6 +25287,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "thinking-machines",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "Inkling",
     "params": [
       {
@@ -25015,6 +25349,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-2.5-flash",
     "status": "deprecated",
     "replacement": "vertex/gemini-3.5-flash-lite",
@@ -25150,6 +25485,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-2.5-flash-lite",
     "status": "deprecated",
     "replacement": "vertex/gemini-3.1-flash-lite",
@@ -25267,6 +25603,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-2.5-pro",
     "status": "deprecated",
     "replacement": "vertex/gemini-3.5-flash",
@@ -25402,6 +25739,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3-flash-preview",
     "params": [
       {
@@ -25562,6 +25900,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.1-flash-lite",
     "status": "active",
     "params": [
@@ -25723,6 +26062,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.1-pro-preview",
     "params": [
       {
@@ -25883,6 +26223,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.1-pro-preview-customtools",
     "params": [
       {
@@ -26043,6 +26384,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.5-flash",
     "status": "active",
     "params": [
@@ -26204,6 +26546,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.5-flash-lite",
     "status": "active",
     "params": [
@@ -26343,6 +26686,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.6-flash",
     "status": "active",
     "params": [
@@ -26482,6 +26826,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "vertex",
     "authType": "api_key",
+    "apiSurface": "google-vertex-generate-content",
     "model": "gemini-3.7-flash",
     "status": "active",
     "params": [
@@ -26621,6 +26966,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.20-0309-non-reasoning",
     "status": "active",
     "params": [
@@ -26692,6 +27038,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.20-0309-non-reasoning",
     "status": "active",
     "params": [
@@ -26763,6 +27110,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.20-0309-reasoning",
     "status": "active",
     "params": [
@@ -26827,6 +27175,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.20-0309-reasoning",
     "status": "active",
     "params": [
@@ -26891,6 +27240,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-responses",
     "model": "grok-4.20-multi-agent-0309",
     "status": "active",
     "params": [
@@ -26961,6 +27311,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.3",
     "status": "active",
     "params": [
@@ -27039,6 +27390,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.3",
     "status": "active",
     "params": [
@@ -27117,6 +27469,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.5",
     "status": "active",
     "params": [
@@ -27195,6 +27548,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.5",
     "status": "active",
     "params": [
@@ -27273,6 +27627,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-4.6",
     "params": [
       {
@@ -27343,6 +27698,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-build-0.1",
     "status": "active",
     "params": [
@@ -27407,6 +27763,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "grok-build-0.1",
     "status": "active",
     "params": [
@@ -27471,6 +27828,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xiaomi",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mimo-v2.5",
     "status": "active",
     "params": [
@@ -27549,6 +27907,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xiaomi",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "mimo-v2.5-pro",
     "status": "active",
     "params": [
@@ -27660,6 +28019,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "xiaomi",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "mimo-v2.5",
     "status": "active",
     "params": [
@@ -27738,6 +28098,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5",
     "status": "active",
     "params": [
@@ -27826,6 +28187,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5-air",
     "status": "active",
     "params": [
@@ -27914,6 +28276,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5-air",
     "status": "active",
     "params": [
@@ -28002,6 +28365,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5-airx",
     "status": "active",
     "params": [
@@ -28090,6 +28454,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5-flash",
     "status": "active",
     "params": [
@@ -28178,6 +28543,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5",
     "status": "active",
     "params": [
@@ -28266,6 +28632,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.5-x",
     "status": "active",
     "params": [
@@ -28354,6 +28721,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.6",
     "status": "active",
     "params": [
@@ -28442,6 +28810,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.6",
     "status": "active",
     "params": [
@@ -28530,6 +28899,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.7",
     "status": "active",
     "params": [
@@ -28618,6 +28988,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.7-flash",
     "status": "active",
     "params": [
@@ -28706,6 +29077,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.7-flashx",
     "status": "active",
     "params": [
@@ -28794,6 +29166,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-4.7",
     "status": "active",
     "params": [
@@ -28882,6 +29255,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5",
     "status": "active",
     "params": [
@@ -28970,6 +29344,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5",
     "status": "active",
     "params": [
@@ -29058,6 +29433,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5-turbo",
     "status": "active",
     "params": [
@@ -29146,6 +29522,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5-turbo",
     "status": "active",
     "params": [
@@ -29234,6 +29611,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.1",
     "status": "active",
     "params": [
@@ -29322,6 +29700,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.1",
     "status": "active",
     "params": [
@@ -29410,6 +29789,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.2",
     "status": "active",
     "params": [
@@ -29520,6 +29900,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "subscription",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.2",
     "status": "active",
     "params": [
@@ -29630,6 +30011,7 @@ const GENERATED_CATALOG = [
   {
     "provider": "z-ai",
     "authType": "api_key",
+    "apiSurface": "openai-chat-completions",
     "model": "glm-5.3",
     "params": [
       {
@@ -29729,6 +30111,7 @@ const GENERATED_CATALOG = [
 ] as const;
 
 type GeneratedCatalogEntry = (typeof GENERATED_CATALOG)[number];
+export type ApiSurface = GeneratedCatalogEntry["apiSurface"];
 export type LifecycleStatus = "active" | "deprecated" | "retired";
 type WithLifecycle<T> = T extends unknown
   ? Omit<T, "status" | "replacement" | "shutdownOn"> & {

--- a/packages/modelparams/src/helpers.ts
+++ b/packages/modelparams/src/helpers.ts
@@ -4,7 +4,7 @@ import { MODEL_IDS, type ModelId, type Provider } from "./generated/model-ids.js
 
 /**
  * Return the catalog entry for a model id. The returned object includes the
- * provider, authType, and the full list of parameters with their ranges,
+ * provider, authType, apiSurface, and the full list of parameters with their ranges,
  * defaults, enum values, applicability rules, etc.
  *
  * @example

--- a/packages/modelparams/src/index.ts
+++ b/packages/modelparams/src/index.ts
@@ -14,7 +14,7 @@ export type {
 export type { ApplicabilityIssue, DropCode, DroppedParam, DropResult } from "./applicability.js";
 export type { ModelId, Provider } from "./generated/model-ids.js";
 export type { ParamsById } from "./generated/params-by-id.js";
-export type { CatalogEntry, LifecycleStatus } from "./generated/data.js";
+export type { ApiSurface, CatalogEntry, LifecycleStatus } from "./generated/data.js";
 export type { ParamIssue, ParseParamsResult } from "./parse.js";
 export type {
   StandardSchemaV1,

--- a/packages/modelparams/tests/runtime.test.ts
+++ b/packages/modelparams/tests/runtime.test.ts
@@ -56,6 +56,7 @@ describe("getModel", () => {
     const m = getModel(HAIKU);
     expect(m.provider).toBe("anthropic");
     expect(m.authType).toBe("api_key");
+    expect(m.apiSurface).toBe("anthropic-messages");
     expect(m.model).toBe("claude-haiku-4-5-20251001");
     expect(m.status).toBe("active");
     expect(m.params.length).toBeGreaterThan(0);

--- a/packages/modelparams/tests/version.test.ts
+++ b/packages/modelparams/tests/version.test.ts
@@ -5,6 +5,7 @@ import { bumpVersion, canonicalCatalog, decideBump } from "../scripts/lib/versio
 const baseModel: Model = {
   provider: "anthropic",
   authType: "api_key",
+  apiSurface: "anthropic-messages",
   model: "claude-test",
   params: [
     {

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import {
   buildCapabilityFacets,
   buildCatalog,
-  buildProviderFacets,
   uniqueProviders,
 } from "../data/catalog.js";
 import { loadAllModels } from "../data/load.js";
@@ -197,10 +196,8 @@ export async function build(): Promise<{ models: number }> {
 
   const catalog = buildCatalog(models);
   const capabilities = buildCapabilityFacets(models);
-  const providers = buildProviderFacets(models);
-
   console.log(`Rendering HTML for ${models.length} model(s)...`);
-  const html = await renderIndex({ catalog, capabilities, providers, analytics: true });
+  const html = await renderIndex({ catalog, capabilities, analytics: true });
   await fs.writeFile(path.join(DIST_DIR, "index.html"), html, "utf8");
 
   console.log("Writing JSON API...");

--- a/src/build/render-model.ts
+++ b/src/build/render-model.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import ejs from "ejs";
 import { describeApplicability } from "../data/applicability.js";
+import { apiSurfaceLabel } from "../data/api-surfaces.js";
 import { modelFullLabel, modelLabel, paramGroupLabel, providerLabel } from "../data/display.js";
 import { modelFaq } from "../data/faq.js";
 import { groupParams } from "../data/group.js";
@@ -42,7 +43,7 @@ export function modelPageTitle(model: Model): string {
 const PARAM_TAIL = ". Type, default, range, and gating conditions for each.";
 
 export function modelPageDescription(model: Model): string {
-  const who = `${modelFullLabel(model)}${authNote(model)}`;
+  const who = `${modelFullLabel(model)} on ${apiSurfaceLabel(model.apiSurface)}${authNote(model)}`;
   if (model.params.length === 0) {
     return `${who}: no API parameters documented yet. Browse the open catalog of LLM API parameters on ${SITE_NAME}.`;
   }
@@ -98,11 +99,9 @@ export function modelIntro(model: Model): string {
   if (model.params.length === 0) {
     return `No API parameters are documented yet for ${who}. The data is community-maintained, so this page fills in as entries land.`;
   }
-  const access =
-    model.authType === "subscription"
-      ? " when you reach it through a subscription rather than an API key"
-      : "";
-  return `These are the API parameters ${SITE_NAME} tracks for ${who}${access} — the settings you send in a request. Each row gives the type, default, valid range or values, and the conditions that gate it. It's the same data the JSON API serves.`;
+  const access = model.authType === "subscription" ? " through a subscription" : " with an API key";
+  const surface = apiSurfaceLabel(model.apiSurface);
+  return `These are the API parameters ${SITE_NAME} tracks for ${who} on ${surface}${access} — the settings you send in a request. Each row gives the type, default, valid range or values, and the conditions that gate it. It's the same data the JSON API serves.`;
 }
 
 export function modelLifecycleSummary(model: Model): string | null {
@@ -129,6 +128,7 @@ export async function renderModelPage(model: Model, allModels: Model[]): Promise
     intro: modelIntro(model),
     lifecycleSummary: modelLifecycleSummary(model),
     providerName: providerLabel(model.provider),
+    surfaceName: apiSurfaceLabel(model.apiSurface),
     modelName: modelLabel(model),
     fullName: modelFullLabel(model),
     providerPath: providerPagePath(model.provider),

--- a/src/build/render.ts
+++ b/src/build/render.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
 import ejs from "ejs";
 import { describeApplicability } from "../data/applicability.js";
-import { buildProviderFacets, type CapabilityFacet, type ProviderFacet } from "../data/catalog.js";
+import { apiSurfaceLabel, apiSurfaceSdkMethod } from "../data/api-surfaces.js";
+import { buildProviderFacets, type CapabilityFacet } from "../data/catalog.js";
 import {
   authLabel,
   conditionIcon,
@@ -13,6 +14,11 @@ import {
   providerLabel,
 } from "../data/display.js";
 import { groupParams } from "../data/group.js";
+import {
+  buildApiSurfaceFacets,
+  buildModelGroupProviderFacets,
+  groupModels,
+} from "../data/model-groups.js";
 import { usageGuideMarkdown } from "../data/llms.js";
 import { logoFor } from "../data/logos.js";
 import { VIEWS_DIR } from "../data/paths.js";
@@ -38,6 +44,8 @@ export const viewHelpers = {
   modelLabel,
   providerLabel,
   authLabel,
+  apiSurfaceLabel,
+  apiSurfaceSdkMethod,
   paramGroupColor,
   paramGroupLabel,
   paramGroupIcon,
@@ -108,7 +116,6 @@ export async function renderShell(meta: ShellMeta, body: string): Promise<string
 export interface RenderOptions {
   catalog: Catalog;
   capabilities: CapabilityFacet[];
-  providers: ProviderFacet[];
   initialThemeClass?: string;
   /** Inject the Vercel Web Analytics snippet. Enabled for production builds; off in dev. */
   analytics?: boolean;
@@ -154,18 +161,21 @@ export function homeDescription(
 }
 
 export async function renderIndex(opts: RenderOptions): Promise<string> {
+  const modelGroups = groupModels(opts.catalog.models);
+  const providers = buildModelGroupProviderFacets(modelGroups);
   const body = await ejs.renderFile(path.join(VIEWS_DIR, "index.ejs"), {
-    models: opts.catalog.models,
+    modelGroups,
+    apiSurfaces: buildApiSurfaceFacets(modelGroups),
     capabilities: opts.capabilities,
-    providers: opts.providers,
+    providers,
     helpers: viewHelpers,
   });
 
   const sampleParams = opts.capabilities.slice(0, 3).map((cap) => cap.path);
   return renderShell(
     {
-      title: homeTitle(opts.catalog.models.length),
-      description: homeDescription(opts.catalog.models.length, opts.providers.length, sampleParams),
+      title: homeTitle(modelGroups.length),
+      description: homeDescription(modelGroups.length, providers.length, sampleParams),
       canonicalUrl: `${SITE_URL}/`,
       ogImage: ogImagePath("/"),
       structuredData: buildHomeStructuredData(

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -1,4 +1,5 @@
 import { setupWebMCP } from "./webmcp.js";
+import { setupModelVariantTabs, syncModelVariants } from "./model-variants.js";
 
 type AuthFilter = "all" | "api_key" | "subscription";
 type SortMode = "provider" | "name" | "params";
@@ -6,6 +7,7 @@ type SortMode = "provider" | "name" | "params";
 interface FilterState {
   query: string;
   auth: AuthFilter;
+  apiSurface: string;
   providers: Set<string>;
   capabilities: Set<string>;
   sort: SortMode;
@@ -14,6 +16,7 @@ interface FilterState {
 const state: FilterState = {
   query: "",
   auth: "all",
+  apiSurface: "all",
   providers: new Set(),
   capabilities: new Set(),
   sort: "name",
@@ -201,24 +204,19 @@ function setupThemeToggle(): void {
 }
 
 function modelMatches(el: HTMLElement): boolean {
-  if (state.auth !== "all" && el.dataset.modelAuth !== state.auth) return false;
-
   if (state.providers.size > 0 && !state.providers.has(el.dataset.modelProvider ?? ""))
     return false;
-
-  if (state.capabilities.size > 0) {
-    const have = new Set((el.dataset.modelCapabilities ?? "").split(/\s+/).filter(Boolean));
-    for (const cap of state.capabilities) {
-      if (!have.has(cap)) return false;
-    }
-  }
 
   if (state.query) {
     const haystack = `${el.dataset.modelName ?? ""} ${el.dataset.modelProvider ?? ""} ${el.dataset.modelId ?? ""}`;
     if (!haystack.includes(state.query)) return false;
   }
 
-  return true;
+  return syncModelVariants(el, {
+    auth: state.auth,
+    apiSurface: state.apiSurface,
+    capabilities: state.capabilities,
+  });
 }
 
 function applyFilters(): void {
@@ -284,6 +282,19 @@ function setupAuthFilters(): void {
   });
 }
 
+function setupApiSurfaceFilters(): void {
+  const buttons = document.querySelectorAll<HTMLButtonElement>("[data-api-surface-filter]");
+  buttons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const surface = button.dataset.apiSurfaceFilter;
+      if (!surface) return;
+      state.apiSurface = surface;
+      buttons.forEach((candidate) => setActive(candidate, candidate === button));
+      applyFilters();
+    });
+  });
+}
+
 function setupToggleChips(selector: string, datasetKey: string, bucket: Set<string>): void {
   const chips = document.querySelectorAll<HTMLButtonElement>(selector);
   chips.forEach((chip) => {
@@ -306,6 +317,7 @@ function hasActiveFilters(): boolean {
   return (
     state.query !== "" ||
     state.auth !== "all" ||
+    state.apiSurface !== "all" ||
     state.providers.size > 0 ||
     state.capabilities.size > 0
   );
@@ -329,6 +341,7 @@ function setupClearFilters(): void {
   button.addEventListener("click", () => {
     state.query = "";
     state.auth = "all";
+    state.apiSurface = "all";
     state.providers.clear();
     state.capabilities.clear();
 
@@ -338,6 +351,9 @@ function setupClearFilters(): void {
     document
       .querySelectorAll<HTMLButtonElement>("[data-auth-filter]")
       .forEach((b) => setActive(b, b.dataset.authFilter === "all"));
+    document
+      .querySelectorAll<HTMLButtonElement>("[data-api-surface-filter]")
+      .forEach((b) => setActive(b, b.dataset.apiSurfaceFilter === "all"));
     document
       .querySelectorAll<HTMLButtonElement>("[data-provider], [data-capability]")
       .forEach((c) => setActive(c, false));
@@ -480,7 +496,11 @@ function setupFilterPanel(): void {
 function updateFilterCount(): void {
   const badge = document.querySelector<HTMLElement>("[data-active-filter-count]");
   if (!badge) return;
-  const count = state.providers.size + state.capabilities.size + (state.auth !== "all" ? 1 : 0);
+  const count =
+    state.providers.size +
+    state.capabilities.size +
+    (state.auth !== "all" ? 1 : 0) +
+    (state.apiSurface !== "all" ? 1 : 0);
   if (count > 0) {
     badge.textContent = String(count);
     badge.classList.remove("hidden");
@@ -614,12 +634,14 @@ document.addEventListener("DOMContentLoaded", () => {
   setupViewModeToggle();
   setupSearch();
   setupAuthFilters();
+  setupApiSurfaceFilters();
   setupToggleChips("[data-provider]", "provider", state.providers);
   setupToggleChips("[data-capability]", "capability", state.capabilities);
   setupFilterPanel();
   setupClearFilters();
   setupSort();
   reorderList();
+  setupModelVariantTabs();
   setupModelLinks();
   setupSearchShortcut();
   setupScrollTopButton();

--- a/src/client/model-variants.ts
+++ b/src/client/model-variants.ts
@@ -1,0 +1,51 @@
+export interface VariantFilters {
+  auth: string;
+  apiSurface: string;
+  capabilities: Set<string>;
+}
+
+function variantMatches(panel: HTMLElement, filters: VariantFilters): boolean {
+  if (filters.auth !== "all" && panel.dataset.variantAuth !== filters.auth) return false;
+  if (filters.apiSurface !== "all" && panel.dataset.variantSurface !== filters.apiSurface)
+    return false;
+  const paths = new Set((panel.dataset.variantCapabilities ?? "").split(/\s+/).filter(Boolean));
+  return [...filters.capabilities].every((capability) => paths.has(capability));
+}
+
+function selectVariant(row: HTMLElement, index: string): void {
+  row.querySelectorAll<HTMLElement>("[data-model-variant]").forEach((panel) => {
+    panel.classList.toggle("hidden", panel.dataset.modelVariant !== index);
+  });
+  row.querySelectorAll<HTMLElement>("[data-model-variant-trigger]").forEach((trigger) => {
+    const active = trigger.dataset.modelVariantTrigger === index;
+    trigger.dataset.active = String(active);
+    trigger.setAttribute("aria-selected", String(active));
+  });
+}
+
+export function syncModelVariants(row: HTMLElement, filters: VariantFilters): boolean {
+  const panels = Array.from(row.querySelectorAll<HTMLElement>("[data-model-variant]"));
+  const matching = panels.filter((panel) => variantMatches(panel, filters));
+  const matchingIds = new Set(matching.map((panel) => panel.dataset.modelVariant));
+
+  row.querySelectorAll<HTMLElement>("[data-model-variant-trigger]").forEach((trigger) => {
+    trigger.classList.toggle("hidden", !matchingIds.has(trigger.dataset.modelVariantTrigger));
+  });
+
+  const active = panels.find((panel) => !panel.classList.contains("hidden"));
+  const selected = active && matching.includes(active) ? active : matching[0];
+  if (selected?.dataset.modelVariant !== undefined) {
+    selectVariant(row, selected.dataset.modelVariant);
+  }
+  return matching.length > 0;
+}
+
+export function setupModelVariantTabs(): void {
+  document.querySelectorAll<HTMLElement>("[data-model-variant-trigger]").forEach((trigger) => {
+    trigger.addEventListener("click", () => {
+      const row = trigger.closest<HTMLElement>(".model");
+      const index = trigger.dataset.modelVariantTrigger;
+      if (row && index !== undefined) selectVariant(row, index);
+    });
+  });
+}

--- a/src/client/webmcp.ts
+++ b/src/client/webmcp.ts
@@ -4,6 +4,14 @@
 // server-side modules (and no zod) into the client bundle.
 
 type AuthType = "api_key" | "subscription";
+type ApiSurface =
+  | "openai-chat-completions"
+  | "openai-responses"
+  | "anthropic-messages"
+  | "google-generate-content"
+  | "amazon-bedrock-converse"
+  | "google-vertex-generate-content"
+  | "cohere-chat";
 type LifecycleStatus = "active" | "deprecated" | "retired";
 
 interface CatalogParam {
@@ -18,6 +26,7 @@ interface CatalogParam {
 interface CatalogModel {
   provider: string;
   authType: AuthType;
+  apiSurface: ApiSurface;
   model: string;
   status?: LifecycleStatus;
   replacement?: string;
@@ -92,6 +101,7 @@ function asStringList(value: unknown): string[] {
 function reflectInUi(filters: {
   query?: string;
   auth?: string;
+  apiSurface?: string;
   providers: string[];
   capabilities: string[];
 }): void {
@@ -102,6 +112,11 @@ function reflectInUi(filters: {
   }
   if (filters.auth) {
     document.querySelector<HTMLButtonElement>(`[data-auth-filter="${filters.auth}"]`)?.click();
+  }
+  if (filters.apiSurface) {
+    document
+      .querySelector<HTMLButtonElement>(`[data-api-surface-filter="${filters.apiSurface}"]`)
+      ?.click();
   }
   setToggleGroup("[data-provider]", "provider", filters.providers);
   setToggleGroup("[data-capability]", "capability", filters.capabilities);
@@ -123,12 +138,14 @@ function setToggleGroup(selector: string, key: string, wanted: string[]): void {
 export function searchCatalog(catalog: Catalog, params: Record<string, unknown>) {
   const query = asString(params.query)?.toLowerCase();
   const auth = asString(params.auth);
+  const apiSurface = asString(params.apiSurface);
   const providers = asStringList(params.provider);
   const capabilities = asStringList(params.capability);
   const limit = typeof params.limit === "number" ? Math.max(1, Math.floor(params.limit)) : 25;
 
   const matches = catalog.models.filter((model) => {
     if (auth && auth !== "all" && model.authType !== auth) return false;
+    if (apiSurface && apiSurface !== "all" && model.apiSurface !== apiSurface) return false;
     if (providers.length > 0 && !providers.includes(model.provider)) return false;
     const paths = new Set(model.params.map((p) => p.path));
     if (!capabilities.every((cap) => paths.has(cap))) return false;
@@ -148,6 +165,7 @@ export function searchCatalog(catalog: Catalog, params: Record<string, unknown>)
       provider: model.provider,
       model: model.model,
       authType: model.authType,
+      apiSurface: model.apiSurface,
       status: model.status,
       replacement: model.replacement,
       shutdownOn: model.shutdownOn,
@@ -162,6 +180,7 @@ function searchModels(catalog: Catalog, params: Record<string, unknown>) {
   reflectInUi({
     query: asString(params.query) ?? "",
     auth: asString(params.auth),
+    apiSurface: asString(params.apiSurface),
     providers: asStringList(params.provider),
     capabilities: asStringList(params.capability),
   });
@@ -189,7 +208,7 @@ function buildTools(): ToolDefinition[] {
       name: "search_models",
       description:
         "Search the LLM parameter catalog. Filter by free-text query, provider slug, " +
-        "required parameter path(s), and auth type (api_key | subscription | all). Also " +
+        "required parameter path(s), API surface, and auth type (api_key | subscription | all). Also " +
         "mirrors the query onto the page's visible filters. Returns matching model ids.",
       inputSchema: {
         type: "object",
@@ -208,6 +227,19 @@ function buildTools(): ToolDefinition[] {
             type: "string",
             enum: ["all", "api_key", "subscription"],
             description: "Auth variant to include. Defaults to all.",
+          },
+          apiSurface: {
+            type: "string",
+            enum: [
+              "openai-chat-completions",
+              "openai-responses",
+              "anthropic-messages",
+              "google-generate-content",
+              "amazon-bedrock-converse",
+              "google-vertex-generate-content",
+              "cohere-chat",
+            ],
+            description: "API/SDK surface, e.g. openai-responses or anthropic-messages.",
           },
           limit: { type: "number", description: "Max models to return (default 25)." },
         },

--- a/src/data/api-surfaces.ts
+++ b/src/data/api-surfaces.ts
@@ -1,0 +1,39 @@
+import { ApiSurface, type ApiSurface as ApiSurfaceName } from "../schema/model.js";
+
+export interface ApiSurfaceMeta {
+  value: ApiSurfaceName;
+  label: string;
+  sdkMethod: string;
+}
+
+const META: Record<ApiSurfaceName, Omit<ApiSurfaceMeta, "value">> = {
+  "openai-chat-completions": {
+    label: "Chat Completions",
+    sdkMethod: "chat.completions.create",
+  },
+  "openai-responses": { label: "Responses", sdkMethod: "responses.create" },
+  "anthropic-messages": { label: "Messages", sdkMethod: "messages.create" },
+  "google-generate-content": {
+    label: "Gemini generateContent",
+    sdkMethod: "models.generateContent",
+  },
+  "amazon-bedrock-converse": { label: "Bedrock Converse", sdkMethod: "ConverseCommand" },
+  "google-vertex-generate-content": {
+    label: "Vertex generateContent",
+    sdkMethod: "generateContent",
+  },
+  "cohere-chat": { label: "Cohere Chat", sdkMethod: "chat" },
+};
+
+export const API_SURFACES: ApiSurfaceMeta[] = ApiSurface.options.map((value) => ({
+  value,
+  ...META[value],
+}));
+
+export function apiSurfaceLabel(surface: ApiSurfaceName): string {
+  return META[surface].label;
+}
+
+export function apiSurfaceSdkMethod(surface: ApiSurfaceName): string {
+  return META[surface].sdkMethod;
+}

--- a/src/data/llms.ts
+++ b/src/data/llms.ts
@@ -1,4 +1,5 @@
 import { describeApplicability } from "./applicability.js";
+import { apiSurfaceLabel } from "./api-surfaces.js";
 import { buildProviderFacets } from "./catalog.js";
 import { authLabel, modelFullLabel, paramGroupLabel, providerLabel } from "./display.js";
 import { groupParams } from "./group.js";
@@ -14,7 +15,7 @@ function modelJsonUrl(siteUrl: string, model: Model): string {
 
 function modelTitle(model: Model): string {
   const variant = model.authType === "subscription" ? ` (${authLabel(model.authType)})` : "";
-  return `${modelFullLabel(model)}${variant}`;
+  return `${modelFullLabel(model)}${variant} on ${apiSurfaceLabel(model.apiSurface)}`;
 }
 
 function plural(n: number, word: string): string {
@@ -43,8 +44,9 @@ function guideIntro(siteUrl: string): string[] {
     "`eu.anthropic....` in Frankfurt, or `global.anthropic....` to let AWS route it. Valid scopes:",
     "us, eu, apac, jp, au, ca, sa, global. A wireId with no placeholder is already complete.",
     "",
-    "For the same reason, **one entry documents one wire format**. Where a host serves two,",
-    "the entry follows the one named here and says nothing about the other: `bedrock/*`",
+    "Every entry names its request and SDK family in `apiSurface`; **one entry documents one",
+    "wire format**. Where a host serves two, use the entry for the surface your code calls:",
+    "`bedrock/*` currently declares `amazon-bedrock-converse` and",
     "documents Amazon Bedrock's `Converse` API (`inferenceConfig.maxTokens`, vendor extras",
     "under `additionalModelRequestFields`), not `InvokeModel` with native per-vendor bodies",
     "(`max_tokens`, top-level `thinking`) as the `AnthropicBedrock` client sends. If your",

--- a/src/data/model-groups.ts
+++ b/src/data/model-groups.ts
@@ -1,0 +1,71 @@
+import { API_SURFACES } from "./api-surfaces.js";
+import type { ProviderFacet } from "./catalog.js";
+import type { ApiSurface, Model } from "../schema/model.js";
+
+export interface ModelGroup {
+  key: string;
+  provider: string;
+  model: string;
+  variants: Model[];
+  apiSurfaces: ApiSurface[];
+  capabilities: string[];
+  maxParams: number;
+}
+
+const surfaceOrder = new Map(API_SURFACES.map((surface, index) => [surface.value, index]));
+
+function sortVariants(a: Model, b: Model): number {
+  if (a.authType !== b.authType) return a.authType === "api_key" ? -1 : 1;
+  return (surfaceOrder.get(a.apiSurface) ?? 0) - (surfaceOrder.get(b.apiSurface) ?? 0);
+}
+
+function finishGroup(group: ModelGroup): ModelGroup {
+  group.variants.sort(sortVariants);
+  group.apiSurfaces = [...new Set(group.variants.map((variant) => variant.apiSurface))];
+  group.capabilities = [
+    ...new Set(group.variants.flatMap((variant) => variant.params.map((param) => param.path))),
+  ];
+  group.maxParams = Math.max(...group.variants.map((variant) => variant.params.length));
+  return group;
+}
+
+export function groupModels(models: Model[]): ModelGroup[] {
+  const groups = new Map<string, ModelGroup>();
+  for (const entry of models) {
+    const key = `${entry.provider}/${entry.model}`;
+    const group = groups.get(key) ?? {
+      key,
+      provider: entry.provider,
+      model: entry.model,
+      variants: [],
+      apiSurfaces: [],
+      capabilities: [],
+      maxParams: 0,
+    };
+    group.variants.push(entry);
+    groups.set(key, group);
+  }
+  return [...groups.values()].map(finishGroup);
+}
+
+export interface ApiSurfaceFacet {
+  apiSurface: ApiSurface;
+  count: number;
+}
+
+export function buildApiSurfaceFacets(groups: ModelGroup[]): ApiSurfaceFacet[] {
+  return API_SURFACES.map(({ value }) => ({
+    apiSurface: value,
+    count: groups.filter((group) => group.apiSurfaces.includes(value)).length,
+  })).filter((facet) => facet.count > 0);
+}
+
+export function buildModelGroupProviderFacets(groups: ModelGroup[]): ProviderFacet[] {
+  const counts = new Map<string, number>();
+  for (const group of groups) {
+    counts.set(group.provider, (counts.get(group.provider) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([provider, count]) => ({ provider, count }))
+    .sort((a, b) => b.count - a.count || a.provider.localeCompare(b.provider));
+}

--- a/src/schema/model.ts
+++ b/src/schema/model.ts
@@ -3,6 +3,17 @@ import { z } from "zod";
 export const AuthType = z.enum(["api_key", "subscription"]);
 export type AuthType = z.infer<typeof AuthType>;
 
+export const ApiSurface = z.enum([
+  "openai-chat-completions",
+  "openai-responses",
+  "anthropic-messages",
+  "google-generate-content",
+  "amazon-bedrock-converse",
+  "google-vertex-generate-content",
+  "cohere-chat",
+]);
+export type ApiSurface = z.infer<typeof ApiSurface>;
+
 export const LifecycleStatus = z.enum(["active", "deprecated", "retired"]);
 export type LifecycleStatus = z.infer<typeof LifecycleStatus>;
 
@@ -177,6 +188,8 @@ export const Model = z
       .min(1)
       .regex(PROVIDER_SLUG, "provider must be a kebab-case slug (e.g. `anthropic`)"),
     authType: AuthType,
+    /** The request/SDK surface whose parameter paths this entry documents. */
+    apiSurface: ApiSurface,
     model: z
       .string()
       .min(1)

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { buildCapabilityFacets, buildCatalog, buildProviderFacets } from "../data/catalog.js";
+import { buildCapabilityFacets, buildCatalog } from "../data/catalog.js";
 import { buildLlmsFullTxt, buildLlmsTxt } from "../data/llms.js";
 import { findModelParams } from "../data/model-params.js";
 import { buildParameterIndex } from "../data/parameters.js";
@@ -45,8 +45,7 @@ export function makeApp(loadModels: LoadModels): express.Express {
       const models = await loadModels();
       const catalog = buildCatalog(models);
       const capabilities = buildCapabilityFacets(models);
-      const providers = buildProviderFacets(models);
-      const html = await renderIndex({ catalog, capabilities, providers });
+      const html = await renderIndex({ catalog, capabilities });
       res.setHeader("Cache-Control", "no-store");
       res.type("html").send(html);
     } catch (err) {

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -132,6 +132,35 @@
   </div>
 </div>
 
+<div class="mt-4" aria-label="Filter by API surface">
+  <p class="mb-2 text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">
+    API surface
+  </p>
+  <div class="-mx-4 flex gap-2 overflow-x-auto px-4 pb-1 sm:mx-0 sm:flex-wrap sm:px-0">
+    <button
+      type="button"
+      data-api-surface-filter="all"
+      data-active="true"
+      aria-pressed="true"
+      class="inline-flex shrink-0 items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300 data-[active=true]:border-accent data-[active=true]:bg-accent data-[active=true]:text-white dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:data-[active=true]:border-accent dark:data-[active=true]:bg-accent"
+    >
+      All surfaces
+      <span class="tabular-nums opacity-60"><%= modelGroups.length %></span>
+    </button>
+    <% for (const surface of apiSurfaces) { %>
+    <button
+      type="button"
+      data-api-surface-filter="<%= surface.apiSurface %>"
+      aria-pressed="false"
+      class="inline-flex shrink-0 items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300 data-[active=true]:border-accent data-[active=true]:bg-accent data-[active=true]:text-white dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:data-[active=true]:border-accent dark:data-[active=true]:bg-accent"
+    >
+      <%= helpers.apiSurfaceLabel(surface.apiSurface) %>
+      <span class="tabular-nums opacity-60"><%= surface.count %></span>
+    </button>
+    <% } %>
+  </div>
+</div>
+
 <div data-filter-panel class="filter-panel-closed border border-slate-200 bg-slate-50 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:shadow-none">
   <div data-filter-scroll class="overflow-y-auto">
   <div class="mx-auto max-w-6xl p-4 sm:p-6">
@@ -238,16 +267,16 @@
 <section class="mt-4" aria-label="Models">
   <%
     const byProvider = new Map();
-    for (const m of models) {
-      const list = byProvider.get(m.provider) || [];
-      list.push(m);
-      byProvider.set(m.provider, list);
+    for (const group of modelGroups) {
+      const list = byProvider.get(group.provider) || [];
+      list.push(group);
+      byProvider.set(group.provider, list);
     }
   %>
   <div class="mb-3 flex items-center justify-between gap-3 text-xs text-slate-500 dark:text-slate-400">
     <p>
-      <span data-visible-count><%= models.length %></span> of
-      <span class="tabular-nums"><%= models.length %></span> models
+      <span data-visible-count><%= modelGroups.length %></span> of
+      <span class="tabular-nums"><%= modelGroups.length %></span> models
     </p>
     <div class="flex items-center gap-2">
       <label class="flex items-center gap-1.5">
@@ -264,7 +293,7 @@
   </div>
   <div class="model-list flex flex-col" data-model-list>
     <% for (const pf of providers) { %>
-    <% const group = byProvider.get(pf.provider) || []; %>
+    <% const providerGroups = byProvider.get(pf.provider) || []; %>
     <h2
       data-group-header
       data-provider="<%= pf.provider %>"
@@ -272,7 +301,7 @@
     >
       <%= helpers.providerLabel(pf.provider) %>
     </h2>
-    <% for (const model of group) { %><%- include("partials/model_row", { model: model, helpers: helpers }) %><% } %>
+    <% for (const group of providerGroups) { %><%- include("partials/model_row", { group: group, helpers: helpers }) %><% } %>
     <% } %>
   </div>
   <p data-empty-state class="mt-6 hidden text-center text-sm italic text-slate-500 dark:text-slate-400">

--- a/src/views/model.ejs
+++ b/src/views/model.ejs
@@ -15,6 +15,7 @@
       <% } %>
       <span><%= providerName %></span>
     </a>
+    <span class="inline-flex shrink-0 items-center rounded-full bg-warm-tag px-2.5 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200"><%= surfaceName %></span>
     <% if (isSubscription) { %>
     <span class="inline-flex shrink-0 items-center bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-200"><%= helpers.authLabel(model.authType) %></span>
     <% } %>
@@ -65,7 +66,7 @@
 <section class="mt-10" aria-label="Parameter summary">
   <h2 class="text-slate-900 dark:text-slate-100"><%= providerName %> <%= modelName %> API parameters in brief</h2>
   <p class="mt-2 max-w-2xl text-sm text-slate-600 dark:text-slate-300">
-    <%= providerName %> <%= modelName %><% if (isSubscription) { %> via subscription<% } %> documents <%= model.params.length %> API parameter<%= model.params.length === 1 ? "" : "s" %>, grouped by what they control:
+    <%= providerName %> <%= modelName %> on <%= surfaceName %><% if (isSubscription) { %> via subscription<% } %> documents <%= model.params.length %> API parameter<%= model.params.length === 1 ? "" : "s" %>, grouped by what they control:
   </p>
   <ul class="mt-3 max-w-2xl space-y-2 text-sm text-slate-700 dark:text-slate-300">
     <% for (const grp of proseGroups) { %>
@@ -150,6 +151,7 @@
       class="model flex items-center border border-slate-200 bg-white px-4 py-3 transition-colors hover:border-slate-300 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-700"
     >
       <span class="truncate text-sm text-slate-900 dark:text-slate-100"><%= helpers.modelLabel(sibling) %></span>
+      <span class="ml-3 hidden rounded-full bg-warm-tag px-1.5 py-0.5 text-[10px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300 sm:inline"><%= helpers.apiSurfaceLabel(sibling.apiSurface) %></span>
       <% if (sibling.authType === "subscription") { %>
       <span class="ml-3 bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-200"><%= helpers.authLabel(sibling.authType) %></span>
       <% } %>

--- a/src/views/partials/model_row.ejs
+++ b/src/views/partials/model_row.ejs
@@ -1,54 +1,47 @@
 <%
-  const id = helpers.modelId(model);
-  const providerName = helpers.providerLabel(model.provider);
-  const modelName = helpers.modelLabel(model);
-  const isSubscription = model.authType === "subscription";
-  const capabilities = model.params.map((p) => p.path).join(" ");
-  const providerLogo = helpers.logoFor(model.provider);
+  const providerName = helpers.providerLabel(group.provider);
+  const modelName = helpers.modelLabel(group);
+  const providerLogo = helpers.logoFor(group.provider);
+  const summaryStatus = group.variants.every((variant) => variant.status === group.variants[0].status)
+    ? group.variants[0].status
+    : undefined;
+  const rowId = group.key.replace('/', '--');
 %>
 <details
   class="model group border border-slate-200 bg-white transition-colors hover:border-slate-300 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-700"
-  data-model-id="<%= id %>"
+  data-model-id="<%= group.key %>"
   data-model-name="<%= modelName.toLowerCase() %>"
-  data-model-provider="<%= model.provider %>"
-  data-model-auth="<%= model.authType %>"
-  data-model-capabilities="<%= capabilities %>"
-  data-model-params="<%= model.params.length %>"
-  id="<%= id.replace('/', '--') %>"
+  data-model-provider="<%= group.provider %>"
+  data-model-params="<%= group.maxParams %>"
+  id="<%= rowId %>"
 >
-  <summary
-    class="flex cursor-pointer list-none items-center px-4 py-3 sm:px-6"
-  >
-    <a
-      href="<%= helpers.modelPagePath(model) %>"
-      data-model-link
-      class="truncate text-sm hover:text-accent sm:text-base dark:hover:text-accent"
-    ><%= modelName %></a>
-    <span class="mx-4 text-slate-300 dark:text-slate-600" aria-hidden="true">|</span>
+  <summary class="flex cursor-pointer list-none items-center gap-3 px-4 py-3 sm:px-6">
+    <span class="min-w-0 truncate text-sm sm:text-base"><%= modelName %></span>
+    <span class="hidden text-slate-300 sm:inline dark:text-slate-600" aria-hidden="true">|</span>
     <span
-      class="provider-badge inline-flex shrink-0 items-center gap-1.5 text-sm sm:text-base"
-      data-provider-slug="<%= model.provider %>"
+      class="provider-badge hidden shrink-0 items-center gap-1.5 text-sm sm:inline-flex sm:text-base"
+      data-provider-slug="<%= group.provider %>"
     >
       <% if (providerLogo) { %>
       <span class="provider-logo inline-flex h-4 w-4 shrink-0 items-center justify-center" aria-hidden="true"><%- providerLogo %></span>
       <% } %>
       <span class="text-slate-600 dark:text-slate-300"><%= providerName %></span>
     </span>
-    <% if (isSubscription) { %>
-    <span class="ml-3 inline-flex shrink-0 items-center rounded-md bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-200"
-      ><%= helpers.authLabel(model.authType) %></span
-    >
+    <span class="hidden min-w-0 gap-1.5 md:flex">
+      <% for (const surface of group.apiSurfaces) { %>
+      <span class="truncate rounded-full bg-warm-tag px-2 py-0.5 text-[11px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"><%= helpers.apiSurfaceLabel(surface) %></span>
+      <% } %>
+    </span>
+    <% if (summaryStatus === "retired") { %>
+    <span class="hidden shrink-0 bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/50 dark:text-red-200 sm:inline-flex">Retired</span>
+    <% } else if (summaryStatus === "deprecated") { %>
+    <span class="hidden shrink-0 bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/50 dark:text-amber-200 sm:inline-flex">Deprecated</span>
     <% } %>
-    <% if (model.status === "deprecated") { %>
-    <span class="ml-3 inline-flex shrink-0 items-center bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/50 dark:text-amber-200">Deprecated</span>
-    <% } else if (model.status === "retired") { %>
-    <span class="ml-3 inline-flex shrink-0 items-center bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/50 dark:text-red-200">Retired</span>
-    <% } %>
-    <span class="ml-auto shrink-0 text-xs tabular-nums text-slate-500 dark:text-slate-400"
-      ><%= model.params.length %> param<%= model.params.length === 1 ? "" : "s" %></span
-    >
+    <span class="ml-auto shrink-0 text-xs tabular-nums text-slate-500 dark:text-slate-400">
+      <% if (group.variants.length > 1) { %><%= group.variants.length %> variants<% } else { %><%= group.maxParams %> param<%= group.maxParams === 1 ? "" : "s" %><% } %>
+    </span>
     <svg
-      class="ml-2 h-4 w-4 shrink-0 text-slate-400 transition-transform group-open:rotate-90"
+      class="h-4 w-4 shrink-0 text-slate-400 transition-transform group-open:rotate-90"
       viewBox="0 0 16 16"
       fill="none"
       stroke="currentColor"
@@ -61,11 +54,57 @@
     </svg>
   </summary>
   <div class="border-t border-slate-200 px-4 py-4 sm:px-6 dark:border-slate-800">
-    <% if (model.params.length === 0) { %>
-    <p class="text-sm italic text-slate-500 dark:text-slate-400">No parameters documented yet.</p>
-    <% } else { %> <%- include("param_table", { params: model.params, helpers: helpers }) %> <% } %>
-    <div class="mt-3 text-right">
-      <a href="<%= helpers.modelPagePath(model) %>" class="text-xs font-medium text-accent hover:text-accent-hover">Open <%= modelName %> page →</a>
+    <% if (group.variants.length > 1) { %>
+    <div class="mb-4 flex flex-wrap gap-2" role="tablist" aria-label="API and access variants">
+      <% for (let i = 0; i < group.variants.length; i++) { const variant = group.variants[i]; %>
+      <button
+        type="button"
+        role="tab"
+        data-model-variant-trigger="<%= i %>"
+        data-variant-auth="<%= variant.authType %>"
+        data-variant-surface="<%= variant.apiSurface %>"
+        data-active="<%= i === 0 %>"
+        aria-selected="<%= i === 0 %>"
+        aria-controls="<%= rowId %>-variant-<%= i %>"
+        class="inline-flex items-center gap-2 border border-slate-200 px-3 py-2 text-xs text-slate-600 hover:border-slate-300 data-[active=true]:border-accent data-[active=true]:bg-accent data-[active=true]:text-white dark:border-slate-700 dark:text-slate-300 dark:data-[active=true]:border-accent dark:data-[active=true]:bg-accent"
+      >
+        <%= helpers.apiSurfaceLabel(variant.apiSurface) %>
+        <span class="opacity-70"><%= helpers.authLabel(variant.authType) %></span>
+      </button>
+      <% } %>
     </div>
+    <% } %>
+
+    <% for (let i = 0; i < group.variants.length; i++) { const variant = group.variants[i]; %>
+    <div
+      id="<%= rowId %>-variant-<%= i %>"
+      role="tabpanel"
+      data-model-variant="<%= i %>"
+      data-variant-auth="<%= variant.authType %>"
+      data-variant-surface="<%= variant.apiSurface %>"
+      data-variant-capabilities="<%= variant.params.map((param) => param.path).join(' ') %>"
+      class="<%= i === 0 ? '' : 'hidden' %>"
+    >
+      <div class="mb-4 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs">
+        <span class="font-semibold text-slate-900 dark:text-slate-100"><%= helpers.apiSurfaceLabel(variant.apiSurface) %></span>
+        <code class="rounded bg-slate-100 px-2 py-1 font-mono text-[11px] text-slate-600 dark:bg-slate-800 dark:text-slate-300"><%= helpers.apiSurfaceSdkMethod(variant.apiSurface) %></code>
+        <span class="text-slate-500 dark:text-slate-400"><%= helpers.authLabel(variant.authType) %></span>
+        <% if (variant.status === "deprecated") { %>
+        <span class="bg-amber-100 px-2 py-0.5 font-medium text-amber-800 dark:bg-amber-900/50 dark:text-amber-200">Deprecated</span>
+        <% } else if (variant.status === "retired") { %>
+        <span class="bg-red-100 px-2 py-0.5 font-medium text-red-800 dark:bg-red-900/50 dark:text-red-200">Retired</span>
+        <% } %>
+        <span class="tabular-nums text-slate-400 dark:text-slate-500"><%= variant.params.length %> param<%= variant.params.length === 1 ? "" : "s" %></span>
+      </div>
+      <% if (variant.params.length === 0) { %>
+      <p class="text-sm italic text-slate-500 dark:text-slate-400">No parameters documented yet.</p>
+      <% } else { %>
+      <%- include("param_table", { params: variant.params, helpers: helpers }) %>
+      <% } %>
+      <div class="mt-3 text-right">
+        <a href="<%= helpers.modelPagePath(variant) %>" class="text-xs font-medium text-accent hover:text-accent-hover">Open <%= modelName %> <%= helpers.apiSurfaceLabel(variant.apiSurface) %> →</a>
+      </div>
+    </div>
+    <% } %>
   </div>
 </details>

--- a/src/views/provider.ejs
+++ b/src/views/provider.ejs
@@ -39,6 +39,7 @@
     >
       <span class="truncate text-sm font-medium text-slate-900 dark:text-slate-100"><%= helpers.modelLabel(model) %></span>
       <div class="mt-3 flex items-center gap-2">
+        <span class="rounded-full bg-warm-tag px-1.5 py-0.5 text-[10px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"><%= helpers.apiSurfaceLabel(model.apiSurface) %></span>
         <% if (model.authType === "subscription") { %>
         <span class="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-200"><%= helpers.authLabel(model.authType) %></span>
         <% } %>
@@ -56,6 +57,7 @@
       class="model flex items-center border border-slate-200 bg-white px-4 py-3 transition-colors hover:border-slate-300 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-700"
     >
       <span class="truncate text-sm font-medium text-slate-900 dark:text-slate-100"><%= helpers.modelLabel(model) %></span>
+      <span class="ml-3 hidden rounded-full bg-warm-tag px-1.5 py-0.5 text-[10px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300 sm:inline"><%= helpers.apiSurfaceLabel(model.apiSurface) %></span>
       <% if (model.authType === "subscription") { %>
       <span class="ml-3 rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-200"><%= helpers.authLabel(model.authType) %></span>
       <% } %>

--- a/tests/catalog-diff.test.ts
+++ b/tests/catalog-diff.test.ts
@@ -5,6 +5,7 @@ import { diffCatalogs, isEmptyDiff, renderCatalogChangelog } from "../src/data/c
 const model = (overrides: Partial<Model> = {}): Model => ({
   provider: "anthropic",
   authType: "api_key",
+  apiSurface: "anthropic-messages",
   model: "claude-test",
   params: [
     {

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { buildCapabilityFacets, buildCatalog, uniqueProviders } from "../src/data/catalog.js";
 import { describeApplicability } from "../src/data/applicability.js";
+import { apiSurfaceLabel, apiSurfaceSdkMethod } from "../src/data/api-surfaces.js";
+import { buildApiSurfaceFacets, groupModels } from "../src/data/model-groups.js";
 import { modelFullLabel, modelLabel, paramLabel, providerLabel } from "../src/data/display.js";
 import {
   findModelParams,
@@ -16,6 +18,7 @@ function makeModel(overrides: Partial<Model> = {}): Model {
   return {
     provider: "anthropic",
     authType: "api_key",
+    apiSurface: "anthropic-messages",
     model: "claude-opus-4-7",
     params: [
       {
@@ -64,6 +67,31 @@ describe("buildCapabilityFacets", () => {
     expect(facets[0]).toEqual({ path: "temperature", count: 2 });
     expect(facets.map((f) => f.path)).toContain("logprobs");
     expect(facets.map((f) => f.path)).toContain("top_p");
+  });
+});
+
+describe("groupModels", () => {
+  it("keeps API surfaces as flat variants under one provider/model row", () => {
+    const chat = makeModel({
+      provider: "openai",
+      model: "gpt-5.5",
+      apiSurface: "openai-chat-completions",
+    });
+    const responses = makeModel({
+      provider: "openai",
+      model: "gpt-5.5",
+      authType: "subscription",
+      apiSurface: "openai-responses",
+    });
+    const groups = groupModels([responses, chat]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.variants).toEqual([chat, responses]);
+    expect(groups[0]?.apiSurfaces).toEqual(["openai-chat-completions", "openai-responses"]);
+    expect(buildApiSurfaceFacets(groups)).toEqual([
+      { apiSurface: "openai-chat-completions", count: 1 },
+      { apiSurface: "openai-responses", count: 1 },
+    ]);
   });
 });
 
@@ -146,6 +174,11 @@ describe("providerless model params", () => {
 });
 
 describe("display helpers", () => {
+  it("labels API surfaces with their representative SDK method", () => {
+    expect(apiSurfaceLabel("openai-responses")).toBe("Responses");
+    expect(apiSurfaceSdkMethod("openai-responses")).toBe("responses.create");
+  });
+
   it("knows the canonical provider names", () => {
     expect(providerLabel("anthropic")).toBe("Anthropic");
     expect(providerLabel("openai")).toBe("OpenAI");

--- a/tests/faq.test.ts
+++ b/tests/faq.test.ts
@@ -6,6 +6,7 @@ function model(over: Partial<Model> = {}): Model {
   return {
     provider: "anthropic",
     authType: "api_key",
+    apiSurface: "anthropic-messages",
     model: "claude-opus-4-7",
     params: [
       {

--- a/tests/glossary.test.ts
+++ b/tests/glossary.test.ts
@@ -3,7 +3,13 @@ import { buildGlossary } from "../src/data/glossary.js";
 import type { Model } from "../src/schema/model.js";
 
 function model(provider: string, name: string, params: Model["params"]): Model {
-  return { provider, authType: "api_key", model: name, params } as Model;
+  return {
+    provider,
+    authType: "api_key",
+    apiSurface: "openai-chat-completions",
+    model: name,
+    params,
+  } as Model;
 }
 
 const temperature = {

--- a/tests/llms.test.ts
+++ b/tests/llms.test.ts
@@ -8,6 +8,7 @@ function makeModel(overrides: Partial<Model> = {}): Model {
   return {
     provider: "anthropic",
     authType: "api_key",
+    apiSurface: "anthropic-messages",
     model: "claude-opus-4-7",
     params: [
       {

--- a/tests/load.test.ts
+++ b/tests/load.test.ts
@@ -9,6 +9,7 @@ let tmpRoot: string;
 
 const VALID_OPUS = `provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-opus-4-7
 params:
   - path: temperature
@@ -24,6 +25,7 @@ params:
 
 const VALID_OPUS_SUB = `provider: anthropic
 authType: subscription
+apiSurface: anthropic-messages
 model: claude-opus-4-7
 params:
   - path: response_style

--- a/tests/parameters.test.ts
+++ b/tests/parameters.test.ts
@@ -9,7 +9,13 @@ function model(
   params: Model["params"],
   authType: Model["authType"] = "api_key",
 ): Model {
-  return { provider, authType, model: name, params } as Model;
+  return {
+    provider,
+    authType,
+    apiSurface: "openai-chat-completions",
+    model: name,
+    params,
+  } as Model;
 }
 
 const topP = {

--- a/tests/removals.test.ts
+++ b/tests/removals.test.ts
@@ -7,7 +7,13 @@ function param(path: string): Parameter {
 }
 
 function model(provider: string, authType: AuthType, name: string, paths: string[]): Model {
-  return { provider, authType, model: name, params: paths.map(param) };
+  return {
+    provider,
+    authType,
+    apiSurface: "openai-chat-completions",
+    model: name,
+    params: paths.map(param),
+  };
 }
 
 describe("findRemovedParams", () => {

--- a/tests/render-meta.test.ts
+++ b/tests/render-meta.test.ts
@@ -26,6 +26,7 @@ function model(over: Partial<Model> = {}): Model {
   return {
     provider: "anthropic",
     authType: "api_key",
+    apiSurface: "anthropic-messages",
     model: "claude-opus-4-7",
     params: [
       {

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -5,6 +5,7 @@ import { buildModelJsonSchema } from "../src/schema/generate.js";
 const VALID_MODEL = {
   provider: "anthropic",
   authType: "api_key",
+  apiSurface: "anthropic-messages",
   model: "claude-opus-4-7",
   params: [
     {
@@ -36,6 +37,13 @@ describe("Model schema", () => {
   it("rejects unknown authType", () => {
     const result = Model.safeParse({ ...VALID_MODEL, authType: "free" });
     expect(result.success).toBe(false);
+  });
+
+  it("requires a known API surface", () => {
+    expect(Model.safeParse({ ...VALID_MODEL, apiSurface: "openai-completions" }).success).toBe(
+      false,
+    );
+    expect(Model.safeParse({ ...VALID_MODEL, apiSurface: undefined }).success).toBe(false);
   });
 
   it("accepts provider-native model ids with dots", () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -8,6 +8,7 @@ function makeModel(overrides: Partial<Model> = {}): Model {
   return {
     provider: "anthropic",
     authType: "api_key",
+    apiSurface: "anthropic-messages",
     model: "claude-opus-4-7",
     params: [
       {
@@ -37,6 +38,7 @@ const MODELS: Model[] = [
   makeModel({ authType: "subscription" }),
   makeModel({
     provider: "openai",
+    apiSurface: "openai-chat-completions",
     model: "gpt-4o",
     params: [
       { path: "top_p", type: "number", label: "Top P", description: "Nucleus.", group: "sampling" },
@@ -134,6 +136,7 @@ describe("GET /api/v1/models/:provider/:slug.json", () => {
     expect(body.provider).toBe("anthropic");
     expect(body.model).toBe("claude-opus-4-7");
     expect(body.authType).toBe("api_key");
+    expect(body.apiSurface).toBe("anthropic-messages");
     expect(body.$schema).toBe("https://modelparams.dev/api/v1/schema.json");
   });
 
@@ -163,7 +166,11 @@ describe("GET / (home)", () => {
 
   it("carries a concrete title and a crawlable browse-by-parameter section", async () => {
     const body = await get("/").then((r) => r.text());
-    expect(body).toContain("modelparams.dev · LLM API Parameters for 3 Models");
+    expect(body).toContain("modelparams.dev · LLM API Parameters for 2 Models");
+    expect(body).toContain("API surface");
+    expect(body).toContain("Chat Completions");
+    expect(body.match(/id="anthropic--claude-opus-4-7"/g)).toHaveLength(1);
+    expect(body).toContain('data-model-variant-trigger="1"');
     expect(body).toContain("Browse by API parameter");
     expect(body).toContain('href="/parameters/temperature"');
     expect(body).toContain('href="/parameters/max_tokens"');
@@ -212,7 +219,9 @@ describe("GET /providers/:provider", () => {
     const res = await get("/providers/anthropic");
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
-    expect(await res.text()).toContain("Anthropic");
+    const body = await res.text();
+    expect(body).toContain("Anthropic");
+    expect(body).toContain("Messages");
   });
 
   it("404s for an unknown provider", async () => {
@@ -227,7 +236,9 @@ describe("GET /models/:provider/:slug", () => {
     const res = await get("/models/openai/gpt-4o");
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
-    expect(await res.text()).toContain("<!doctype html>");
+    const body = await res.text();
+    expect(body).toContain("<!doctype html>");
+    expect(body).toContain("Chat Completions");
   });
 
   it("404s for an unknown model", async () => {

--- a/tests/structured-data.test.ts
+++ b/tests/structured-data.test.ts
@@ -16,6 +16,7 @@ function model(over: Partial<Model> = {}): Model {
   return {
     provider: "anthropic",
     authType: "api_key",
+    apiSurface: "anthropic-messages",
     model: "claude-opus-4-7",
     params: [
       {

--- a/tests/sync-status.test.ts
+++ b/tests/sync-status.test.ts
@@ -9,6 +9,7 @@ import {
 const SAMPLE = `# yaml-language-server: $schema=https://modelparams.dev/api/v1/schema.json
 provider: anthropic
 authType: api_key
+apiSurface: anthropic-messages
 model: claude-opus-4-1-20250805
 params:
   - path: temperature

--- a/tests/validate-endpoint.test.ts
+++ b/tests/validate-endpoint.test.ts
@@ -5,6 +5,7 @@ interface ValidateBody {
   model: string;
   provider: string;
   authType: string;
+  apiSurface: string;
   wireId?: string;
   valid: boolean;
   issues: { path: string; code: string; message: string; conflictsWith?: string[] }[];
@@ -45,6 +46,7 @@ describe("POST /api/v1/validate", () => {
     });
     expect(status).toBe(200);
     expect(body.valid).toBe(true);
+    expect(body.apiSurface).toBe("anthropic-messages");
     expect(body.issues).toEqual([]);
     expect(body.safeParams).toEqual({ max_tokens: 1024, temperature: 1 });
   });

--- a/tests/webmcp.test.ts
+++ b/tests/webmcp.test.ts
@@ -3,11 +3,18 @@ import { modelId, searchCatalog } from "../src/client/webmcp.js";
 
 type AuthType = "api_key" | "subscription";
 
-function model(provider: string, name: string, authType: AuthType, paths: string[]) {
+function model(
+  provider: string,
+  name: string,
+  authType: AuthType,
+  paths: string[],
+  apiSurface = provider === "anthropic" ? "anthropic-messages" : "openai-chat-completions",
+) {
   return {
     provider,
     model: name,
     authType,
+    apiSurface,
     params: paths.map((path) => ({
       path,
       type: "number",
@@ -73,6 +80,11 @@ describe("searchCatalog", () => {
     expect(searchCatalog(CATALOG, { auth: "all" }).total).toBe(4);
   });
 
+  it("filters by API surface", () => {
+    expect(searchCatalog(CATALOG, { apiSurface: "anthropic-messages" }).total).toBe(2);
+    expect(searchCatalog(CATALOG, { apiSurface: "openai-chat-completions" }).total).toBe(2);
+  });
+
   it("combines filters (AND semantics)", () => {
     const result = searchCatalog(CATALOG, { provider: "anthropic", auth: "api_key" });
     expect(result.total).toBe(1);
@@ -97,6 +109,7 @@ describe("searchCatalog", () => {
       id: "anthropic/claude-opus-4-7-subscription",
       provider: "anthropic",
       authType: "subscription",
+      apiSurface: "anthropic-messages",
       parameterCount: 2,
     });
     expect(sub?.parameters).toEqual(["temperature", "thinking.type"]);


### PR DESCRIPTION
## What this changes

- Adds a required `apiSurface` to every catalog entry and migrates all 382 model records.
- Groups the homepage into one row per provider/model, with surface and access variants inside the row.
- Adds API-surface filtering and shows the matching parameter set and representative SDK method.
- Exposes the surface through the JSON API, validation endpoint, npm and Python packages, MCP tools, and WebMCP.

## Type of change

- [ ] Add a model (new YAML file under `models/`)
- [ ] Add a provider (new folder under `models/`, plus a logo)
- [ ] Add or update parameters on an existing model
- [ ] Fix incorrect data (default, range, values, applicability)
- [x] Site or tooling (code under `src/`, docs, CI)

## Source

Existing catalog request paths and the repository's documented API-surface contract.

## Before opening

- [x] `npm run validate` and `npm test` pass locally
- [x] Filenames follow the existing API-key and subscription conventions
- [x] No existing parameter was removed

Also verified lint, typecheck, production build, workspace tests, Python lint/type/tests, generated output, the parameter-removal guard, and desktop/mobile browser interactions.
