### PR TITLE
chore: release modelparams@0.0.59 + modelparams-py@0.0.40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7999,7 +7999,7 @@
       }
     },
     "packages/modelparams": {
-      "version": "0.0.58",
+      "version": "0.0.59",
       "license": "MIT",
       "devDependencies": {
         "tsd": "^0.31.0"

--- a/packages/modelparams-python/CHANGELOG.md
+++ b/packages/modelparams-python/CHANGELOG.md
@@ -5,6 +5,18 @@ prepared, and describe the catalog changes a version ships. Versions published
 before this file existed are listed under
 [Releases](https://github.com/mnfst/modelparams.dev/releases).
 
+## 0.0.40
+
+### Models added
+
+- `xai/grok-4.6-subscription`
+
+### Parameters changed
+
+- `xai/grok-4.5`: updated `reasoning_effort`
+- `xai/grok-4.5-subscription`: updated `reasoning_effort`
+- `xai/grok-4.6`: added `reasoning_effort`; updated `stop`
+
 ## 0.0.39
 
 ### Models added

--- a/packages/modelparams-python/pyproject.toml
+++ b/packages/modelparams-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "modelparams"
-version = "0.0.39"
+version = "0.0.40"
 description = "Typed model parameters for Python, generated from the modelparams.dev catalog."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/modelparams-python/uv.lock
+++ b/packages/modelparams-python/uv.lock
@@ -520,7 +520,7 @@ wheels = [
 
 [[package]]
 name = "modelparams"
-version = "0.0.39"
+version = "0.0.40"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/packages/modelparams/CHANGELOG.md
+++ b/packages/modelparams/CHANGELOG.md
@@ -5,6 +5,18 @@ prepared, and describe the catalog changes a version ships. Versions published
 before this file existed are listed under
 [Releases](https://github.com/mnfst/modelparams.dev/releases).
 
+## 0.0.59
+
+### Models added
+
+- `xai/grok-4.6-subscription`
+
+### Parameters changed
+
+- `xai/grok-4.5`: updated `reasoning_effort`
+- `xai/grok-4.5-subscription`: updated `reasoning_effort`
+- `xai/grok-4.6`: added `reasoning_effort`; updated `stop`
+
 ## 0.0.58
 
 ### Models added

--- a/packages/modelparams/package.json
+++ b/packages/modelparams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modelparams",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "description": "TypeScript types and runtime data for model parameters. Generated from the modelparams.dev open catalog.",
   "keywords": [
     "llm",


### PR DESCRIPTION
Batched release prepared by `.github/workflows/release-prepare.yml`.
Merging this PR publishes the packages below; closing it holds them back.

## modelparams (npm) — 0.0.58 → 0.0.59

### Models added

- `xai/grok-4.6-subscription`

### Parameters changed

- `xai/grok-4.5`: updated `reasoning_effort`
- `xai/grok-4.5-subscription`: updated `reasoning_effort`
- `xai/grok-4.6`: added `reasoning_effort`; updated `stop`

## modelparams (PyPI) — 0.0.39 → 0.0.40

### Models added

- `xai/grok-4.6-subscription`

### Parameters changed

- `xai/grok-4.5`: updated `reasoning_effort`
- `xai/grok-4.5-subscription`: updated `reasoning_effort`
- `xai/grok-4.6`: added `reasoning_effort`; updated `stop`