### PR TITLE
chore: release modelparams@0.0.60 + modelparams-py@0.0.41

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7999,7 +7999,7 @@
       }
     },
     "packages/modelparams": {
-      "version": "0.0.59",
+      "version": "0.0.60",
       "license": "MIT",
       "devDependencies": {
         "tsd": "^0.31.0"

--- a/packages/modelparams-python/CHANGELOG.md
+++ b/packages/modelparams-python/CHANGELOG.md
@@ -5,6 +5,39 @@ prepared, and describe the catalog changes a version ships. Versions published
 before this file existed are listed under
 [Releases](https://github.com/mnfst/modelparams.dev/releases).
 
+## 0.0.41
+
+### Models added
+
+- `alibaba/kimi-k3`
+- `alibaba/qwen3.8-flash`
+- `alibaba/qwen3.8-max-0902`
+- `anthropic/claude-fable-5-1`
+- `fireworks/deepseek-v4-flash-vision-exp`
+- `fireworks/glm-5p3`
+- `fireworks/glm-5p3-flash`
+- `google/gemini-3.8-flash`
+- `groq/qwen3.8-27b`
+- `mistral/glm-5-2`
+- `nvidia/deepseek-v4-pro-0813`
+- `nvidia/gemma-4-31b-it`
+- `nvidia/gpt-oss-120b`
+- `nvidia/gpt-oss-20b`
+- `nvidia/kimi-k3`
+- `nvidia/laguna-xs-2.1`
+- `nvidia/minimax-m3`
+- `nvidia/muse-glimmer-30b`
+- `openai/gpt-6-astra`
+- `opencode-go/deepseek-v4-flash-vision-exp-subscription`
+- `opencode-go/glm-5.3-flash-subscription`
+- `opencode-go/glm-5.3-subscription`
+- `opencode-go/grok-4.6-subscription`
+- `opencode-go/hy4-preview-subscription`
+- `opencode-go/longcat-2.0-subscription`
+- `opencode-go/qwen3.8-flash-subscription`
+- `opencode-go/qwen3.8-max-subscription`
+- `z-ai/glm-5.3-flash`
+
 ## 0.0.40
 
 ### Models added

--- a/packages/modelparams-python/pyproject.toml
+++ b/packages/modelparams-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "modelparams"
-version = "0.0.40"
+version = "0.0.41"
 description = "Typed model parameters for Python, generated from the modelparams.dev catalog."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/modelparams-python/uv.lock
+++ b/packages/modelparams-python/uv.lock
@@ -520,7 +520,7 @@ wheels = [
 
 [[package]]
 name = "modelparams"
-version = "0.0.40"
+version = "0.0.41"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/packages/modelparams/CHANGELOG.md
+++ b/packages/modelparams/CHANGELOG.md
@@ -5,6 +5,39 @@ prepared, and describe the catalog changes a version ships. Versions published
 before this file existed are listed under
 [Releases](https://github.com/mnfst/modelparams.dev/releases).
 
+## 0.0.60
+
+### Models added
+
+- `alibaba/kimi-k3`
+- `alibaba/qwen3.8-flash`
+- `alibaba/qwen3.8-max-0902`
+- `anthropic/claude-fable-5-1`
+- `fireworks/deepseek-v4-flash-vision-exp`
+- `fireworks/glm-5p3`
+- `fireworks/glm-5p3-flash`
+- `google/gemini-3.8-flash`
+- `groq/qwen3.8-27b`
+- `mistral/glm-5-2`
+- `nvidia/deepseek-v4-pro-0813`
+- `nvidia/gemma-4-31b-it`
+- `nvidia/gpt-oss-120b`
+- `nvidia/gpt-oss-20b`
+- `nvidia/kimi-k3`
+- `nvidia/laguna-xs-2.1`
+- `nvidia/minimax-m3`
+- `nvidia/muse-glimmer-30b`
+- `openai/gpt-6-astra`
+- `opencode-go/deepseek-v4-flash-vision-exp-subscription`
+- `opencode-go/glm-5.3-flash-subscription`
+- `opencode-go/glm-5.3-subscription`
+- `opencode-go/grok-4.6-subscription`
+- `opencode-go/hy4-preview-subscription`
+- `opencode-go/longcat-2.0-subscription`
+- `opencode-go/qwen3.8-flash-subscription`
+- `opencode-go/qwen3.8-max-subscription`
+- `z-ai/glm-5.3-flash`
+
 ## 0.0.59
 
 ### Models added

--- a/packages/modelparams/package.json
+++ b/packages/modelparams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modelparams",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "description": "TypeScript types and runtime data for model parameters. Generated from the modelparams.dev open catalog.",
   "keywords": [
     "llm",


### PR DESCRIPTION
Batched release prepared by `.github/workflows/release-prepare.yml`.
Merging this PR publishes the packages below; closing it holds them back.

## modelparams (npm) — 0.0.59 → 0.0.60

### Models added

- `alibaba/kimi-k3`
- `alibaba/qwen3.8-flash`
- `alibaba/qwen3.8-max-0902`
- `anthropic/claude-fable-5-1`
- `fireworks/deepseek-v4-flash-vision-exp`
- `fireworks/glm-5p3`
- `fireworks/glm-5p3-flash`
- `google/gemini-3.8-flash`
- `groq/qwen3.8-27b`
- `mistral/glm-5-2`
- `nvidia/deepseek-v4-pro-0813`
- `nvidia/gemma-4-31b-it`
- `nvidia/gpt-oss-120b`
- `nvidia/gpt-oss-20b`
- `nvidia/kimi-k3`
- `nvidia/laguna-xs-2.1`
- `nvidia/minimax-m3`
- `nvidia/muse-glimmer-30b`
- `openai/gpt-6-astra`
- `opencode-go/deepseek-v4-flash-vision-exp-subscription`
- `opencode-go/glm-5.3-flash-subscription`
- `opencode-go/glm-5.3-subscription`
- `opencode-go/grok-4.6-subscription`
- `opencode-go/hy4-preview-subscription`
- `opencode-go/longcat-2.0-subscription`
- `opencode-go/qwen3.8-flash-subscription`
- `opencode-go/qwen3.8-max-subscription`
- `z-ai/glm-5.3-flash`

## modelparams (PyPI) — 0.0.40 → 0.0.41

### Models added

- `alibaba/kimi-k3`
- `alibaba/qwen3.8-flash`
- `alibaba/qwen3.8-max-0902`
- `anthropic/claude-fable-5-1`
- `fireworks/deepseek-v4-flash-vision-exp`
- `fireworks/glm-5p3`
- `fireworks/glm-5p3-flash`
- `google/gemini-3.8-flash`
- `groq/qwen3.8-27b`
- `mistral/glm-5-2`
- `nvidia/deepseek-v4-pro-0813`
- `nvidia/gemma-4-31b-it`
- `nvidia/gpt-oss-120b`
- `nvidia/gpt-oss-20b`
- `nvidia/kimi-k3`
- `nvidia/laguna-xs-2.1`
- `nvidia/minimax-m3`
- `nvidia/muse-glimmer-30b`
- `openai/gpt-6-astra`
- `opencode-go/deepseek-v4-flash-vision-exp-subscription`
- `opencode-go/glm-5.3-flash-subscription`
- `opencode-go/glm-5.3-subscription`
- `opencode-go/grok-4.6-subscription`
- `opencode-go/hy4-preview-subscription`
- `opencode-go/longcat-2.0-subscription`
- `opencode-go/qwen3.8-flash-subscription`
- `opencode-go/qwen3.8-max-subscription`
- `z-ai/glm-5.3-flash`