### PR TITLE
docs: add PyPI downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 [![npm version](https://img.shields.io/npm/v/modelparams.svg)](https://www.npmjs.com/package/modelparams)
 [![npm downloads](https://img.shields.io/npm/dm/modelparams.svg)](https://www.npmjs.com/package/modelparams)
+[![PyPI downloads](https://img.shields.io/pypi/dm/modelparams.svg)](https://pypi.org/project/modelparams/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 Every API parameter each AI model accepts, in one place: `temperature`, `top_p`, `max_tokens` and the rest of the request body, with defaults, ranges and gating conditions. Not weight counts — see [model parameters vs. API parameters](https://modelparams.dev/model-parameters-vs-api-parameters). Inspired by [models.dev](https://github.com/anomalyco/models.dev); we use it at [Manifest](https://manifest.build/).


### PR DESCRIPTION
## What this changes

Add a monthly PyPI downloads badge next to the existing npm badges.

## Type of change

- [ ] Add a model (new YAML file under `models/`)
- [ ] Add a provider (new folder under `models/`, plus a logo)
- [ ] Add or update parameters on an existing model
- [ ] Fix incorrect data (default, range, values, applicability)
- [x] Site or tooling (code under `src/`, docs, CI)

## Source

Python package: https://pypi.org/project/modelparams/

## Before opening

- [x] `npm run validate` and `npm test` pass locally
- [x] Filenames follow the convention: `models/<provider>/<model>.yaml`, or `<model>-subscription.yaml` for the subscription route
- [x] No existing parameter was removed (removals are blocked, see CONTRIBUTING)